### PR TITLE
Update cats to 0.9 and others

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val freestyle = (crossProject in file("freestyle")).
   settings(name := "freestyle").
   settings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-free" % "0.8.1",
+      "org.typelevel" %%% "cats-free" % "0.9.0",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     )
   ).
@@ -95,8 +95,8 @@ lazy val freestyleMonix = (crossProject in file("freestyle-monix")).
   settings(name := "freestyle-monix").
   settings(
     libraryDependencies ++= Seq(
-      "io.monix" %%% "monix-eval" % "2.1.0",
-      "io.monix" %%% "monix-cats" % "2.1.0"
+      "io.monix" %%% "monix-eval" % "2.2.1",
+      "io.monix" %%% "monix-cats" % "2.2.1"
     )
   ).
   jsSettings(sharedJsSettings: _*)
@@ -110,7 +110,7 @@ lazy val freestyleEffects = (crossProject in file("freestyle-effects")).
   settings(name := "freestyle-effects").
   settings(
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.0"      % "test"
+      "org.scalatest" %% "scalatest" % "3.0.1"      % "test"
     )
   ).
   jsSettings(sharedJsSettings: _*)
@@ -124,9 +124,9 @@ lazy val freestyleDoobie = (project in file("freestyle-doobie")).
   settings(name := "freestyle-doobie").
   settings(
     libraryDependencies ++= Seq(
-      "org.tpolecat"  %% "doobie-core-cats" % "0.3.1-M3",
-      "org.tpolecat"  %% "doobie-h2-cats"   % "0.3.1-M3" % "test",
-      "org.scalatest" %% "scalatest"        % "3.0.0"          % "test"
+      "org.tpolecat"  %% "doobie-core-cats" % "0.4.1",
+      "org.tpolecat"  %% "doobie-h2-cats"   % "0.4.1" % "test",
+      "org.scalatest" %% "scalatest"        % "3.0.1"          % "test"
     )
   )
 
@@ -152,7 +152,7 @@ lazy val freestyleConfig = (crossProject in file("freestyle-config")).
   settings(
     libraryDependencies ++= Seq(
       "eu.unicredit" %%% "shocon" % "0.1.7",
-      "org.scalatest" %%% "scalatest" % "3.0.0" % "test"
+      "org.scalatest" %%% "scalatest" % "3.0.1" % "test"
     )
   )
 
@@ -166,9 +166,9 @@ lazy val freestyleFetch = (crossProject in file("freestyle-fetch")).
   settings(name := "freestyle-fetch").
   settings(
     libraryDependencies ++= Seq(
-      "com.fortysevendeg" %%% "fetch" % "0.4.0",
-      "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
-      "com.fortysevendeg" %%% "fetch-monix" % "0.4.0"
+      "com.fortysevendeg" %%% "fetch" % "0.5.0",
+      "org.scalatest" %%% "scalatest" % "3.0.1" % "test",
+      "com.fortysevendeg" %%% "fetch-monix" % "0.5.0"
      )
   ).
   jsSettings(sharedJsSettings: _*)
@@ -181,7 +181,7 @@ lazy val freestyleLogging = (crossProject in file("freestyle-logging")).
   settings(commonSettings: _*).
   settings(name := "freestyle-logging").
   settings(
-    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % "test"
+    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.1" % "test"
   ).
   jvmSettings(
     libraryDependencies += "io.verizon.journal" %% "core" % "3.0.18"
@@ -202,7 +202,7 @@ lazy val tests = (project in file("tests")).
   settings(
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "org.scalatest" %%% "scalatest" % "3.0.0" % "test"
+      "org.scalatest" %%% "scalatest" % "3.0.1" % "test"
     )
   )
 

--- a/freestyle-fetch/shared/src/test/scala/FetchTests.scala
+++ b/freestyle-fetch/shared/src/test/scala/FetchTests.scala
@@ -77,6 +77,7 @@ object datasources {
   import cats.instances.list._
 
   implicit object ToStringSource extends DataSource[Int, String] {
+    override def name = "ToString"
     override def fetchOne(id: Int): Query[Option[String]] =
       Query.sync(Option(id.toString))
     override def fetchMany(ids: NonEmptyList[Int]): Query[Map[Int, String]] =


### PR DESCRIPTION
The build fails on my machine due to https://github.com/sbt/sbt/issues/2786.

Possible solutions:
- Apply the [workaround](https://github.com/sbt/sbt/issues/2786#issuecomment-258906054)
- Update to the [latest scalafmt plugin](https://github.com/olafurpg/scalafmt/pull/610) which dropped the reformat on compile setting