### PR TITLE
Extend cache operations

### DIFF
--- a/freestyle-cache-redis/shared/src/main/scala/rediscala/Kleislis.scala
+++ b/freestyle-cache-redis/shared/src/main/scala/rediscala/Kleislis.scala
@@ -1,13 +1,10 @@
 package freestyle.cache.redis.rediscala
 
 import cats.data.Kleisli
+
 import scala.concurrent.Future
-import _root_.redis.{ByteStringSerializer => Serializer, ByteStringDeserializer => Deserializer}
-import _root_.redis.commands.{
-  Keys => KeyCommands,
-  Server => ServerCommands,
-  Strings => StringCommands
-}
+import _root_.redis.{Cursor, ByteStringDeserializer => Deserializer, ByteStringSerializer => Serializer}
+import _root_.redis.commands.{Keys => KeyCommands, Server => ServerCommands, Strings => StringCommands}
 
 private[rediscala] trait StringCommandsCont {
 
@@ -34,6 +31,9 @@ private[rediscala] trait StringCommandsCont {
   def setnx[Key : Format, Value: Serializer](key: Key, value: Value): Ops[Future, Boolean] =
     Kleisli((client: StringCommands) => client.setnx(key, value))
 
+  def setxx[Key : Format, Value: Serializer](key: Key, value: Value): Ops[Future, Boolean] =
+    Kleisli((client: StringCommands) => client.set(key, value, XX = true))
+
 }
 
 private[rediscala] trait KeyCommandsCont {
@@ -46,6 +46,9 @@ private[rediscala] trait KeyCommandsCont {
 
   def keys[Key]: Ops[Future, Seq[String]] =
     Kleisli((client: KeyCommands) => client.keys("*"))
+
+  def scan[Key]: Ops[Future, Cursor[Seq[String]]] =
+    Kleisli((client: KeyCommands) => client.scan(0, Option(1), None))
 }
 
 private[rediscala] trait ServerCommandsCont {

--- a/freestyle-cache-redis/shared/src/main/scala/rediscala/Kleislis.scala
+++ b/freestyle-cache-redis/shared/src/main/scala/rediscala/Kleislis.scala
@@ -23,7 +23,7 @@ private[rediscala] trait StringCommandsCont {
   def set[Key: Format, Value: Serializer](key: Key, value: Value): Ops[Future, Boolean] =
     Kleisli((client: StringCommands) => client.set(key, value))
 
-  def mset[Key : Format, Value: Serializer](keyValues: Map[Key, Value])(implicit format: Format[Key]): Ops[Future, Boolean] = {
+  def mset[Key, Value: Serializer](keyValues: Map[Key, Value])(implicit format: Format[Key]): Ops[Future, Boolean] = {
     val b = keyValues.map { case (k,v) => (format(k), v) }
     Kleisli((client: StringCommands) => client.mset(b))
   }

--- a/freestyle-cache-redis/shared/src/main/scala/rediscala/Kleislis.scala
+++ b/freestyle-cache-redis/shared/src/main/scala/rediscala/Kleislis.scala
@@ -26,6 +26,14 @@ private[rediscala] trait StringCommandsCont {
   def set[Key: Format, Value: Serializer](key: Key, value: Value): Ops[Future, Boolean] =
     Kleisli((client: StringCommands) => client.set(key, value))
 
+  def mset[Key : Format, Value: Serializer](keyValues: Map[Key, Value])(implicit format: Format[Key]): Ops[Future, Boolean] = {
+    val b = keyValues.map { case (k,v) => (format(k), v) }
+    Kleisli((client: StringCommands) => client.mset(b))
+  }
+
+  def setnx[Key : Format, Value: Serializer](key: Key, value: Value): Ops[Future, Boolean] =
+    Kleisli((client: StringCommands) => client.setnx(key, value))
+
 }
 
 private[rediscala] trait KeyCommandsCont {

--- a/freestyle-cache-redis/shared/src/main/scala/rediscala/RedisMap.scala
+++ b/freestyle-cache-redis/shared/src/main/scala/rediscala/RedisMap.scala
@@ -26,6 +26,12 @@ class MapWrapper[M[_], Key, Value](
   override def put(key: Key, value: Value): Ops[M, Unit] =
     RediscalaCont.set(key, value).transform(toM).void
 
+  override def putAll(keyValues: Map[Key, Value]): Ops[M, Unit] =
+    RediscalaCont.mset(keyValues).transform(toM).void
+
+  override def putIfAbsent(key: Key, newVal: Value): Ops[M, Unit] =
+    RediscalaCont.setnx(key, newVal).transform(toM).void
+
   override def delete(key: Key): Ops[M, Unit] =
     RediscalaCont.del(List(key)).transform(toM).void
 

--- a/freestyle-cache-redis/shared/src/main/scala/rediscala/RedisMap.scala
+++ b/freestyle-cache-redis/shared/src/main/scala/rediscala/RedisMap.scala
@@ -3,7 +3,7 @@ package freestyle.cache.redis.rediscala
 import cats.{~>, Functor}
 import cats.syntax.functor._
 import scala.concurrent.Future
-import _root_.redis.{ByteStringDeserializer, ByteStringSerializer}
+import _root_.redis.{ByteStringDeserializer, ByteStringSerializer, Cursor}
 import freestyle.cache.KeyValueMap
 
 class MapWrapper[M[_], Key, Value](
@@ -43,6 +43,12 @@ class MapWrapper[M[_], Key, Value](
 
   override def clear(): Ops[M, Unit] =
     RediscalaCont.flushDB.transform(toM).void
+
+  override def replace(key: Key, newVal: Value): Ops[M, Unit] =
+    RediscalaCont.setxx(key, newVal).transform(toM).void
+
+  override def isEmpty : Ops[M, Boolean] =
+    RediscalaCont.scan.transform(toM).map(_.data.isEmpty)
 
 }
 

--- a/freestyle-cache-redis/shared/src/test/scala/RedisTests.scala
+++ b/freestyle-cache-redis/shared/src/test/scala/RedisTests.scala
@@ -6,6 +6,7 @@ import freestyle.implicits._
 import freestyle.cache.redis.rediscala._
 import org.scalatest._
 import scala.concurrent.{ExecutionContext, Future}
+import cats.implicits._
 
 class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
 
@@ -24,15 +25,217 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
   "Redis integration into Freestyle" should {
 
     "allow to interleave one CacheM within the programs monadic flow" in {
-      import cats.implicits._
       def program[F[_]: CacheM]: FreeS[F, Int] =
         for {
           a <- Applicative[FreeS[F, ?]].pure(Some(1))
-          b <- (CacheM[F].put("Joe", 13) *> CacheM[F].get("Joe"))
+          b <- CacheM[F].put("Joe", 13) *> CacheM[F].get("Joe")
           c <- Applicative[FreeS[F, ?]].pure(Some(1))
         } yield Seq(a, b, c).flatten.sum
       program[CacheM.Op].exec[Future] map { _ shouldBe 15 }
     }
+  }
 
+  "GET" should {
+
+    "result in None if the datastore is empty" in {
+      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+        CacheM[F].get("a")
+
+      program[CacheM.Op].exec[Future] map { _ shouldBe None }
+    }
+
+    "result in None if a different key is set" in {
+      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+        CacheM[F].put("a", 0) *> CacheM[F].get("b")
+
+      program[CacheM.Op].exec[Future] map { _ shouldBe None }
+    }
+
+    "result in Some(v) if v is the only set value" in {
+      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+        CacheM[F].put("a", 0) *> CacheM[F].get("a")
+
+      program[CacheM.Op].exec[Future] map { _ shouldBe Some(0)}
+    }
+  }
+
+  "PUT" should {
+
+    "reduce consecutive PUT on the same key down to last SET" in {
+      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- (CacheM[F].put("a", 0) *> CacheM[F].put("a", 1))
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Future] map { _ shouldBe ((Some(1), 1)) }
+    }
+
+    "ignore succeeding PUT to other Keys" in {
+      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].put("a", 0) *> CacheM[F].put("b", 1)
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Future] map { _ shouldBe ((Some(0), 2)) }
+    }
+
+    "ignore preceding PUT to other Keys" in {
+      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].put("b", 1) *> CacheM[F].put("a", 0)
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Future] map { _ shouldBe ((Some(0), 2)) }
+    }
+  }
+
+  "PUTALL" should {
+
+      "ignore succeeding PUT to other Keys" in {
+        def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+          for {
+            _ <- CacheM[F].putAll(Map("a"-> 0,"b"-> 1)) *> CacheM[F].put("c", 2)
+            a <- CacheM[F].get("a")
+            k <- CacheM[F].keys
+          } yield (a, k.size)
+
+        program[CacheM.Op].exec[Future] map {_ shouldBe ((Some(0), 3)) }
+    }
+
+    "ignore a preceding PUT on same key" in {
+      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].put("a", 0) *> CacheM[F].putAll(Map("a"-> 1,"b"-> 1))
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Future] map { _ shouldBe ((Some(1), 2))}
+    }
+  }
+
+  "PUTIFABSENT" should {
+
+    "ignore a PUTIFABSENT because the key is already associated with a value" in {
+      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].put("a", 0) *> CacheM[F].putIfAbsent("a", 1)
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Future] map { _ shouldBe ((Some(0), 1))}
+    }
+
+    "ignore a succeeding PUT on different key" in {
+      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].put("b", 1) *> CacheM[F].putIfAbsent("a", 0)
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Future] map { _ shouldBe ((Some(0), 2))}
+    }
+
+    "ignore preceding PUTIFABSENT to other Keys" in {
+      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].putIfAbsent("b", 1) *> CacheM[F].putIfAbsent("a", 0)
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Future] map { _  shouldBe ((Some(0), 2))}
+    }
+  }
+
+  "DELETE" should {
+
+    "nullify a preceeding PUT on same key" in {
+      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].put("a", 0) *> CacheM[F].del("a")
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Future] map { _  shouldBe ((None, 0)) }
+    }
+
+    "be overridden by succeeding PUT on same Key" in {
+      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].del("a") *> CacheM[F].put("a", 0)
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Future] map { _  shouldBe ((Some(0), 1)) }
+    }
+
+    "ignore a preceeding PUT on different key" in {
+      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+        CacheM[F].put("a", 0) *> CacheM[F].del("b") *> CacheM[F].get("a")
+
+      program[CacheM.Op].exec[Future] map { _  shouldBe Some(0) }
+    }
+
+    "ignore a succeeding PUT on different key" in {
+      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+        CacheM[F].del("b") *> CacheM[F].put("a", 0) *> CacheM[F].get("a")
+
+      program[CacheM.Op].exec[Future] map { _  shouldBe Some(0) }
+    }
+  }
+
+  "CLEAR" should {
+    "remove all the keys" in {
+      def program[F[_] : CacheM] =
+        for {
+          k1 <- CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].keys
+          k2 <- CacheM[F].clear *> CacheM[F].keys
+        } yield (k1.size, k2.size)
+
+      program[CacheM.Op].exec[Future] map { _  shouldBe ((2, 0)) }
+    }
+  }
+
+  "REPLACE" should {
+    "replace the entry for a key" in {
+      def program[F[_] : CacheM] =
+        CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].replace("a", 1) *> CacheM[F].get("a")
+
+      program[CacheM.Op].exec[Future] map { _  shouldBe Some(1) }
+    }
+
+    "ignore replace the entry because a key not exist" in {
+      def program[F[_] : CacheM] =
+        CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].replace("c", 1) *> CacheM[F].get("c")
+
+      program[CacheM.Op].exec[Future] map { _  shouldBe None }
+    }
+  }
+
+  "ISEMPTY" should {
+    "isn't empty" in {
+      def program[F[_] : CacheM] =
+        CacheM[F].put("a", 0) *> CacheM[F].isEmpty
+
+      program[CacheM.Op].exec[Future] map { _  shouldBe false }
+    }
+
+    "is empty" in {
+      def program[F[_] : CacheM] =
+        CacheM[F].put("a", 0) *> CacheM[F].clear *> CacheM[F].isEmpty
+
+      program[CacheM.Op].exec[Future] map { _  shouldBe true }
+    }
   }
 }

--- a/freestyle-cache/shared/src/main/scala/cache.scala
+++ b/freestyle-cache/shared/src/main/scala/cache.scala
@@ -20,6 +20,12 @@ package cache {
       // Sets the value of a key to a newValue.
       def put(key: Key, newVal: Val): FreeS.Par[F, Unit]
 
+      // Copy all of the mappings from the specified map to this map
+      def putAll(keyValues: Map[Key, Val]): FreeS.Par[F, Unit]
+
+      //If the specified key is not already associated with a value, associate it with the given value.
+      def putIfAbsent(key: Key, newVal: Val): FreeS.Par[F, Unit]
+
       // Removes the entry for the key if one exists
       def del(key: Key): FreeS.Par[F, Unit]
 
@@ -82,6 +88,10 @@ package cache {
           interpret(rawMap.get(key))
         override def putImpl(key: Key, newVal: Val): G[Unit] =
           interpret(rawMap.put(key, newVal))
+        override def putAllImpl(keyValues: Map[Key, Val]):G[Unit] =
+          interpret(rawMap.putAll(keyValues))
+        override def putIfAbsentImpl(key: Key, newVal: Val) : G[Unit]=
+          interpret(rawMap.putIfAbsent(key,newVal))
         override def delImpl(key: Key): G[Unit] =
           interpret(rawMap.delete(key))
         override def hasImpl(key: Key): G[Boolean] =
@@ -100,6 +110,10 @@ package cache {
     def get(key: Key): F[Option[Val]]
 
     def put(key: Key, newVal: Val): F[Unit]
+
+    def putAll(keyValues: Map[Key, Val]) : F[Unit]
+
+    def putIfAbsent(key: Key, newVal: Val) : F[Unit]
 
     def delete(key: Key): F[Unit]
 

--- a/freestyle-cache/shared/src/main/scala/cache.scala
+++ b/freestyle-cache/shared/src/main/scala/cache.scala
@@ -95,9 +95,9 @@ package cache {
           interpret(rawMap.get(key))
         override def put(key: Key, newVal: Val): G[Unit] =
           interpret(rawMap.put(key, newVal))
-        override def putAllImpl(keyValues: Map[Key, Val]):G[Unit] =
+        override def putAll(keyValues: Map[Key, Val]):G[Unit] =
           interpret(rawMap.putAll(keyValues))
-        override def putIfAbsentImpl(key: Key, newVal: Val) : G[Unit]=
+        override def putIfAbsent(key: Key, newVal: Val) : G[Unit]=
           interpret(rawMap.putIfAbsent(key,newVal))
         override def del(key: Key): G[Unit] =
           interpret(rawMap.delete(key))
@@ -107,9 +107,9 @@ package cache {
           interpret(rawMap.keys)
         override def clear: G[Unit] =
           interpret(rawMap.clear)
-        override def replaceImpl(key: Key,newVal: Val): G[Unit] =
+        override def replace(key: Key,newVal: Val): G[Unit] =
           interpret(rawMap.replace(key,newVal))
-        override def isEmptyImpl : G[Boolean] =
+        override def isEmpty: G[Boolean] =
           interpret(rawMap.isEmpty)
       }
 

--- a/freestyle-cache/shared/src/main/scala/cache.scala
+++ b/freestyle-cache/shared/src/main/scala/cache.scala
@@ -37,6 +37,13 @@ package cache {
 
       // Removes all entries
       def clear: FreeS.Par[F, Unit]
+
+      //Replaces the entry for a key only if currently mapped to some value
+      def replace(key: Key, newVal: Val): FreeS.Par[F, Unit]
+
+      //Returns true if this map contains no key-value mappings.
+      def isEmpty: FreeS.Par[F, Boolean]
+
     }
 
     /*
@@ -100,6 +107,10 @@ package cache {
           interpret(rawMap.keys)
         override def clearImpl: G[Unit] =
           interpret(rawMap.clear)
+        override def replaceImpl(key: Key,newVal: Val): G[Unit] =
+          interpret(rawMap.replace(key,newVal))
+        override def isEmptyImpl : G[Boolean] =
+          interpret(rawMap.isEmpty)
       }
 
     }
@@ -122,6 +133,10 @@ package cache {
     def keys: F[List[Key]]
 
     def clear: F[Unit]
+
+    def replace(key: Key, newVal: Val) : F[Unit]
+
+    def isEmpty: F[Boolean]
   }
 
 }

--- a/freestyle-cache/shared/src/main/scala/cache.scala
+++ b/freestyle-cache/shared/src/main/scala/cache.scala
@@ -20,7 +20,7 @@ package cache {
       // Sets the value of a key to a newValue.
       def put(key: Key, newVal: Val): FreeS.Par[F, Unit]
 
-      // Copy all of the mappings from the specified map to this map
+      // Copy all of the mappings from the specified map to this cache
       def putAll(keyValues: Map[Key, Val]): FreeS.Par[F, Unit]
 
       //If the specified key is not already associated with a value, associate it with the given value.
@@ -41,7 +41,7 @@ package cache {
       //Replaces the entry for a key only if currently mapped to some value
       def replace(key: Key, newVal: Val): FreeS.Par[F, Unit]
 
-      //Returns true if this map contains no key-value mappings.
+      //Returns true if this cache contains no key-value mappings.
       def isEmpty: FreeS.Par[F, Boolean]
 
     }

--- a/freestyle-cache/shared/src/main/scala/hashmap/HashMapWrapper.scala
+++ b/freestyle-cache/shared/src/main/scala/hashmap/HashMapWrapper.scala
@@ -10,12 +10,13 @@ import java.util.concurrent.ConcurrentHashMap
  *  Being immutable, the hashCode is attached to each key and
  */
 final class ConcurrentHashMapWrapper[F[_], Key, Value](
-    implicit hasher: Hasher[Key],
-    C: Capture[F]
+  implicit hasher: Hasher[Key],
+  C: Capture[F]
 ) extends KeyValueMap[F, Key, Value] {
 
   private[this] final case class HKey(key: Key, hash: Int) {
     override def hashCode() = hash
+
     override def equals(other: Any): Boolean =
       if (other.isInstanceOf[HKey]) {
         this.key == other.asInstanceOf[HKey].key
@@ -29,9 +30,9 @@ final class ConcurrentHashMapWrapper[F[_], Key, Value](
   private[this] val table = new ConcurrentHashMap[this.HKey, Value]()
 
   /**
-   * @returns Some(v) if v is the value to which the specified key is mapped, or
-   *   None if this map contains no mapping for the key
-   */
+    * @returns Some(v) if v is the value to which the specified key is mapped, or
+    *          None if this map contains no mapping for the key
+    */
   override def get(key: Key): F[Option[Value]] = C.capture {
     Option(table.get(hkey(key))) // Option.apply handles null
   }
@@ -46,8 +47,8 @@ final class ConcurrentHashMapWrapper[F[_], Key, Value](
     ()
   }
 
-  override def putIfAbsent(key: Key, newVal: Value) : F[Unit] = C.capture{
-    table.putIfAbsent(hkey(key),newVal)
+  override def putIfAbsent(key: Key, newVal: Value): F[Unit] = C.capture {
+    table.putIfAbsent(hkey(key), newVal)
     ()
   }
 
@@ -66,13 +67,22 @@ final class ConcurrentHashMapWrapper[F[_], Key, Value](
 
   override def clear: F[Unit] = C.capture(table.clear)
 
+  override def replace(key: Key, newVal: Value): F[Unit] = C.capture {
+    table.replace(hkey(key), newVal)
+    ()
+  }
+
+  override def isEmpty: F[Boolean] = C.capture{
+    table.isEmpty
+  }
+
 }
 
 object implicits {
 
   implicit def concurrentHashMapWrapper[F[_], Key, Value](
-      implicit hasher: Hasher[Key],
-      C: Capture[F]
+    implicit hasher: Hasher[Key],
+    C: Capture[F]
   ): KeyValueMap[F, Key, Value] =
     new ConcurrentHashMapWrapper[F, Key, Value]()
 

--- a/freestyle-cache/shared/src/main/scala/hashmap/HashMapWrapper.scala
+++ b/freestyle-cache/shared/src/main/scala/hashmap/HashMapWrapper.scala
@@ -43,8 +43,7 @@ final class ConcurrentHashMapWrapper[F[_], Key, Value](
   }
 
   override def putAll(keyValues: Map[Key, Value]): F[Unit] = C.capture {
-    keyValues.map { case (k, v) => table.put(hkey(k), v) }
-    ()
+    keyValues.foreach{ case (k, v) => table.put(hkey(k), v) }
   }
 
   override def putIfAbsent(key: Key, newVal: Value): F[Unit] = C.capture {

--- a/freestyle-cache/shared/src/main/scala/hashmap/HashMapWrapper.scala
+++ b/freestyle-cache/shared/src/main/scala/hashmap/HashMapWrapper.scala
@@ -41,6 +41,16 @@ final class ConcurrentHashMapWrapper[F[_], Key, Value](
     ()
   }
 
+  override def putAll(keyValues: Map[Key, Value]): F[Unit] = C.capture {
+    keyValues.map { case (k, v) => table.put(hkey(k), v) }
+    ()
+  }
+
+  override def putIfAbsent(key: Key, newVal: Value) : F[Unit] = C.capture{
+    table.putIfAbsent(hkey(key),newVal)
+    ()
+  }
+
   override def delete(key: Key): F[Unit] = C.capture {
     table.remove(hkey(key)) // Option.apply handles null
     ()

--- a/freestyle-cache/shared/src/test/scala/CacheTests.scala
+++ b/freestyle-cache/shared/src/test/scala/CacheTests.scala
@@ -1,6 +1,6 @@
 package freestyle.cache
 
-import cats.{~>, Applicative, Id}
+import cats.{Applicative, Id, ~>}
 import cats.syntax.cartesian._
 import cats.instances.option._
 import freestyle._
@@ -16,21 +16,21 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
 
   "GET" should {
     "result in None if the datastore is empty" in {
-      def program[F[_]: CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
         CacheM[F].get("a")
 
       program[CacheM.Op].exec[Id] shouldBe None
     }
 
     "result in None if a different key is set" in {
-      def program[F[_]: CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
         CacheM[F].put("a", 0) *> CacheM[F].get("b")
 
       program[CacheM.Op].exec[Id] shouldBe None
     }
 
     "result in Some(v) if v is the only set value" in {
-      def program[F[_]: CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
         CacheM[F].put("a", 0) *> CacheM[F].get("a")
 
       program[CacheM.Op].exec[Id] shouldBe Some(0)
@@ -40,7 +40,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
   "PUT" should {
 
     "reduce consecutive PUT on the same key down to last SET" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- (CacheM[F].put("a", 0) *> CacheM[F].put("a", 1))
           a <- CacheM[F].get("a")
@@ -51,7 +51,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
     }
 
     "ignore succeeding PUT to other Keys" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("a", 0) *> CacheM[F].put("b", 1)
           a <- CacheM[F].get("a")
@@ -62,7 +62,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
     }
 
     "ignore preceding PUT to other Keys" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("b", 1) *> CacheM[F].put("a", 0)
           a <- CacheM[F].get("a")
@@ -73,10 +73,74 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
     }
   }
 
+  "PUTALL" should {
+
+    "ignore succeeding PUT to other Keys" in {
+      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].putAll(Map("a"-> 0,"b"-> 1)) *> CacheM[F].put("c", 2)
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Id] shouldBe ((Some(0), 3))
+    }
+
+    "ignore a preceding PUT on same key" in {
+      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].put("a", 0) *> CacheM[F].putAll(Map("a"-> 1,"b"-> 1))
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Id] shouldBe ((Some(1), 2))
+    }
+
+  }
+
+  "PUTIFABSENT" should {
+
+    "ignore a PUTIFABSENT because the key is already associated with a value" in {
+      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].put("a", 0) *> CacheM[F].putIfAbsent("a", 1)
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Id] shouldBe ((Some(0), 1))
+    }
+
+    "ignore a succeeding PUT on different key" in {
+      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].put("b", 1) *> CacheM[F].putIfAbsent("a", 0)
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Id] shouldBe ((Some(0), 2))
+    }
+
+    "ignore preceding PUTIFABSENT to other Keys" in {
+      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+        for {
+          _ <- CacheM[F].putIfAbsent("b", 1) *> CacheM[F].putIfAbsent("a", 0)
+          a <- CacheM[F].get("a")
+          k <- CacheM[F].keys
+        } yield (a, k.size)
+
+      program[CacheM.Op].exec[Id] shouldBe ((Some(0), 2))
+    }
+
+  }
+
+
   "DELETE" should {
 
     "nullify a preceeding PUT on same key" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("a", 0) *> CacheM[F].del("a")
           a <- CacheM[F].get("a")
@@ -87,7 +151,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
     }
 
     "be overridden by succeeding PUT on same Key" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].del("a") *> CacheM[F].put("a", 0)
           a <- CacheM[F].get("a")
@@ -98,14 +162,14 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
     }
 
     "ignore a preceeding PUT on different key" in {
-      def program[F[_]: CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
         CacheM[F].put("a", 0) *> CacheM[F].del("b") *> CacheM[F].get("a")
 
       program[CacheM.Op].exec[Id] shouldBe Some(0)
     }
 
     "ignore a succeeding PUT on different key" in {
-      def program[F[_]: CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
         CacheM[F].del("b") *> CacheM[F].put("a", 0) *> CacheM[F].get("a")
 
       program[CacheM.Op].exec[Id] shouldBe Some(0)
@@ -114,13 +178,45 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
 
   "CLEAR" should {
     "remove all the keys" in {
-      def program[F[_]: CacheM] =
+      def program[F[_] : CacheM] =
         for {
-          k1 <- (CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].keys)
-          k2 <- (CacheM[F].clear *> CacheM[F].keys)
+          k1 <- CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].keys
+          k2 <- CacheM[F].clear *> CacheM[F].keys
         } yield (k1.size, k2.size)
 
       program[CacheM.Op].exec[Id] shouldBe ((2, 0))
+    }
+  }
+
+  "REPLACE" should {
+    "replace the entry for a key" in {
+      def program[F[_] : CacheM] =
+        CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].replace("a", 1) *> CacheM[F].get("a")
+
+      program[CacheM.Op].exec[Id] shouldBe Some(1)
+    }
+
+    "ignore replace the entry because a key not exist" in {
+      def program[F[_] : CacheM] =
+        CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].replace("c", 1) *> CacheM[F].get("c")
+
+      program[CacheM.Op].exec[Id] shouldBe None
+    }
+  }
+
+  "ISEMPTY" should {
+    "isn't empty" in {
+      def program[F[_] : CacheM] =
+        CacheM[F].put("a", 0) *> CacheM[F].isEmpty
+
+      program[CacheM.Op].exec[Id] shouldBe false
+    }
+
+    "is empty" in {
+      def program[F[_] : CacheM] =
+        CacheM[F].put("a", 0) *> CacheM[F].clear *> CacheM[F].isEmpty
+
+      program[CacheM.Op].exec[Id] shouldBe true
     }
   }
 


### PR DESCRIPTION
This PR solves #76 and extend the algebra of Cache, with operations:
```scala
def putAll(keyValues: Map[Key, Val]): FreeS.Par[F, Unit]
def putIfAbsent(key: Key, newVal: Val): FreeS.Par[F, Unit]
def replace(key: Key, newVal: Val): FreeS.Par[F, Unit]
def isEmpty: FreeS.Par[F, Boolean]
````
@raulraja  Could you review, please?

On the other hand, I've added more test in Redis. @diesalbla , Could you review this part, please?

Thanks