### PR TITLE
87 - Code Improvements to the `@free` macro

### DIFF
--- a/tests/src/test/scala/test.scala
+++ b/tests/src/test/scala/test.scala
@@ -77,7 +77,7 @@ class tests extends WordSpec with Matchers {
         def sc1(a: Int, b: Int, c: Int): FreeS[F, Int]
         def sc2(a: Int, b: Int, c: Int): FreeS[F, Int]
       }
-      implicitly[FriendlyFreeS.T[_] =:= FriendlyFreeS.FriendlyFreeSOP[_]]
+      implicitly[FriendlyFreeS.T[_] =:= FriendlyFreeS.T[_]]
       implicitly[FriendlyFreeS.Sc1OP <:< FriendlyFreeS.T[Int]]
       implicitly[FriendlyFreeS.Sc2OP <:< FriendlyFreeS.T[Int]]
       ()


### PR DESCRIPTION
This PR carries a few changes to the implementation of the `@free` macro, to make it easier to debug or port.

One change is the use of nomenclature: 
* The parameteric `trait Foo[F[_]]` or `abstract class Foo[F[_]]` provided by the user, which is annotated by the `@free` annotation, is referred to as an _effect_.
* Each method in this _Effect_ whose return type is a `FreeS[F, A]` or `FreeS.Par[F, A]` is called a _Request_. The ADT (`trait` and `case classes`) used to represent these methods is called the _request ADT_. 
* The `class` that builds elements of the `Adt` using the `cats.free.Inject` instance is called the _Lifter_. 
* The `trait` that matches the objects in the Request ADT and issues operation in the domain `F` is called the _Handler_.

We also reorganize the code: we wrap the functionalities using a [macro bundle](http://docs.scala-lang.org/overviews/macros/bundles.html), and we use an internal class `Request` that, from the request `def` provided as input in the `@free` trait or abstract class (the effect), it gives all the elements related to that request.

@raulraja ¿Could you review? 
