### PR TITLE
Uses PrinterLogger for JS project

### DIFF
--- a/freestyle-logging/js/src/main/scala/io/freestyle/loggingJS.scala
+++ b/freestyle-logging/js/src/main/scala/io/freestyle/loggingJS.scala
@@ -11,8 +11,7 @@ object loggingJS {
         implicit ME: MonadError[M, Throwable]): LoggingM.Interpreter[M] =
       new LoggingM.Interpreter[M] with LazyLogging {
 
-        LoggerConfig.factory = ConsoleLoggerFactory()
-        LoggerConfig.level = LogLevel.DEBUG
+        LoggerConfig.factory = PrintLoggerFactory()
 
         def debugImpl(msg: String): M[Unit] = ME.catchNonFatal(logger.debug(msg))
 

--- a/freestyle-logging/js/src/test/scala/io/freestyle/LoggingTests.scala
+++ b/freestyle-logging/js/src/test/scala/io/freestyle/LoggingTests.scala
@@ -19,7 +19,7 @@ class LoggingTests extends AsyncWordSpec with Matchers {
     "allow a log message to be interleaved inside a program monadic flow" in {
       val program = for {
         a <- app.nonLogging.x
-        _ <- app.loggingM.info("Message")
+        _ <- app.loggingM.debug("Message")
         b <- Applicative[FreeS[App.T, ?]].pure(1)
       } yield a + b
       program.exec[Future] map { _ shouldBe 2 }


### PR DESCRIPTION
This pull request changes the logger used in JS project: we'll use `PrintLogger` instead of `ConsoleLogger`. 

It fixes a bug that throws a runtime error when using `debug` function: the `console` object of NodeJs (the default environment of Scala JS) doesn't have the `debug` function.

@raulraja Could you review please? Thanks!