### PR TITLE
72 Cache Docs

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -37,6 +37,9 @@ options:
       - title: Traverse
         url: docs/effects/#Traverse
 
+      - title: Cache
+        url: docs/effects/Cache/
+
   - title: Patterns
     url: TODO.html
 

--- a/docs/src/main/tut/docs/effects/cache.md
+++ b/docs/src/main/tut/docs/effects/cache.md
@@ -6,15 +6,14 @@ permalink: /docs/effects/Cache/
 
 ## Cache
 
-The `Cache` effect algebra allows to interact with a _global_ key-value data store.
-The algebra declares several abstract operations that allow for reading and writing data into the store.
-This algebra is parametrized on the types `K`, of keys used for the indexing, and on the type `V`, of values stored in the cache.
+The `Cache` effect algebra allows interacting with a _global_ key-value data store.
+It declares several abstract operations to read and write data into the store.
+This algebra is parametrized on the types `K`, and `V`, for keys and values in the store, respectively.
 
-The algebra does not assume any specific implementation or representation of the data store.
-That representation is given and specified by each _interpreter or handler_ for the algebra.
-Simmilarly, the algebra imposes on the type parameters `K` and `V` no type constraint concerning
-ordering, hashing, or encoding. We assume, though, that an equality test between their values exists.
-
+The algebra assumes no specific implementation or representation of the data store, for
+that is given by each  _interpreter or handler_ for the algebra.
+For the same reason, it poses no type constraint on `K` or `V` with regards to ordering, hashing, or encoding.
+Except, of course, that equality is defined for both types.
 
 ### Operations
 
@@ -41,45 +40,45 @@ To make the algebra parametric on the types of `Key` and `Value`, we wrap the de
 * `keys` is a  query to retrieve a list of keys for which an association is present in the store. No restriction is posed on the order in which the keys will appear on the list, in relation to any ordering for the `Key` type.
 
 
-### Laws and Equations
+#### Laws
 
-In this section we give some of the laws that specify the intended semantics of the `CacheM` algebra. This laws should hold in any handler/interpreter for it.
-All of these laws are applicable in the context of a single group of `FreeS` independent operations, which we assume are run as a single batch of operations.
-The key intuition behind these equations is that, within a single group of operations, every command issued to modify the key-value associations in the store must have an effect visible on succeeding operations in the same group.
+In this section we describe some laws that specify the intended semantics of the `CacheM` effect algebra, which any handler or interpreter for it should hold.
+These laws are applicable to any group of independent operations within the `FreeS.Par[F, ?]` type, which is the `Applicable` fragment.
+However, the laws may not hold in the general `Free[FreeS.Par[F, ?], ?]` case, of a _sequential_ group of independent operations.
+Intuitively, a group `FreeS.Par` of operations is run atomically on the data store, without interleaving any other operations, and every command's effect should be immediately visible on succeeding operations.
 
-The laws are written as equalities between monadic programs. Intuitively, equality between potentially side-effectful monadic programs means that:
+Each law is an _equality_ between two programs of type `FreeS.Par[F, A]`, where equality means that:
 
-* The (monad-wrapped) results from one computation is equal to those of the other; and
-* their side-effects are non-distinguishable: there is no sequence of cache operations that, if attached to either program, would yield a different result.
+* The results of type `A` from interpreting both programs should be equal; and
+* their side-effects on the data store are not distinguishable: there is no sequence `FreeS.Par` of `CacheM` foperations that,
+  if attached to both programs to the left or to the right, would yield a different result.
 
-In these laws, we use the binary operators `<*`, `*>`, and `|@|`, from the `cats.syntax.CartesianOps` trait in the `cats` library.
-Briefly, for any two values `a : F[A]` and `b: F[B]`, `a *> b : F[B]` projects to the right, `a <* b: F[A]` projects on the left, and `a |@| b: F[(A,B)]` keeps a tuple of the results.
-We use the variables `x` and `y` to denote keys of type `Key`, with `x != y`, and we use `v`, or `w` to denote values of type `Value`.
+In these laws, we use the binary operators `<*`, `*>`, and `|@|`, to indicate the composition and
+projection of operations on the left, on the right, or on a pair. These operators come from the `cats.syntax.CartesianOps` trait.
+We use variables `x` and `y` to denote keys of type `Key`, with `x != y`,  and we use `v`, or `w` to denote values of type `Value`.
 
-#### Get
+##### Get
 
-Intuitively, a `get` abstract operation is just a query and should not modify the associations in the store.
-
-This can be expressed with two conditions:
+A `get` abstract operation is a query that should not modify the store.
+This can be expressed with these conditions:
 
 1. Any `get` operation whose result is ignored can be discarded from the program.
 2. Consecutive `get` operations on a same key `x` should give the same result.
 3. Consecutive `get` operations on different keys should give the same result for each key.
 
 ```Scala
-get(x) *> ff   === ff <* get(x) === ff   // 1, for any other operation ff
+get(x) *> ff   === ff <* get(x) === ff   // for any other operation ff
 get(x) |@| get(x)  === get( x).map( dup )
 get(x) |@| get(y)  === ( get(y) |@| get(x) ).map( swap )
 ```
+Where `swap` is the function of type `(A,B) => (B,A)`, and `dup` is the function of type `A => (A,A)`.
 
-In the previous conditions we use the functions `swap: (A,B) => (B,A)` and `dup: A => (A,A)`; and we
+##### Put
 
-#### Put
-
-The `put` abstract operation on the keys of a key-value store is like an assignment to a mutable variable.
+A `put` operation on a key in the store is like an assignment to a mutable variable.
 The following laws restrict `put` operations and `get` operations:
 
-1. Two `put` operations on the same key is equivalent to the rightmost of these.
+1. Two `put` operations on the same key are equivalent to the rightmost (last) one.
 2. Two `put` operations on different keys can be swapped.
 3. On a same key `x`, a `put` followed by the `get` is the same as giving the `put` value, right after the `put` operation.
 4. Operations `get` and `put` on different keys can be swapped.
@@ -91,7 +90,7 @@ put( x, v) *> get( x)    === put( x, v) *> pure( Some(v) )
 put( x, v) *> get( y)    === get( y) <* put( x, v)
 ```
 
-#### Delete
+##### Delete
 
 The laws concerning `del` with `get` are the following ones:
 
@@ -119,7 +118,7 @@ del( x, v) *> put( x, v) === put( x, v)            // 4
 del( x, v) *> put( y, v) === put( y, v) *> del( x) // 5
 ```
 
-#### Keys, Clear
+##### Keys, Clear
 
 The `clear` abstract operation is equivalent to issuing a `del` on all existing keys.
 
@@ -135,10 +134,91 @@ put( x, v) *> clear === clear
 
 The `keys` abstract operation, that returns a list of keys of type `Key`, must hold the following conditions:
 
-1. The list should only contain keys for which `get` would not give `None`.
+1. The list should contain a key if and only if the `get` on that key would be `Some`.
 2. The `keys` should not modify the data-store, so any `get` following it should give the same result.
 
 ```Scala
 get(x).map(_.isDefined) === keys.map(_.contains(x) ) //1
 keys *> get(x) === get(x)
 ```
+
+### Interpreters
+
+#### Concurrent Hash Map
+
+The package `freestyle.cache.hashmap` in the project `freestyle-cache`, contains an in-program (no I/O needed)
+effect-handler / interpreter for the `CacheM` effect algebra.
+This interpreter implements the data store with a [Concurrent Hash Map](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html).
+Note that the `ConcurrentHashMap` provides no global locking, nor any facilities for issuing and executing transactionally a set of operations.
+Thus, the laws described above may not hold for this interpreter. 
+
+##### Hashable Type Class
+
+A hash table divides keys according to each key's hash code. In particular, a `ConcurrentHashMap` uses the `hashCode()` method
+from the [`Object`](https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html) class ([`Any`](http://www.scala-lang.org/api/current/scala/Any.html) in Scala).
+Most classes from the Java or Scala libraries define this method, and in Scala each `case class` has a definition based on its fields.
+However, using this methods directly has two problems:
+
+* Because `hashCode` is an object method, fixed by the class, we can not use different hash algorithms in different hash tables.
+* Since `Object` provides a default implementation of `hashCode`, most programmer-defined classes may not override it.
+
+To avoid these problems, we define a Scala typeclass `Hasher[A]`, i.e. a  trait with a single `hashCode` function, and for building the `CacheM` interpreter
+we require an instance of `Hasher` for the `Key` type. We provide default implementations of this trait for several simple types.
+
+#### Redis
+
+The package `freestyle.cache.redis` in the project `freestyle-cache-redis` provides a handler-interpreter for the `CacheM` effect algebra.
+This interpreter implements the data store using a [Redis](http://redis.io/) database.
+Access to a Redis server is done through [`rediscala`](https://github.com/etaty/rediscala), an Akka-based client library for Scala.
+
+##### Codification
+
+In the `rediscala` client for Redis, the keys used for indexing values are always of type `String`; whereas
+a special binary codification is needed for values (of type `Value`).
+in the Redis integration we use a couple of typeclasses to transform either keys or values, to and from `String`:
+
+* The `Format[A]` trait defines the function from the `Key` type (the parameter for the `CacheM` algebra) to `String`.
+  The companion object provides a few helper methods and default instances.
+* The `Parse[A]` trait is a function to try to _parse_ a `Key` from a `String`.
+  The return type is an `Option[Key]`, to indicate the possibility of failure.
+
+These typeclasses are used for transforming
+
+The use of these typeclasses is also intended to avoid coupling the programs based on `freestyle` to a particular client library.
+
+##### Batching and Transactions
+
+As explained in the guide, any Freestyle program has two levels: the _applicative_ level (in type `FreeS.Par`)
+contains sequences of locally independent operations, where the result of one can not be used as argument to another.
+Such dependencies are only handled in the _monadic_ level, in which the results from a group of operations are retrieved
+to be used in another group.
+
+In  `Redis`, since each command is issued through the network, retrieving any value incurs in a round-trip latency.
+This reduces performance, and exposes the results of fqueries to concurrent modifications of the data store.
+To avoid these problems, we want the `Redis` handler to run any sequence of operations inside a `FreeS.Par` so that:
+
+* Commands issued to the Redis server are _pipelined_, so as to reduce the total roundtrip to one; and
+* the whole command sequence is run _atomically_, that is, without interleaving any other operation.
+
+Regarding pipelining, the `rediscala` client already uses [Redis pipelining](https://redis.io/topics/pipelining) to
+issue operations as soon as they are enqueued.
+For atomicity, the implementation runs each `FreeS.Par` sequence of independent operations in a
+Redis [_transaction_](https://redis.io/topics/transactions).
+This allows the implementation to hold the laws for the `CacheM` effect algebra given above.
+
+##### Kleisli
+
+To combine several `CacheM` operations in a single `FreeS.Par`, we use the [`Kleisli`](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/data/Kleisli.scala) class from the `cats` library.
+Intuitively, for each single `CacheM` operation the interpreter does not _issue_ an operation to the client,
+but instead creates a `Function` that, when applied to a client, will issue the command through it.
+
+```Scala
+def del[Key](keys: List[Key])(implicit format: Format[Key]): Ops[Future, Long] =
+  Kleisli((client: KeyCommands) => client.del(keys.map(format): _*))
+```
+
+Given two such `Kleisli` objects that correspond to two independent operations, composing them can be done through the
+default instance of `Applicative` for `Kleisli` in `cats`. The result would be a function that takes a  _client_ and issues
+the commands for the operations in the order in which they appear.
+
+

--- a/docs/src/main/tut/docs/effects/cache.md
+++ b/docs/src/main/tut/docs/effects/cache.md
@@ -1,0 +1,144 @@
+---
+layout: docs
+title: Cache
+permalink: /docs/effects/Cache/
+---
+
+## Cache
+
+The `Cache` effect algebra allows to interact with a _global_ key-value data store.
+The algebra declares several abstract operations that allow for reading and writing data into the store.
+This algebra is parametrized on the types `K`, of keys used for the indexing, and on the type `V`, of values stored in the cache.
+
+The algebra does not assume any specific implementation or representation of the data store.
+That representation is given and specified by each _interpreter or handler_ for the algebra.
+Simmilarly, the algebra imposes on the type parameters `K` and `V` no type constraint concerning
+ordering, hashing, or encoding. We assume, though, that an equality test between their values exists.
+
+
+### Operations
+
+The set of abstract operations of the `Cache` algebra are specified as follows.
+
+```Scala
+class KeyValueProvider[Key, Value] {
+    @free sealed trait CacheM[F[_]] {
+      def get(key: Key):              FreeS.Par[F, Option[Val]]
+      def put(key: Key, newVal: Val): FreeS.Par[F, Unit]
+      def del(key: Key):              FreeS.Par[F, Unit]
+      def has(key: Key):              FreeS.Par[F, Boolean]
+      def keys:                       FreeS.Par[F, List[Key]]
+      def clear:                      FreeS.Par[F, Unit]
+    }
+}
+```
+To make the algebra parametric on the types of `Key` and `Value`, we wrap the declaration of the algebra inside a `KeyValueProvider`; but note that this class has no instance data.
+
+* `get(key: Key): M[Option[Val]]` issues a query to the data store on a given key. The result can be `None`, if the store has no mapping for that key, or `Some(v)` if the key is mapped to the value `v`.
+* `put(key: Key, v: Value)` issues a command to
+* `del(key: Key)` issues a command to disassociate a given key from the store, if it was present.
+* `clear` is an abstract operation to disassociate all keys and values in the store.
+* `keys` is a  query to retrieve a list of keys for which an association is present in the store. No restriction is posed on the order in which the keys will appear on the list, in relation to any ordering for the `Key` type.
+
+
+### Laws and Equations
+
+In this section we give some of the laws that specify the intended semantics of the `CacheM` algebra. This laws should hold in any handler/interpreter for it.
+All of these laws are applicable in the context of a single group of `FreeS` independent operations, which we assume are run as a single batch of operations.
+The key intuition behind these equations is that, within a single group of operations, every command issued to modify the key-value associations in the store must have an effect visible on succeeding operations in the same group.
+
+The laws are written as equalities between monadic programs. Intuitively, equality between potentially side-effectful monadic programs means that:
+
+* The (monad-wrapped) results from one computation is equal to those of the other; and
+* their side-effects are non-distinguishable: there is no sequence of cache operations that, if attached to either program, would yield a different result.
+
+In these laws, we use the binary operators `<*`, `*>`, and `|@|`, from the `cats.syntax.CartesianOps` trait in the `cats` library.
+Briefly, for any two values `a : F[A]` and `b: F[B]`, `a *> b : F[B]` projects to the right, `a <* b: F[A]` projects on the left, and `a |@| b: F[(A,B)]` keeps a tuple of the results.
+We use the variables `x` and `y` to denote keys of type `Key`, with `x != y`, and we use `v`, or `w` to denote values of type `Value`.
+
+#### Get
+
+Intuitively, a `get` abstract operation is just a query and should not modify the associations in the store.
+
+This can be expressed with two conditions:
+
+1. Any `get` operation whose result is ignored can be discarded from the program.
+2. Consecutive `get` operations on a same key `x` should give the same result.
+3. Consecutive `get` operations on different keys should give the same result for each key.
+
+```Scala
+get(x) *> ff   === ff <* get(x) === ff   // 1, for any other operation ff
+get(x) |@| get(x)  === get( x).map( dup )
+get(x) |@| get(y)  === ( get(y) |@| get(x) ).map( swap )
+```
+
+In the previous conditions we use the functions `swap: (A,B) => (B,A)` and `dup: A => (A,A)`; and we
+
+#### Put
+
+The `put` abstract operation on the keys of a key-value store is like an assignment to a mutable variable.
+The following laws restrict `put` operations and `get` operations:
+
+1. Two `put` operations on the same key is equivalent to the rightmost of these.
+2. Two `put` operations on different keys can be swapped.
+3. On a same key `x`, a `put` followed by the `get` is the same as giving the `put` value, right after the `put` operation.
+4. Operations `get` and `put` on different keys can be swapped.
+
+```Scala
+put( x, v) *> put( x, w) === put( x, w)
+put( x, v) *> put( y, w) === put( y, w) *> put( x, v)
+put( x, v) *> get( x)    === put( x, v) *> pure( Some(v) )
+put( x, v) *> get( y)    === get( y) <* put( x, v)
+```
+
+#### Delete
+
+The laws concerning `del` with `get` are the following ones:
+
+* On a same key `x`, the result of a `del` right after a `get` should be `None`:
+* On different keys `x` and `n`, a `del` and a `get` can be swapped:
+
+```Scala
+del( x) *> get( x) === del( x) *> pure( None)
+del( x) *> get( y) === get( y) <* del( x)
+```
+
+The following laws concern several `delete` interactions, as well as `put` and `delete` operations.
+
+1. Two `del` operations on a same key `x` are equivalent to just one of them.
+2. Two `del` operations on different keys `x`, `y`, can be swapped.
+3. On a same key `x`, a `put` followed by a delete should be equivalent to just the delete.
+4. On a same key `x`, a `del` followed by a `put` should be equivalent to just the `put` operation.
+5. Operations `put` and `del` on different keys can be reordered swapped.
+
+```Scala
+del( x) *> del( x) === del( x)                     // 1
+del( x) *> del( y) === del( y) *> del( x)          // 2
+put( x, v) *> del( x) === del( x)                  // 3
+del( x, v) *> put( x, v) === put( x, v)            // 4
+del( x, v) *> put( y, v) === put( y, v) *> del( x) // 5
+```
+
+#### Keys, Clear
+
+The `clear` abstract operation is equivalent to issuing a `del` on all existing keys.
+
+1. After a `clear`, a `get` should always return `None`:
+2. After a `clear`, any `del` is redundant:
+3. Any `put` operation right before a `clear` can be ignored:
+
+```Scala
+clear *> get( x) === clear *> pure( None)
+clear *> del( x) === clear
+put( x, v) *> clear === clear
+```
+
+The `keys` abstract operation, that returns a list of keys of type `Key`, must hold the following conditions:
+
+1. The list should only contain keys for which `get` would not give `None`.
+2. The `keys` should not modify the data-store, so any `get` following it should give the same result.
+
+```Scala
+get(x).map(_.isDefined) === keys.map(_.contains(x) ) //1
+keys *> get(x) === get(x)
+```

--- a/freestyle-cache-redis/shared/src/main/scala/rediscala/Coders.scala
+++ b/freestyle-cache-redis/shared/src/main/scala/rediscala/Coders.scala
@@ -1,7 +1,5 @@
 package freestyle.cache.redis.rediscala
 
-import _root_.redis.{ByteStringSerializer => Serializer, ByteStringDeserializer => Deserializer}
-
 trait Format[A] extends (A ⇒ String)
 
 object Format {
@@ -25,16 +23,3 @@ object Parser {
 
 }
 
-object Deserializers {
-
-  def parser[A](parser: String ⇒ Option[A]): Deserializer[Option[A]] =
-    Deserializer.String.map(parser)
-
-}
-
-object Serializers {
-
-  def printer[A](printer: A ⇒ String): Serializer[A] =
-    Serializer.String.contramap(printer)
-
-}

--- a/freestyle-cache-redis/shared/src/main/scala/rediscala/Instances.scala
+++ b/freestyle-cache-redis/shared/src/main/scala/rediscala/Instances.scala
@@ -8,7 +8,7 @@ import _root_.redis.commands.Transactions
  * parallel fragments execute their operations as _parallel_ as possible.
  * Since Redis is a single-threaded server, _parallel_ means sending operations together
  * in a single batch, which is possible if there are no data dependencies between them. */
-class Interpret[F[_]](client: Transactions) extends (Ops[F, ?] ~> F) {
+class Interpret[F[_]](client: Transactions) extends (Kleisli[F, Commands, ?] ~> F) {
 
   override def apply[A](fa: Kleisli[F, Commands, A]): F[A] = {
     val transaction = client.transaction()

--- a/freestyle-cache-redis/shared/src/main/scala/rediscala/Kleislis.scala
+++ b/freestyle-cache-redis/shared/src/main/scala/rediscala/Kleislis.scala
@@ -9,7 +9,7 @@ import _root_.redis.commands.{
   Strings => StringCommands
 }
 
-trait StringCommandsCont {
+private[rediscala] trait StringCommandsCont {
 
   def append[Key, Value](key: Key, value: Value)(
       implicit format: Format[Key],
@@ -28,7 +28,7 @@ trait StringCommandsCont {
 
 }
 
-trait KeyCommandsCont {
+private[rediscala] trait KeyCommandsCont {
 
   def del[Key](keys: List[Key])(implicit format: Format[Key]): Ops[Future, Long] =
     Kleisli((client: KeyCommands) => client.del(keys.map(format): _*))
@@ -40,11 +40,11 @@ trait KeyCommandsCont {
     Kleisli((client: KeyCommands) => client.keys("*"))
 }
 
-trait ServerCommandsCont {
+private[rediscala] trait ServerCommandsCont {
 
   def flushDB: Ops[Future, Boolean] =
     Kleisli((client: ServerCommands) => client.flushdb)
 
 }
 
-object RediscalaCont extends StringCommandsCont with KeyCommandsCont with ServerCommandsCont
+private[rediscala] object RediscalaCont extends StringCommandsCont with KeyCommandsCont with ServerCommandsCont

--- a/freestyle-cache-redis/shared/src/main/scala/rediscala/RedisMap.scala
+++ b/freestyle-cache-redis/shared/src/main/scala/rediscala/RedisMap.scala
@@ -3,17 +3,22 @@ package freestyle.cache.redis.rediscala
 import cats.{~>, Functor}
 import cats.syntax.functor._
 import scala.concurrent.Future
-import _root_.redis.{ByteStringSerializer => Serializer, ByteStringDeserializer => Deserializer}
+import _root_.redis.{ByteStringDeserializer, ByteStringSerializer}
 import freestyle.cache.KeyValueMap
 
 class MapWrapper[M[_], Key, Value](
-    implicit format: Format[Key],
-    parser: Parser[Key],
-    read: Deserializer[Option[Value]],
-    writer: Serializer[Value],
+    implicit formatKey: Format[Key],
+    parseKey: Parser[Key],
+    formatVal: Format[Value],
+    parseVal: Parser[Value],
     toM: Future ~> M,
     funcM: Functor[M]
 ) extends KeyValueMap[Ops[M, ?], Key, Value] {
+
+  private[this] implicit val serial: ByteStringDeserializer[Option[Value]] =
+    ByteStringDeserializer.String.map(parseVal)
+  private[this] implicit val deserial: ByteStringSerializer[Value] =
+    ByteStringSerializer.String.contramap(formatVal)
 
   override def get(key: Key): Ops[M, Option[Value]] =
     RediscalaCont.get[Key, Option[Value]](key).transform(toM).map(_.flatten)
@@ -28,7 +33,7 @@ class MapWrapper[M[_], Key, Value](
     RediscalaCont.exists(key).transform(toM)
 
   override def keys: Ops[M, List[Key]] =
-    RediscalaCont.keys.transform(toM).map(_.toList.flatMap(parser.apply))
+    RediscalaCont.keys.transform(toM).map(_.toList.flatMap(parseKey.apply))
 
   override def clear(): Ops[M, Unit] =
     RediscalaCont.flushDB.transform(toM).void
@@ -38,10 +43,10 @@ class MapWrapper[M[_], Key, Value](
 object MapWrapper {
 
   implicit def apply[M[_], Key, Value](
-      implicit format: Format[Key],
-      parser: Parser[Key],
-      read: Deserializer[Option[Value]],
-      writer: Serializer[Value],
+      implicit formatKey: Format[Key],
+      parseKey: Parser[Key],
+      formatValue: Format[Value],
+      parseValue: Parser[Value],
       toM: Future ~> M,
       funcM: Functor[M]
   ): MapWrapper[M, Key, Value] = new MapWrapper

--- a/freestyle-cache-redis/shared/src/test/scala/TestUtil.scala
+++ b/freestyle-cache-redis/shared/src/test/scala/TestUtil.scala
@@ -7,15 +7,14 @@ import freestyle.cache.redis.rediscala._
 
 object TestUtil {
 
-  def redisMap(implicit ec: ExecutionContext): MapWrapper[Future, String, Int] = {
-    val format = Format((key: String) => key)
-    val parser = Parser((str: String) => Some(str))
-    val reader = Deserializers.parser(str => scala.util.Try(Integer.parseInt(str)).toOption)
-    val writer = Serializers.printer((age: Int) => age.toString)
-    val toM    = FunctionK.id[Future]
-    val funcM  = future.catsStdInstancesForFuture(ec)
-
-    new MapWrapper()(format, parser, reader, writer, toM, funcM)
-  }
+  def redisMap(implicit ec: ExecutionContext): MapWrapper[Future, String, Int] =
+    new MapWrapper()(
+      formatKey = Format((key: String) => key),
+      parseKey = Parser((str: String) => Some(str)),
+      formatVal = Format((age: Int) => age.toString),
+      parseVal = Parser((str:String) => scala.util.Try(Integer.parseInt(str)).toOption),
+      toM    = FunctionK.id[Future],
+      funcM  = future.catsStdInstancesForFuture(ec)
+    )
 
 }


### PR DESCRIPTION
This PR closes ticket #72.

We add to the documentation a section about the `Cache` effect. This section contains the following: 

* A description about the `CacheF` effect algebra. We describe its type parameters, and its operations. For these operations, we give an intuition about each of them and a few algebraic properties that specify their semantics.

* A description of its handlers/interpreters, the type classes they require, and the patterns they use.
