### PR TITLE
Clear Macro Module

### DIFF
--- a/docs/src/main/tut/docs/modules/README.md
+++ b/docs/src/main/tut/docs/modules/README.md
@@ -113,7 +113,7 @@ If you were to create this by hand in the case of the example above it will look
 ```tut:book
 import cats.data.Coproduct
 
-type C01[A] = Coproduct[Database.Op, Cache.Op, A]
+type C01[A] = Coproduct[Cache.Op, Database.Op, A]
 type C02[A] = Coproduct[Presenter.Op, C01, A]
 type ManualAppCoproduct[A] = Coproduct[IdValidation.Op, C02, A]
 ```


### PR DESCRIPTION
This PR solves #104. It applies some maintenance and cleanup to the `@module` macro annotation. 

* We remove unused or duplicated code. 
* We simplify naming of internal elements.
* We try to use more restrictive types for inner methods. 
* We unfold and simplify algorithms to recollect type leaves, and to assemble Coproducts. Most relevantly, we reduce the latter from a `scanLeft` to a `map`.

