### PR TITLE
Fixing issue with CNAME file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val micrositeSettings = Seq(
   micrositeHighlightTheme := "dracula",
   micrositeExternalLayoutsDirectory := (resourceDirectory in Compile).value / "microsite" / "layouts",
   micrositeExternalIncludesDirectory := (resourceDirectory in Compile).value / "microsite" / "includes",
-  includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "CNAME",
+  includeFilter in Jekyll := ("*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "CNAME"),
   micrositePalette := Map(
     "brand-primary"     -> "#01C2C2",
     "brand-secondary"   -> "#142236",


### PR DESCRIPTION
This PR should fix an issue with the CNAME file in the documentation microsite, as a wrong includeFilter was being applied to the sbt-site configuration. In addition to this, a fix to sbt-microsites has been issued to add this as a default setting in the following PR: https://github.com/47deg/sbt-microsites/pull/142

Could you please review, @raulraja? Thanks!