### PR TITLE
DO NOT MERGE emove `F` param: proof of concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ Applications built with Freestyle can be interpreted to any runtime semantics su
 ```scala
 import freestyle._
 
-@free trait Database[F[_]] {
-  def get(id: UserId): FreeS[F, User]
+@free trait Database {
+  def get(id: UserId): Oper.Seq[User]
 }
 
-@free trait Cache[F[_]] {
-  def get(id: UserId): FreeS[F, User]
+@free trait Cache {
+  def get(id: UserId): Oper.Seq[User]
 }
 
-@module trait Persistence[F[_]] {
-  val database: Database[F]
-  val cache: Cache[F]
+@module trait Persistence {
+  val database: Database
+  val cache: Cache
 }
 ```
 
@@ -35,7 +35,7 @@ Simply require any of your `@free` or `@module` trait as implicits where needed.
 ```scala
 def storedUsers[F[_]]
     (userId: UserId)
-    (implicit persistence: Persistence[F]): FreeS[F, (User, User)] = {
+    (implicit persistence: Persistence.To[F]): FreeS[F, (User, User)] = {
   import persistence._
   for {
     cachedUser <- cache.get(userId)
@@ -53,7 +53,7 @@ the target runtime interpreters.
 def loadUser[F[_]]
   (userId: UserId)
   (implicit 
-    doobie: DoobieM[F], 
+    doobie: DoobieM.To[F], 
     logging: LoggingM[F]): FreeS[F, User] = {
     import doobie.implicits._
     for {

--- a/docs/src/main/resources/microsite/css/custom.css
+++ b/docs/src/main/resources/microsite/css/custom.css
@@ -149,9 +149,9 @@ h1, h2, h3, h4, h5, h6, #site-header {
     font-size: 32px;
 }
 ree trait UserRepository[F[_]] {
-  def get(id: Long): FreeS[F, User]
-  def save(user: User): FreeS[F, User]
-  def list: FreeS[F, List[User]]
+  def get(id: Long): Oper.Seq[User]
+  def save(user: User): Oper.Seq[User]
+  def list: Oper.Seq[List[User]]
 }
 #site-main p {
     margin-bottom: 30px;

--- a/docs/src/main/tut/README.md
+++ b/docs/src/main/tut/README.md
@@ -16,11 +16,11 @@ Applications built with Freestyle can be interpreted to any runtime semantics su
 import freestyle._
 
 @free trait Database[F[_]] {
-  def get(id: UserId): FreeS[F, User]
+  def get(id: UserId): Oper.Seq[User]
 }
 
 @free trait Cache[F[_]] {
-  def get(id: UserId): FreeS[F, User]
+  def get(id: UserId): Oper.Seq[User]
 }
 
 @module trait Persistence[F[_]] {

--- a/docs/src/main/tut/README.md
+++ b/docs/src/main/tut/README.md
@@ -15,17 +15,17 @@ Applications built with Freestyle can be interpreted to any runtime semantics su
 ```scala
 import freestyle._
 
-@free trait Database[F[_]] {
+@free trait Database {
   def get(id: UserId): Oper.Seq[User]
 }
 
-@free trait Cache[F[_]] {
+@free trait Cache {
   def get(id: UserId): Oper.Seq[User]
 }
 
-@module trait Persistence[F[_]] {
-  val database: Database[F]
-  val cache: Cache[F]
+@module trait Persistence {
+  val database: Database
+  val cache: Cache
 }
 ```
 </div>

--- a/docs/src/main/tut/docs/README.md
+++ b/docs/src/main/tut/docs/README.md
@@ -42,12 +42,12 @@ In the example below we will define two algebras with intermixed sequential and 
 import freestyle._
 import freestyle.implicits._
 
-@free trait Validation[F[_]] {
+@free trait Validation {
   def minSize(s: String, n: Int): Oper.Par[Boolean]
   def hasNumber(s: String): Oper.Par[Boolean]
 }
 
-@free trait Interaction[F[_]] {
+@free trait Interaction {
   def tell(msg: String): Oper.Seq[Unit]
   def ask(prompt: String): Oper.Seq[String]
 }
@@ -61,9 +61,9 @@ Freestyle algebras can be combined into `@module` definitions which provide agre
 parametrization of Free programs.
 
 ```tut:silent:decorate(.kazari-id-1)
-@module trait Application[F[_]] {
-  val validation: Validation[F]
-  val interaction: Interaction[F]
+@module trait Application {
+  val validation: Validation
+  val interaction: Interaction
 }
 ```
 
@@ -80,7 +80,7 @@ Abstract definitions it's all it takes to start building programs that support s
 The example below combines both algebras to produce a more complex program
 
 ```tut:silent:decorate(.kazari-id-1)
-def program[F[_]](implicit A: Application[F]) = {
+def program[F[_]](implicit A: Application.To[F]) = {
   import A._
   import cats.implicits._
 

--- a/docs/src/main/tut/docs/README.md
+++ b/docs/src/main/tut/docs/README.md
@@ -43,13 +43,13 @@ import freestyle._
 import freestyle.implicits._
 
 @free trait Validation[F[_]] {
-  def minSize(s: String, n: Int): FreeS.Par[F, Boolean]
-  def hasNumber(s: String): FreeS.Par[F, Boolean]
+  def minSize(s: String, n: Int): Oper.Par[Boolean]
+  def hasNumber(s: String): Oper.Par[Boolean]
 }
 
 @free trait Interaction[F[_]] {
-  def tell(msg: String): FreeS[F, Unit]
-  def ask(prompt: String): FreeS[F, String]
+  def tell(msg: String): Oper.Seq[Unit]
+  def ask(prompt: String): Oper.Seq[String]
 }
 ```
 

--- a/docs/src/main/tut/docs/algebras/README.md
+++ b/docs/src/main/tut/docs/algebras/README.md
@@ -50,7 +50,7 @@ object UserRepository {
   final case class Save(user: User) extends Op[User]
   final case class GetAll(filter: String) extends Op[List[User]]
 
-  class RaiseTo[L[_]](implicit I: Inject[Op, L]) extends UserRepository[L] {
+  class To[L[_]](implicit I: Inject[Op, L]) extends UserRepository[L] {
 
     def get(id: Long): FreeS[L, User] =
         FreeS.liftPar( FreeS.inject[Op, L]( Get(id)) )
@@ -62,10 +62,10 @@ object UserRepository {
         FreeS.liftPar( FreeS.inject[Op, L]( GetAll(filter)) )
   }
 
-  implicit def raiseTo[L[_]](implicit I: Inject[Op, L]): UserRepository[L] =
-    new RaiseTo[L]
+  implicit def to[L[_]](implicit I: Inject[Op, L]): UserRepository[L] =
+    new To[L]
 
-  def apply[F[_]](implicit c: UserRepository[F]): UserRepository[F] = c
+  def apply[L[_]](implicit c: UserRepository[L]): UserRepository[L] = c
 
   trait Handler[M[_]] extends FunctionK[Op, M] {
 

--- a/docs/src/main/tut/docs/algebras/README.md
+++ b/docs/src/main/tut/docs/algebras/README.md
@@ -20,10 +20,10 @@ import freestyle._
 
 case class User(id: Long, name: String)
 
-@free trait UserRepository[F[_]] {
-  def get(id: Long): FreeS[F, User]
-  def save(user: User): FreeS[F, User]
-  def list: FreeS[F, List[User]]
+@free trait UserRepository {
+  def get(id: Long): Oper.Seq[User]
+  def save(user: User): Oper.Seq[User]
+  def list: Oper.Seq[List[User]]
 }
 ```
 
@@ -34,10 +34,10 @@ import freestyle.FreeS
 
 case class User(id: Long, name: String)
 
-trait UserRepository[F[_]] {
-  def get(id: Long): FreeS[F, User]
-  def save(user: User): FreeS[F, User]
-  def getAll(filter: String): FreeS[F, List[User]]
+trait UserRepository {
+  def get(id: Long): Oper.Seq[User]
+  def save(user: User): Oper.Seq[User]
+  def getAll(filter: String): Oper.Seq[List[User]]
 }
 
 object UserRepository {
@@ -124,13 +124,13 @@ You may use this to manually build `Coproduct` types which will serve in the par
 import cats.data.Coproduct
 
 @free trait Service1[F[_]]{
-  def x(n: Int): FreeS[F, Int]
+  def x(n: Int): Oper.Seq[Int]
 }
 @free trait Service2[F[_]]{
-  def y(n: Int): FreeS[F, Int]
+  def y(n: Int): Oper.Seq[Int]
 }
 @free trait Service3[F[_]]{
-  def z(n: Int): FreeS[F, Int]
+  def z(n: Int): Oper.Seq[Int]
 }
 type C1[A] = Coproduct[Service1.Op, Service2.Op, A]
 type Module[A] = Coproduct[Service3.Op, C1, A]

--- a/docs/src/main/tut/docs/effects/README.md
+++ b/docs/src/main/tut/docs/effects/README.md
@@ -376,7 +376,7 @@ import freestyle.effects._
 val list = traverse[List]
 import list._, list.implicits._
 
-def programTraverse[F[_]: TraverseM] =
+def programTraverse[F[_]: TraverseM.To] =
   for {
     a <- TraverseM[F].fromTraversable(1 :: 2 :: 3 :: Nil)
     b <- (a + 1).pure[FreeS[F, ?]]

--- a/docs/src/main/tut/docs/effects/README.md
+++ b/docs/src/main/tut/docs/effects/README.md
@@ -58,7 +58,7 @@ val boom = new RuntimeException("BOOM")
 
 type Target[A] = Either[Throwable, A]
 
-def shortCircuit[F[_]: ErrorM] =
+def shortCircuit[F[_]: ErrorM.To] =
   for {
     a <- 1.pure[FreeS[F, ?]]
     b <- ErrorM[F].either[Int](Left(boom))
@@ -70,7 +70,7 @@ shortCircuit[ErrorM.Op].exec[Target]
 
 ```tut:book
 
-def continueWithRightValue[F[_]: ErrorM] =
+def continueWithRightValue[F[_]: ErrorM.To] =
   for {
     a <- 1.pure[FreeS[F, ?]]
     b <- ErrorM[F].either[Int](Right(1))
@@ -86,7 +86,7 @@ If you want so simply raise an error without throwing an exception you may use t
 the program. 
 
 ```tut:book
-def shortCircuitWithError[F[_]: ErrorM] =
+def shortCircuitWithError[F[_]: ErrorM.To] =
   for {
     a <- 1.pure[FreeS[F, ?]]
     b <- ErrorM[F].error[Int](boom)
@@ -108,7 +108,7 @@ in `scala.util.control.NonFatal`.
 ```tut:book
 import cats.Eval
 
-def catchingExceptions[F[_]: ErrorM] =
+def catchingExceptions[F[_]: ErrorM.To] =
   for {
     a <- 1.pure[FreeS[F, ?]]
     b <- ErrorM[F].catchNonFatal[Int](Eval.later(throw new RuntimeException))
@@ -137,7 +137,7 @@ will short circuit.
 import freestyle.effects.option._
 import freestyle.effects.option.implicits._
 
-def programNone[F[_]: OptionM] =
+def programNone[F[_]: OptionM.To] =
   for {
     a <- 1.pure[FreeS[F, ?]]
     b <- OptionM[F].option[Int](None)
@@ -151,7 +151,7 @@ If a `Some(_)` is found the value is extracted and lifted into the context and t
 normally.
 
 ```tut:book
-def programSome[F[_]: OptionM] =
+def programSome[F[_]: OptionM.To] =
   for {
     a <- 1.pure[FreeS[F, ?]]
     b <- OptionM[F].option(Some(1))
@@ -167,7 +167,7 @@ programSome[OptionM.Op].exec[Option]
 care. 
 
 ```tut:book
-def programNone2[F[_]: OptionM] =
+def programNone2[F[_]: OptionM.To] =
   for {
     a <- 1.pure[FreeS[F, ?]]
     b <- OptionM[F].none[Int]
@@ -205,7 +205,7 @@ val rd = reader[Config]
 
 import rd.implicits._
 
-def programAsk[F[_]: rd.ReaderM] =
+def programAsk[F[_]: rd.ReaderM.To] =
   for {
     _ <- 1.pure[FreeS[F, ?]]
     c <- rd.ReaderM[F].ask
@@ -220,7 +220,7 @@ programAsk[rd.ReaderM.Op].exec[ConfigEnv].run(Config(n = 10))
 `reader` allows extracting values of the environment and lifting them into the context of `FreeS`
 
 ```tut:book
-def programReader[F[_]: rd.ReaderM] =
+def programReader[F[_]: rd.ReaderM.To] =
   for {
     a <- 1.pure[FreeS[F, ?]]
     b <- rd.ReaderM[F].reader(_.n)
@@ -255,7 +255,7 @@ import wr.implicits._
 
 type Logger[A] = Writer[List[Int], A]
 
-def programWriter[F[_]: wr.WriterM] =
+def programWriter[F[_]: wr.WriterM.To] =
   for {
     _ <- 1.pure[FreeS[F, ?]]
     b <- wr.WriterM[F].writer((Nil, 1))
@@ -270,7 +270,7 @@ programWriter[wr.WriterM.Op].exec[Logger].run
 `tell` appends a value for monoidal accumulation
 
 ```tut:book
-def programTell[F[_]: wr.WriterM] =
+def programTell[F[_]: wr.WriterM.To] =
   for {
     _ <- 1.pure[FreeS[F, ?]]
     b <- wr.WriterM[F].writer((List(1), 1))
@@ -306,7 +306,7 @@ type TargetState[A] = State[Int, A]
 
 import st.implicits._
 
-def programGet[F[_]: st.StateM] =
+def programGet[F[_]: st.StateM.To] =
   for {
     a <- 1.pure[FreeS[F, ?]]
     b <- st.StateM[F].get
@@ -321,7 +321,7 @@ programGet[st.StateM.Op].exec[TargetState].run(1).value
 `set` replaces the current state
 
 ```tut:book
-def programSet[F[_]: st.StateM] =
+def programSet[F[_]: st.StateM.To] =
   for {
     _ <- st.StateM[F].set(1)
     a <- st.StateM[F].get
@@ -335,7 +335,7 @@ programSet[st.StateM.Op].exec[TargetState].run(0).value
 `modify` modifies the current state
 
 ```tut:book
-def programModify[F[_]: st.StateM] =
+def programModify[F[_]: st.StateM.To] =
   for {
     a <- st.StateM[F].get
     _ <- st.StateM[F].modify(_ + a)
@@ -350,7 +350,7 @@ programModify[st.StateM.Op].exec[TargetState].run(1).value
 `inspect` runs a function over the current state and returns the resulting value
 
 ```tut:book
-def programInspect[F[_]: st.StateM] =
+def programInspect[F[_]: st.StateM.To] =
   for {
     a <- st.StateM[F].get
     b <- st.StateM[F].inspect(_ + a)
@@ -392,7 +392,7 @@ In the same way as `OptionM#none`, the empty value is determined by how the `Mon
 is implemented.
 
 ```tut:book
-def programEmpty[F[_]: TraverseM] =
+def programEmpty[F[_]: TraverseM.To] =
   for {
     _ <- TraverseM[F].empty[Int]
     a <- TraverseM[F].fromTraversable(1 :: 2 :: 3 :: Nil)
@@ -433,7 +433,7 @@ type ValidationResult[A] = State[List[ValidationError], A]
 ```tut:book
 import cats.instances.list._
 
-def programValid[F[_]: vl.ValidationM] =
+def programValid[F[_]: vl.ValidationM.To] =
   for {
     a <- 1.pure[FreeS[F, ?]]
     b <- vl.ValidationM[F].valid(1)
@@ -448,7 +448,7 @@ programValid[vl.ValidationM.Op].exec[ValidationResult].runEmpty
 `invalid` accumulates a validation error.
 
 ```tut:book
-def programInvalid[F[_]: vl.ValidationM] =
+def programInvalid[F[_]: vl.ValidationM.To] =
   for {
     a <- 1.pure[FreeS[F, ?]]
     _ <- vl.ValidationM[F].invalid(NotValid("oh no"))
@@ -463,7 +463,7 @@ programInvalid[vl.ValidationM.Op].exec[ValidationResult].runEmpty
 `errors` allows you to inspect the accumulated errors so far.
 
 ```tut:book
-def programErrors[F[_]: vl.ValidationM] =
+def programErrors[F[_]: vl.ValidationM.To] =
   for {
     _ <- vl.ValidationM[F].invalid(NotValid("oh no"))
     errs <- vl.ValidationM[F].errors
@@ -478,7 +478,7 @@ programErrors[vl.ValidationM.Op].exec[ValidationResult].runEmpty
 We can interleave `Either[ValidationError, ?]` values in the program, and if they have errors in the left side they will be accumulated.
 
 ```tut:book
-def programFromEither[F[_]: vl.ValidationM] =
+def programFromEither[F[_]: vl.ValidationM.To] =
   for {
     _ <- vl.ValidationM[F].fromEither(Left(NotValid("oh no")) : Either[ValidationError, Int])
 	a <- vl.ValidationM[F].fromEither(Right(42) : Either[ValidationError, Int])
@@ -494,7 +494,7 @@ We can interleave `ValidatedNel[ValidationError, ?]` values in the program, and 
 ```tut:book
 import cats.data.{Validated, ValidatedNel, NonEmptyList}
 
-def programFromValidatedNel[F[_]: vl.ValidationM] =
+def programFromValidatedNel[F[_]: vl.ValidationM.To] =
   for {
     a <- vl.ValidationM[F].fromValidatedNel(
 	   Validated.Valid(42)
@@ -515,7 +515,7 @@ programFromValidatedNel[vl.ValidationM.Op].exec[ValidationResult].runEmpty
 By importing the validation effect implicits, a couple methods are available for lifting valid and invalid values to our program: `liftValid` and `liftInvalid`.
 
 ```tut:book
-def programSyntax[F[_]: vl.ValidationM] =
+def programSyntax[F[_]: vl.ValidationM.To] =
   for {
     a <- 42.liftValid
 	_ <- NotValid("oh no").liftInvalid

--- a/docs/src/main/tut/docs/effects/cache.md
+++ b/docs/src/main/tut/docs/effects/cache.md
@@ -22,12 +22,12 @@ The set of abstract operations of the `Cache` algebra are specified as follows.
 ```Scala
 class KeyValueProvider[Key, Value] {
     @free sealed trait CacheM[F[_]] {
-      def get(key: Key):              FreeS.Par[F, Option[Val]]
-      def put(key: Key, newVal: Val): FreeS.Par[F, Unit]
-      def del(key: Key):              FreeS.Par[F, Unit]
-      def has(key: Key):              FreeS.Par[F, Boolean]
-      def keys:                       FreeS.Par[F, List[Key]]
-      def clear:                      FreeS.Par[F, Unit]
+      def get(key: Key):              Oper.Par[Option[Val]]
+      def put(key: Key, newVal: Val): Oper.Par[Unit]
+      def del(key: Key):              Oper.Par[Unit]
+      def has(key: Key):              Oper.Par[Boolean]
+      def keys:                       Oper.Par[List[Key]]
+      def clear:                      Oper.Par[Unit]
     }
 }
 ```

--- a/docs/src/main/tut/docs/effects/cache.md
+++ b/docs/src/main/tut/docs/effects/cache.md
@@ -21,7 +21,7 @@ The set of abstract operations of the `Cache` algebra are specified as follows.
 
 ```Scala
 class KeyValueProvider[Key, Value] {
-    @free sealed trait CacheM[F[_]] {
+    @free sealed trait CacheM {
       def get(key: Key):              Oper.Par[Option[Val]]
       def put(key: Key, newVal: Val): Oper.Par[Unit]
       def del(key: Key):              Oper.Par[Unit]

--- a/docs/src/main/tut/docs/fetch/README.md
+++ b/docs/src/main/tut/docs/fetch/README.md
@@ -34,7 +34,7 @@ Let's start by creating a simple algebra for our application for printing messag
 import freestyle._
 import freestyle.implicits._
 
-@free trait Interact[F[_]] {
+@free trait Interact {
   def tell(msg: String): Oper.Seq[Unit]
 }
 ```
@@ -45,9 +45,9 @@ Then, make sure to include the fetch algebra `FetchM` in your application:
 import freestyle.fetch._
 import freestyle.fetch.implicits._
 
-@module trait App[F[_]] {
-  val interact: Interact[F]
-  val fetches: FetchM[F]
+@module trait App {
+  val interact: Interact
+  val fetches: FetchM
 }
 ```
 
@@ -55,7 +55,7 @@ Now that we've got our `Interact` algebra and `FetchM` in our app, we're ready t
 
 ```tut:book
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
 ): FreeS[F, Int] =  for {
     _ <- app.interact.tell("Hello")
     x <- app.fetches.runA(fetchOne(1))
@@ -98,7 +98,7 @@ We've already seen `FetchM#runA`, which runs a fetch returning the final result.
 
 ```tut:book
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
 ): FreeS[F, Int] =  for {
     _ <- app.interact.tell("Hello")
     x <- app.fetches.runA(fetchOne(1))
@@ -112,7 +112,7 @@ There is a variant of `runA` where a cache can be specified: `FetchM#runAWithCac
 
 ```tut:book
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
 ): FreeS[F, Int] =  for {
     _ <- app.interact.tell("Hello")
     x <- app.fetches.runAWithCache(fetchOne(1), InMemoryCache.empty)
@@ -128,7 +128,7 @@ Fetch tracks its internal state with an environment of type `FetchEnv`. The `Fet
 
 ```tut:book
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
 ): FreeS[F, FetchEnv] =  for {
     _ <- app.interact.tell("Hello")
     env <- app.fetches.runE(fetchOne(1))
@@ -142,7 +142,7 @@ There is a variant of `runE` where a cache can be specified: `FetchM#runEWithCac
 
 ```tut:book
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
 ): FreeS[F, FetchEnv] =  for {
     _ <- app.interact.tell("Hello")
     env <- app.fetches.runEWithCache(fetchOne(1), InMemoryCache.empty)
@@ -158,7 +158,7 @@ If we are intested in both the final environment and the fetch result, we can us
 
 ```tut:book
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
 ): FreeS[F, FetchEnv] =  for {
     _ <- app.interact.tell("Hello")
     r <- app.fetches.runF(fetchOne(1))
@@ -173,7 +173,7 @@ There is a variant of `runF` where a cache can be specified: `FetchM#runFWithCac
 
 ```tut:book
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
 ): FreeS[F, FetchEnv] =  for {
     _ <- app.interact.tell("Hello")
 	r <- app.fetches.runFWithCache(fetchOne(1), InMemoryCache.empty)
@@ -192,7 +192,7 @@ One of the things to consider when interleaving fetches in free programs is that
 
 ```tut:book
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
 ): FreeS[F, Int] =  for {
     _ <- app.interact.tell("Hello")
 	x <- app.fetches.runA(fetchOne(1))
@@ -207,7 +207,7 @@ However, we can run a fetch getting both the environment and result with `runF`,
 
 ```tut:book
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
 ): FreeS[F, Int] =  for {
     _ <- app.interact.tell("Hello")
     r <- app.fetches.runF(fetchOne(1))

--- a/docs/src/main/tut/docs/fetch/README.md
+++ b/docs/src/main/tut/docs/fetch/README.md
@@ -35,7 +35,7 @@ import freestyle._
 import freestyle.implicits._
 
 @free trait Interact[F[_]] {
-  def tell(msg: String): FreeS[F, Unit]
+  def tell(msg: String): Oper.Seq[Unit]
 }
 ```
 

--- a/docs/src/main/tut/docs/fs2/README.md
+++ b/docs/src/main/tut/docs/fs2/README.md
@@ -16,7 +16,7 @@ We'll start by creating a simple algebra for our application for printing messag
 import freestyle._
 
 @free trait Interact[F[_]] {
-  def tell(msg: String): FreeS[F, Unit]
+  def tell(msg: String): Oper.Seq[Unit]
 }
 ```
 

--- a/docs/src/main/tut/docs/fs2/README.md
+++ b/docs/src/main/tut/docs/fs2/README.md
@@ -15,7 +15,7 @@ We'll start by creating a simple algebra for our application for printing messag
 ```tut:book
 import freestyle._
 
-@free trait Interact[F[_]] {
+@free trait Interact {
   def tell(msg: String): Oper.Seq[Unit]
 }
 ```
@@ -28,9 +28,9 @@ import freestyle.implicits._
 import freestyle.fs2._
 import freestyle.fs2.implicits._
 
-@module trait App[F[_]] {
-  val interact: Interact[F]
-  val streams: StreamM[F]
+@module trait App {
+  val interact: Interact
+  val streams: StreamM
 }
 ```
 
@@ -40,7 +40,7 @@ Now that we've got our `Interact` algebra and `StreamM` in our app, we're ready 
 import _root_.fs2.Stream
 
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
   ): FreeS[F, Vector[Int]] =  for {
     _ <- app.interact.tell("Hello")
 	x <- app.streams.runLog(Stream.emits(List(1, 2, 3)))
@@ -85,7 +85,7 @@ We've already seen `StreamM#runLog`, that runs a stream accumulating its result 
 
 ```tut:book
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
 ): FreeS[F, Vector[Int]] = app.streams.runLog(Stream.emit(42))
 
 Await.result(program[App.Op].exec[Future], Duration.Inf)
@@ -102,9 +102,8 @@ val aStream: Stream[Eff, Int] = Stream.emits(0 until 10)
 Now we can fold over the above stream by adding all its numbers:
 
 ```tut:book
-def program[F[_]](
-  implicit app: App[F]
-): FreeS[F, Int] = app.streams.runFold(0, (x: Int, y: Int) => x + y)(aStream)
+def program[F[_]]( implicit app: App.To[F] ): FreeS[F, Int] = 
+    app.streams.runFold(0, (x: Int, y: Int) => x + y)(aStream)
 
 Await.result(program[App.Op].exec[Future], Duration.Inf)
 ```
@@ -115,7 +114,7 @@ Another option is to run a stream discarding all the results but the last one. S
 
 ```tut:book
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
 ): FreeS[F, Option[Int]] = app.streams.runLast(aStream)
 
 Await.result(program[App.Op].exec[Future], Duration.Inf)
@@ -150,7 +149,7 @@ We now can interleave this stream inside our free programs, choosing the streams
 
 ```tut:book
 def program[F[_]](
-  implicit app: App[F]
+  implicit app: App.To[F]
 ): FreeS[F, Unit] = for {
  _ <- app.interact.tell("Converting from farenheit to celsius")
  _ <- app.streams.run(converter)

--- a/docs/src/main/tut/docs/interpreters/README.md
+++ b/docs/src/main/tut/docs/interpreters/README.md
@@ -25,10 +25,10 @@ import freestyle._
 import cats.implicits._
 
 @free trait KVStore[F[_]] {
-  def put[A](key: String, value: A): FreeS[F, Unit]
-  def get[A](key: String): FreeS[F, Option[A]]
-  def delete(key: String): FreeS[F, Unit]
-  def update[A](key: String, f: A => A): FreeS[F, Unit] = 
+  def put[A](key: String, value: A): Oper.Seq[Unit]
+  def get[A](key: String): Oper.Seq[Option[A]]
+  def delete(key: String): Oper.Seq[Unit]
+  def update[A](key: String, f: A => A): Oper[Unit] = 
     get[A](key) flatMap {
       case Some(a) => put[A](key, f(a))
       case None => ().pure[FreeS[F, ?]]
@@ -87,8 +87,8 @@ To illustrate interpreter composition let's define a new algebra `Log` which we 
 
 ```tut:book
 @free trait Log[F[_]] {
-  def info(msg: String): FreeS[F, Unit]
-  def warn(msg: String): FreeS[F, Unit]
+  def info(msg: String): Oper.Seq[Unit]
+  def warn(msg: String): Oper.Seq[Unit]
 }
 ```
 

--- a/docs/src/main/tut/docs/interpreters/README.md
+++ b/docs/src/main/tut/docs/interpreters/README.md
@@ -24,11 +24,11 @@ Consider the following algebra adapted to Freestyle from the [Typelevel Cats Fre
 import freestyle._
 import cats.implicits._
 
-@free trait KVStore[F[_]] {
+@free trait KVStore {
   def put[A](key: String, value: A): Oper.Seq[Unit]
   def get[A](key: String): Oper.Seq[Option[A]]
   def delete(key: String): Oper.Seq[Unit]
-  def update[A](key: String, f: A => A): Oper[Unit] = 
+  def update[A](key: String, f: A => A): Oper[Unit] =
     get[A](key) flatMap {
       case Some(a) => put[A](key, f(a))
       case None => ().pure[FreeS[F, ?]]
@@ -86,7 +86,7 @@ by the evidence of it's algebras's interpreters.
 To illustrate interpreter composition let's define a new algebra `Log` which we will compose with our `KVStore` operations.
 
 ```tut:book
-@free trait Log[F[_]] {
+@free trait Log {
   def info(msg: String): Oper.Seq[Unit]
   def warn(msg: String): Oper.Seq[Unit]
 }
@@ -108,9 +108,9 @@ Before we create a program where we combine all operations let's consider both `
 of a module in our application
 
 ```tut:book
-@module trait Backend[F[_]] {
-  val store: KVStore[F]
-  val log: Log[F]
+@module trait Backend {
+  val store: KVStore
+  val log: Log
 }
 ```
 

--- a/docs/src/main/tut/docs/modules/README.md
+++ b/docs/src/main/tut/docs/modules/README.md
@@ -19,16 +19,16 @@ In the presentation side an application may display or perform some input valida
 import freestyle._
 
 object algebras {
-    @free trait Database[F[_]] {
+    @free trait Database {
       def get(id: Int): Oper.Seq[Int]
     }
-    @free trait Cache[F[_]] {
+    @free trait Cache {
       def get(id: Int): Oper.Seq[Option[Int]]
     }
-    @free trait Presenter[F[_]] {
+    @free trait Presenter {
       def show(id: Int): Oper.Seq[Int]
     }
-    @free trait IdValidation[F[_]] {
+    @free trait IdValidation {
       def validate(id: Option[Int]): Oper.Seq[Int]
     }
 }
@@ -42,17 +42,17 @@ Modules can be further nested so they become part of the tree that conforms an a
 import algebras._
 
 object modules {
-    @module trait Persistence[F[_]] {
-      val database: Database[F]
-      val cache: Cache[F]
+    @module trait Persistence {
+      val database: Database
+      val cache: Cache
     }
-    @module trait Display[F[_]] {
-      val presenter: Presenter[F]
-      val validator: IdValidation[F]
+    @module trait Display {
+      val presenter: Presenter
+      val validator: IdValidation
     }
-    @module trait App[F[_]] {
-      val persistence: Persistence[F]
-      val display: Display[F]
+    @module trait App {
+      val persistence: Persistence
+      val display: Display
     }
 }
 ```
@@ -62,9 +62,7 @@ This enables to build programs that are properly typed and parameterized in a mo
 ```tut:book
 import modules._
 
-def program[F[_]](
-	implicit
-	  app: App[F]): FreeS[F, Int] = {
+def program[F[_]]( implicit app: App.To[F]): FreeS[F, Int] = {
   import app.display._, app.persistence._
   for {
     cachedToken <- cache.get(1)
@@ -99,7 +97,7 @@ using the implicits scoping rules to place different implementations where appro
 This also solves all Dependency Injection problems automatically for all modules in applications that model their layers a modules with the `@module` annotation.
 
 ```tut:book
-def doWithApp[F[_]](implicit app: App[F]) = ???
+def doWithApp[F[_]](implicit app: App.To[F]) = ???
 ```
 
 ## Convenient type aliases

--- a/docs/src/main/tut/docs/modules/README.md
+++ b/docs/src/main/tut/docs/modules/README.md
@@ -20,16 +20,16 @@ import freestyle._
 
 object algebras {
     @free trait Database[F[_]] {
-      def get(id: Int): FreeS[F, Int]
+      def get(id: Int): Oper.Seq[Int]
     }
     @free trait Cache[F[_]] {
-      def get(id: Int): FreeS[F, Option[Int]]
+      def get(id: Int): Oper.Seq[Option[Int]]
     }
     @free trait Presenter[F[_]] {
-      def show(id: Int): FreeS[F, Int]
+      def show(id: Int): Oper.Seq[Int]
     }
     @free trait IdValidation[F[_]] {
-      def validate(id: Option[Int]): FreeS[F, Int]
+      def validate(id: Option[Int]): Oper.Seq[Int]
     }
 }
 ```

--- a/docs/src/main/tut/docs/parallelism/README.md
+++ b/docs/src/main/tut/docs/parallelism/README.md
@@ -30,8 +30,8 @@ Independent operations that can be executed potentially in parallel may be place
 import freestyle._
 
 @free trait Validation[F[_]] {
-  def minSize(n: Int): FreeS.Par[F, Boolean]
-  def hasNumber: FreeS.Par[F, Boolean]
+  def minSize(n: Int): Oper.Par[Boolean]
+  def hasNumber: Oper.Par[Boolean]
 }
 ```
 
@@ -83,9 +83,9 @@ Sequential and parallel actions can be easily intermixed in `@free` algebras.
 
 ```tut:book
 @free trait MixedFreeS[F[_]] {
-  def x: FreeS.Par[F, Int]
-  def y: FreeS.Par[F, Int]
-  def z: FreeS[F, Int]
+  def x: Oper.Par[Int]
+  def y: Oper.Par[Int]
+  def z: Oper.Seq[Int]
 }
 ```
 

--- a/docs/src/main/tut/docs/parallelism/README.md
+++ b/docs/src/main/tut/docs/parallelism/README.md
@@ -29,7 +29,7 @@ Independent operations that can be executed potentially in parallel may be place
 ```tut:book
 import freestyle._
 
-@free trait Validation[F[_]] {
+@free trait Validation {
   def minSize(n: Int): Oper.Par[Boolean]
   def hasNumber: Oper.Par[Boolean]
 }
@@ -82,7 +82,7 @@ val validator = parValidation.exec[ParValidator]
 Sequential and parallel actions can be easily intermixed in `@free` algebras.
 
 ```tut:book
-@free trait MixedFreeS[F[_]] {
+@free trait MixedFreeS {
   def x: Oper.Par[Int]
   def y: Oper.Par[Int]
   def z: Oper.Seq[Int]
@@ -95,7 +95,7 @@ Using the [cats cartesian builder operator \|@\|](http://eed3si9n.com/herding-ca
 import freestyle.implicits._
 import cats.implicits._
 
-def program[F[_]](implicit M: MixedFreeS[F]) = {
+def program[F[_]](implicit M: MixedFreeS.To[F]) = {
   import M._
   for {
     a <- z //3

--- a/docs/src/main/tut/docs/stack/README.md
+++ b/docs/src/main/tut/docs/stack/README.md
@@ -38,12 +38,12 @@ We will represent these capabilities using two algebras: `CustomerPersistence` a
 ```tut:book
 object algebras {
   @free trait CustomerPersistence[F[_]] {
-    def getCustomer(id: CustomerId): FreeS.Par[F, Option[Customer]]
+    def getCustomer(id: CustomerId): Oper.Par[Option[Customer]]
   }
 
   @free trait StockPersistence[F[_]] {
-    def checkQuantityAvailable(cultivar: String): FreeS.Par[F, Int]
-    def registerOrder(order: Order): FreeS.Par[F, Unit]
+    def checkQuantityAvailable(cultivar: String): Oper.Par[Int]
+    def registerOrder(order: Order): Oper.Par[Unit]
   }
 }
 ```

--- a/freestyle-async-monix/shared/src/test/scala/asyncMonix/AsyncMonixTests.scala
+++ b/freestyle-async-monix/shared/src/test/scala/asyncMonix/AsyncMonixTests.scala
@@ -17,7 +17,7 @@ class AsyncMonixTests extends AsyncWordSpec with Matchers {
 
   "Async Monix Freestyle integration" should {
     "support Task as the target runtime" in {
-      def program[F[_]: AsyncM] =
+      def program[F[_]: AsyncM.To] =
         for {
           a <- FreeS.pure(1)
           b <- AsyncM[F].async[Int]((cb) => cb(Right(42)))

--- a/freestyle-async/shared/src/main/scala/async.scala
+++ b/freestyle-async/shared/src/main/scala/async.scala
@@ -13,8 +13,8 @@ object async {
   }
 
   /** Async computation algebra. **/
-  @free sealed trait AsyncM[F[_]] {
-    def async[A](fa: Proc[A]): FreeS.Par[F, A]
+  @free sealed trait AsyncM {
+    def async[A](fa: Proc[A]): Oper.Par[A]
   }
 
   object implicits {

--- a/freestyle-async/shared/src/test/scala/async/AsyncTests.scala
+++ b/freestyle-async/shared/src/test/scala/async/AsyncTests.scala
@@ -16,7 +16,7 @@ class AsyncTests extends AsyncWordSpec with Matchers {
 
   "Async Freestyle integration" should {
     "allow an Async to be interleaved inside a program monadic flow" in {
-      def program[F[_]: AsyncM] =
+      def program[F[_]: AsyncM.To] =
         for {
           a <- FreeS.pure(1)
           b <- AsyncM[F].async[Int]((cb) => cb(Right(42)))
@@ -27,7 +27,7 @@ class AsyncTests extends AsyncWordSpec with Matchers {
     }
 
     "allow multiple Async to be interleaved inside a program monadic flow" in {
-      def program[F[_]: AsyncM] =
+      def program[F[_]: AsyncM.To] =
         for {
           a <- FreeS.pure(1)
           b <- AsyncM[F].async[Int]((cb) => cb(Right(42)))
@@ -44,7 +44,7 @@ class AsyncTests extends AsyncWordSpec with Matchers {
     case class OhNoException() extends Exception
 
     "allow Async errors to short-circuit a program" in {
-      def program[F[_]: AsyncM] =
+      def program[F[_]: AsyncM.To] =
         for {
           a <- FreeS.pure(1)
           b <- AsyncM[F].async[Int]((cb) => cb(Left(OhNoException())))

--- a/freestyle-cache-redis/shared/src/test/scala/RedisTests.scala
+++ b/freestyle-cache-redis/shared/src/test/scala/RedisTests.scala
@@ -25,7 +25,7 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
   "Redis integration into Freestyle" should {
 
     "allow to interleave one CacheM within the programs monadic flow" in {
-      def program[F[_]: CacheM]: FreeS[F, Int] =
+      def program[F[_]: CacheM.To]: FreeS[F, Int] =
         for {
           a <- Applicative[FreeS[F, ?]].pure(Some(1))
           b <- CacheM[F].put("Joe", 13) *> CacheM[F].get("Joe")
@@ -38,21 +38,21 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
   "GET" should {
 
     "result in None if the datastore is empty" in {
-      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM.To]: FreeS[F, Option[Int]] =
         CacheM[F].get("a")
 
       program[CacheM.Op].exec[Future] map { _ shouldBe None }
     }
 
     "result in None if a different key is set" in {
-      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_]: CacheM.To]: FreeS[F, Option[Int]] =
         CacheM[F].put("a", 0) *> CacheM[F].get("b")
 
       program[CacheM.Op].exec[Future] map { _ shouldBe None }
     }
 
     "result in Some(v) if v is the only set value" in {
-      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM.To]: FreeS[F, Option[Int]] =
         CacheM[F].put("a", 0) *> CacheM[F].get("a")
 
       program[CacheM.Op].exec[Future] map { _ shouldBe Some(0)}
@@ -62,7 +62,7 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
   "PUT" should {
 
     "reduce consecutive PUT on the same key down to last SET" in {
-      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- (CacheM[F].put("a", 0) *> CacheM[F].put("a", 1))
           a <- CacheM[F].get("a")
@@ -73,7 +73,7 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
     }
 
     "ignore succeeding PUT to other Keys" in {
-      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("a", 0) *> CacheM[F].put("b", 1)
           a <- CacheM[F].get("a")
@@ -84,7 +84,7 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
     }
 
     "ignore preceding PUT to other Keys" in {
-      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("b", 1) *> CacheM[F].put("a", 0)
           a <- CacheM[F].get("a")
@@ -98,7 +98,7 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
   "PUTALL" should {
 
       "ignore succeeding PUT to other Keys" in {
-        def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+        def program[F[_]: CacheM.To]: FreeS[F, (Option[Int], Int)] =
           for {
             _ <- CacheM[F].putAll(Map("a"-> 0,"b"-> 1)) *> CacheM[F].put("c", 2)
             a <- CacheM[F].get("a")
@@ -109,7 +109,7 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
     }
 
     "ignore a preceding PUT on same key" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_]: CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("a", 0) *> CacheM[F].putAll(Map("a"-> 1,"b"-> 1))
           a <- CacheM[F].get("a")
@@ -123,7 +123,7 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
   "PUTIFABSENT" should {
 
     "ignore a PUTIFABSENT because the key is already associated with a value" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_]: CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("a", 0) *> CacheM[F].putIfAbsent("a", 1)
           a <- CacheM[F].get("a")
@@ -134,7 +134,7 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
     }
 
     "ignore a succeeding PUT on different key" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_]: CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("b", 1) *> CacheM[F].putIfAbsent("a", 0)
           a <- CacheM[F].get("a")
@@ -145,7 +145,7 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
     }
 
     "ignore preceding PUTIFABSENT to other Keys" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_]: CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].putIfAbsent("b", 1) *> CacheM[F].putIfAbsent("a", 0)
           a <- CacheM[F].get("a")
@@ -159,7 +159,7 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
   "DELETE" should {
 
     "nullify a preceeding PUT on same key" in {
-      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("a", 0) *> CacheM[F].del("a")
           a <- CacheM[F].get("a")
@@ -170,7 +170,7 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
     }
 
     "be overridden by succeeding PUT on same Key" in {
-      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].del("a") *> CacheM[F].put("a", 0)
           a <- CacheM[F].get("a")
@@ -181,14 +181,14 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
     }
 
     "ignore a preceeding PUT on different key" in {
-      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM.To]: FreeS[F, Option[Int]] =
         CacheM[F].put("a", 0) *> CacheM[F].del("b") *> CacheM[F].get("a")
 
       program[CacheM.Op].exec[Future] map { _  shouldBe Some(0) }
     }
 
     "ignore a succeeding PUT on different key" in {
-      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM.To]: FreeS[F, Option[Int]] =
         CacheM[F].del("b") *> CacheM[F].put("a", 0) *> CacheM[F].get("a")
 
       program[CacheM.Op].exec[Future] map { _  shouldBe Some(0) }
@@ -197,7 +197,7 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
 
   "CLEAR" should {
     "remove all the keys" in {
-      def program[F[_] : CacheM] =
+      def program[F[_] : CacheM.To] =
         for {
           k1 <- CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].keys
           k2 <- CacheM[F].clear *> CacheM[F].keys
@@ -209,14 +209,14 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
 
   "REPLACE" should {
     "replace the entry for a key" in {
-      def program[F[_] : CacheM] =
+      def program[F[_] : CacheM.To] =
         CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].replace("a", 1) *> CacheM[F].get("a")
 
       program[CacheM.Op].exec[Future] map { _  shouldBe Some(1) }
     }
 
     "ignore replace the entry because a key not exist" in {
-      def program[F[_] : CacheM] =
+      def program[F[_] : CacheM.To] =
         CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].replace("c", 1) *> CacheM[F].get("c")
 
       program[CacheM.Op].exec[Future] map { _  shouldBe None }
@@ -225,14 +225,14 @@ class RedisTests extends AsyncWordSpec with Matchers with RedisTestContext {
 
   "ISEMPTY" should {
     "isn't empty" in {
-      def program[F[_] : CacheM] =
+      def program[F[_] : CacheM.To] =
         CacheM[F].put("a", 0) *> CacheM[F].isEmpty
 
       program[CacheM.Op].exec[Future] map { _  shouldBe false }
     }
 
     "is empty" in {
-      def program[F[_] : CacheM] =
+      def program[F[_] : CacheM.To] =
         CacheM[F].put("a", 0) *> CacheM[F].clear *> CacheM[F].isEmpty
 
       program[CacheM.Op].exec[Future] map { _  shouldBe true }

--- a/freestyle-cache/shared/src/main/scala/cache.scala
+++ b/freestyle-cache/shared/src/main/scala/cache.scala
@@ -12,37 +12,37 @@ package cache {
      * We assume that the actual store is too big or remote to allow for general
      * operations over all values, or to search or to iterate over all keys
      */
-    @free sealed trait CacheM[F[_]] {
+    @free sealed trait CacheM {
 
       // Gets the value associated to a key, if there is one */
-      def get(key: Key): FreeS.Par[F, Option[Val]]
+      def get(key: Key): Oper.Par[Option[Val]]
 
       // Sets the value of a key to a newValue.
-      def put(key: Key, newVal: Val): FreeS.Par[F, Unit]
+      def put(key: Key, newVal: Val): Oper.Par[Unit]
 
       // Copy all of the mappings from the specified map to this cache
-      def putAll(keyValues: Map[Key, Val]): FreeS.Par[F, Unit]
+      def putAll(keyValues: Map[Key, Val]): Oper.Par[Unit]
 
       //If the specified key is not already associated with a value, associate it with the given value.
-      def putIfAbsent(key: Key, newVal: Val): FreeS.Par[F, Unit]
+      def putIfAbsent(key: Key, newVal: Val): Oper.Par[Unit]
 
       // Removes the entry for the key if one exists
-      def del(key: Key): FreeS.Par[F, Unit]
+      def del(key: Key): Oper.Par[Unit]
 
       // Returns whether there is an entry for key or not.
-      def has(key: Key): FreeS.Par[F, Boolean]
+      def has(key: Key): Oper.Par[Boolean]
 
       // Returns the set of keys in the store
-      def keys: FreeS.Par[F, List[Key]]
+      def keys: Oper.Par[List[Key]]
 
       // Removes all entries
-      def clear: FreeS.Par[F, Unit]
+      def clear: Oper.Par[Unit]
 
       //Replaces the entry for a key only if currently mapped to some value
-      def replace(key: Key, newVal: Val): FreeS.Par[F, Unit]
+      def replace(key: Key, newVal: Val): Oper.Par[Unit]
 
       //Returns true if this cache contains no key-value mappings.
-      def isEmpty: FreeS.Par[F, Boolean]
+      def isEmpty: Oper.Par[Boolean]
 
     }
 

--- a/freestyle-cache/shared/src/test/scala/CacheTests.scala
+++ b/freestyle-cache/shared/src/test/scala/CacheTests.scala
@@ -16,21 +16,21 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
 
   "GET" should {
     "result in None if the datastore is empty" in {
-      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM.To]: FreeS[F, Option[Int]] =
         CacheM[F].get("a")
 
       program[CacheM.Op].exec[Id] shouldBe None
     }
 
     "result in None if a different key is set" in {
-      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM.To]: FreeS[F, Option[Int]] =
         CacheM[F].put("a", 0) *> CacheM[F].get("b")
 
       program[CacheM.Op].exec[Id] shouldBe None
     }
 
     "result in Some(v) if v is the only set value" in {
-      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM.To]: FreeS[F, Option[Int]] =
         CacheM[F].put("a", 0) *> CacheM[F].get("a")
 
       program[CacheM.Op].exec[Id] shouldBe Some(0)
@@ -40,7 +40,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
   "PUT" should {
 
     "reduce consecutive PUT on the same key down to last SET" in {
-      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- (CacheM[F].put("a", 0) *> CacheM[F].put("a", 1))
           a <- CacheM[F].get("a")
@@ -51,7 +51,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
     }
 
     "ignore succeeding PUT to other Keys" in {
-      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("a", 0) *> CacheM[F].put("b", 1)
           a <- CacheM[F].get("a")
@@ -62,7 +62,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
     }
 
     "ignore preceding PUT to other Keys" in {
-      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("b", 1) *> CacheM[F].put("a", 0)
           a <- CacheM[F].get("a")
@@ -76,7 +76,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
   "PUTALL" should {
 
     "ignore succeeding PUT to other Keys" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_]: CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].putAll(Map("a"-> 0,"b"-> 1)) *> CacheM[F].put("c", 2)
           a <- CacheM[F].get("a")
@@ -87,7 +87,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
     }
 
     "ignore a preceding PUT on same key" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_]: CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("a", 0) *> CacheM[F].putAll(Map("a"-> 1,"b"-> 1))
           a <- CacheM[F].get("a")
@@ -102,7 +102,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
   "PUTIFABSENT" should {
 
     "ignore a PUTIFABSENT because the key is already associated with a value" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_]: CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("a", 0) *> CacheM[F].putIfAbsent("a", 1)
           a <- CacheM[F].get("a")
@@ -113,7 +113,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
     }
 
     "ignore a succeeding PUT on different key" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_]: CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("b", 1) *> CacheM[F].putIfAbsent("a", 0)
           a <- CacheM[F].get("a")
@@ -124,7 +124,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
     }
 
     "ignore preceding PUTIFABSENT to other Keys" in {
-      def program[F[_]: CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_]: CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].putIfAbsent("b", 1) *> CacheM[F].putIfAbsent("a", 0)
           a <- CacheM[F].get("a")
@@ -140,7 +140,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
   "DELETE" should {
 
     "nullify a preceeding PUT on same key" in {
-      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].put("a", 0) *> CacheM[F].del("a")
           a <- CacheM[F].get("a")
@@ -151,7 +151,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
     }
 
     "be overridden by succeeding PUT on same Key" in {
-      def program[F[_] : CacheM]: FreeS[F, (Option[Int], Int)] =
+      def program[F[_] : CacheM.To]: FreeS[F, (Option[Int], Int)] =
         for {
           _ <- CacheM[F].del("a") *> CacheM[F].put("a", 0)
           a <- CacheM[F].get("a")
@@ -162,14 +162,14 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
     }
 
     "ignore a preceeding PUT on different key" in {
-      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM.To]: FreeS[F, Option[Int]] =
         CacheM[F].put("a", 0) *> CacheM[F].del("b") *> CacheM[F].get("a")
 
       program[CacheM.Op].exec[Id] shouldBe Some(0)
     }
 
     "ignore a succeeding PUT on different key" in {
-      def program[F[_] : CacheM]: FreeS[F, Option[Int]] =
+      def program[F[_] : CacheM.To]: FreeS[F, Option[Int]] =
         CacheM[F].del("b") *> CacheM[F].put("a", 0) *> CacheM[F].get("a")
 
       program[CacheM.Op].exec[Id] shouldBe Some(0)
@@ -178,7 +178,7 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
 
   "CLEAR" should {
     "remove all the keys" in {
-      def program[F[_] : CacheM] =
+      def program[F[_] : CacheM.To] =
         for {
           k1 <- CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].keys
           k2 <- CacheM[F].clear *> CacheM[F].keys
@@ -190,14 +190,14 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
 
   "REPLACE" should {
     "replace the entry for a key" in {
-      def program[F[_] : CacheM] =
+      def program[F[_] : CacheM.To] =
         CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].replace("a", 1) *> CacheM[F].get("a")
 
       program[CacheM.Op].exec[Id] shouldBe Some(1)
     }
 
     "ignore replace the entry because a key not exist" in {
-      def program[F[_] : CacheM] =
+      def program[F[_] : CacheM.To] =
         CacheM[F].put("a", 0) *> CacheM[F].put("b", 1) *> CacheM[F].replace("c", 1) *> CacheM[F].get("c")
 
       program[CacheM.Op].exec[Id] shouldBe None
@@ -206,14 +206,14 @@ class CacheTests extends WordSpec with Matchers with CacheTestContext {
 
   "ISEMPTY" should {
     "isn't empty" in {
-      def program[F[_] : CacheM] =
+      def program[F[_] : CacheM.To] =
         CacheM[F].put("a", 0) *> CacheM[F].isEmpty
 
       program[CacheM.Op].exec[Id] shouldBe false
     }
 
     "is empty" in {
-      def program[F[_] : CacheM] =
+      def program[F[_] : CacheM.To] =
         CacheM[F].put("a", 0) *> CacheM[F].clear *> CacheM[F].isEmpty
 
       program[CacheM.Op].exec[Id] shouldBe true

--- a/freestyle-config/shared/src/main/scala/config.scala
+++ b/freestyle-config/shared/src/main/scala/config.scala
@@ -22,10 +22,10 @@ object config {
     def millisDuration(path: String): Option[Duration]
   }
 
-  @free sealed trait ConfigM[F[_]] {
-    def load: FreeS[F, Config]
-    def empty: FreeS[F, Config]
-    def parseString(s: String): FreeS[F, Config]
+  @free sealed trait ConfigM {
+    def load: Oper.Seq[Config]
+    def empty: Oper.Seq[Config]
+    def parseString(s: String): Oper.Seq[Config]
   }
 
   object implicits {

--- a/freestyle-config/shared/src/test/scala/ConfigTests.scala
+++ b/freestyle-config/shared/src/test/scala/ConfigTests.scala
@@ -40,8 +40,8 @@ class ConfigTests extends AsyncWordSpec with Matchers {
 
 object algebras {
   @free
-  trait NonConfig[F[_]] {
-    def x: FreeS[F, Int]
+  trait NonConfig {
+    def x: Oper.Seq[Int]
   }
 
   implicit def nonConfigHandler: NonConfig.Handler[Future] =
@@ -50,9 +50,9 @@ object algebras {
     }
 
   @module
-  trait App[F[_]] {
-    val nonConfig: NonConfig[F]
-    val configM: ConfigM[F]
+  trait App {
+    val nonConfig: NonConfig
+    val configM: ConfigM
   }
 
   val app = App[App.Op]

--- a/freestyle-doobie/src/main/scala/doobie.scala
+++ b/freestyle-doobie/src/main/scala/doobie.scala
@@ -6,8 +6,8 @@ import fs2.util.{Catchable, Suspendable}
 
 object doobie {
 
-  @free sealed trait DoobieM[F[_]] {
-    def transact[A](f: ConnectionIO[A]): FreeS.Par[F, A]
+  @free sealed trait DoobieM {
+    def transact[A](f: ConnectionIO[A]): Oper.Par[A]
   }
 
   object implicits {
@@ -17,7 +17,7 @@ object doobie {
         def transact[A](fa: ConnectionIO[A]): M[A] = fa.transact(xa)
       }
 
-    implicit def freeSLiftDoobie[F[_]: DoobieM]: FreeSLift[F, ConnectionIO] =
+    implicit def freeSLiftDoobie[F[_]: DoobieM.To]: FreeSLift[F, ConnectionIO] =
       new FreeSLift[F, ConnectionIO] {
         def liftFSPar[A](cio: ConnectionIO[A]): FreeS.Par[F, A] = DoobieM[F].transact(cio)
       }

--- a/freestyle-doobie/src/test/scala/doobie.scala
+++ b/freestyle-doobie/src/test/scala/doobie.scala
@@ -57,8 +57,8 @@ class DoobieTests extends AsyncWordSpec with Matchers {
 
 object algebras {
   @free
-  trait NonDoobie[F[_]] {
-    def x: FreeS[F, Int]
+  trait NonDoobie {
+    def x: Oper.Seq[Int]
   }
 
   implicit def nonDoobieHandler: NonDoobie.Handler[Task] =
@@ -67,10 +67,10 @@ object algebras {
     }
 
   @module
-  trait App[F[_]] {
-    val nonDoobie: NonDoobie[F]
-    val doobieM: DoobieM[F]
+  trait App {
+    val nonDoobie: NonDoobie
+    val doobieM: DoobieM
   }
 
-  val app = App[App.Op]
+  val app = App.to[App.Op]
 }

--- a/freestyle-doobie/src/test/scala/doobie.scala
+++ b/freestyle-doobie/src/test/scala/doobie.scala
@@ -72,5 +72,5 @@ object algebras {
     val doobieM: DoobieM
   }
 
-  val app = App.to[App.Op]
+  val app = App[App.Op]
 }

--- a/freestyle-effects/shared/src/main/scala/effects/error.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/error.scala
@@ -5,10 +5,10 @@ import cats.{Eval, MonadError}
 
 object error {
 
-  @free sealed trait ErrorM[F[_]] {
-    def either[A](fa: Either[Throwable, A]): FreeS.Par[F, A]
-    def error[A](e: Throwable): FreeS.Par[F, A]
-    def catchNonFatal[A](a: Eval[A]): FreeS.Par[F, A]
+  @free sealed trait ErrorM {
+    def either[A](fa: Either[Throwable, A]): Oper.Par[A]
+    def error[A](e: Throwable): Oper.Par[A]
+    def catchNonFatal[A](a: Eval[A]): Oper.Par[A]
   }
 
   trait ErrorImplicits {
@@ -20,11 +20,11 @@ object error {
       def catchNonFatal[A](a: Eval[A]): M[A]        = ME.catchNonFatal[A](a.value)
     }
 
-    class ErrorFreeSLift[F[_]: ErrorM] extends FreeSLift[F, Either[Throwable, ?]] {
+    class ErrorFreeSLift[F[_]: ErrorM.To] extends FreeSLift[F, Either[Throwable, ?]] {
       def liftFSPar[A](fa: Either[Throwable, A]): FreeS.Par[F, A] = ErrorM[F].either(fa)
     }
 
-    implicit def freeSLiftError[F[_]: ErrorM]: FreeSLift[F, Either[Throwable, ?]] =
+    implicit def freeSLiftError[F[_]: ErrorM.To]: FreeSLift[F, Either[Throwable, ?]] =
       new ErrorFreeSLift[F]
 
   }

--- a/freestyle-effects/shared/src/main/scala/effects/option.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/option.scala
@@ -5,9 +5,9 @@ import cats.MonadFilter
 
 object option {
 
-  @free sealed trait OptionM[F[_]] {
-    def option[A](fa: Option[A]): FreeS.Par[F, A]
-    def none[A]: FreeS.Par[F, A]
+  @free sealed trait OptionM {
+    def option[A](fa: Option[A]): Oper.Par[A]
+    def none[A]: Oper.Par[A]
   }
 
   trait OptionImplicits {
@@ -17,11 +17,11 @@ object option {
       def none[A]: M[A]                  = MF.empty[A]
     }
 
-    class OptionFreeSLift[F[_]: OptionM] extends FreeSLift[F, Option] {
+    class OptionFreeSLift[F[_]: OptionM.To] extends FreeSLift[F, Option] {
       def liftFSPar[A](fa: Option[A]): FreeS.Par[F, A] = OptionM[F].option(fa)
     }
 
-    implicit def freeSLiftOption[F[_]: OptionM]: FreeSLift[F, Option] = new OptionFreeSLift[F]
+    implicit def freeSLiftOption[F[_]: OptionM.To]: FreeSLift[F, Option] = new OptionFreeSLift[F]
   }
 
   object implicits extends OptionImplicits

--- a/freestyle-effects/shared/src/main/scala/effects/reader.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/reader.scala
@@ -7,9 +7,9 @@ object reader {
 
   final class EnvironmentProvider[R] {
 
-    @free sealed abstract class ReaderM[F[_]] {
-      def ask: FreeS.Par[F, R]
-      def reader[B](f: R => B): FreeS.Par[F, B]
+    @free sealed abstract class ReaderM {
+      def ask: Oper.Par[R]
+      def reader[B](f: R => B): Oper.Par[B]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/main/scala/effects/state.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/state.scala
@@ -7,11 +7,11 @@ object state {
 
   final class StateSeedProvider[S] {
 
-    @free sealed abstract class StateM[F[_]] {
-      def get: FreeS.Par[F, S]
-      def set(s: S): FreeS.Par[F, Unit]
-      def modify(f: S => S): FreeS.Par[F, Unit]
-      def inspect[A](f: S => A): FreeS.Par[F, A]
+    @free sealed abstract class StateM {
+      def get: Oper.Par[S]
+      def set(s: S): Oper.Par[Unit]
+      def modify(f: S => S): Oper.Par[Unit]
+      def inspect[A](f: S => A): Oper.Par[A]
     }
 
     object implicits {
@@ -24,11 +24,11 @@ object state {
         def inspect[A](f: S => A): M[A] = MS.inspect(f)
       }
 
-      class StateInspectFreeSLift[F[_]: StateM] extends FreeSLift[F, Function1[S, ?]] {
+      class StateInspectFreeSLift[F[_]: StateM.To] extends FreeSLift[F, Function1[S, ?]] {
         def liftFSPar[A](fa: S => A): FreeS.Par[F, A] = StateM[F].inspect(fa)
       }
 
-      implicit def freeSLiftStateInspect[F[_]: StateM]: FreeSLift[F, Function1[S, ?]] =
+      implicit def freeSLiftStateInspect[F[_]: StateM.To]: FreeSLift[F, Function1[S, ?]] =
         new StateInspectFreeSLift[F]
 
     }

--- a/freestyle-effects/shared/src/main/scala/effects/traverse.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/traverse.scala
@@ -9,9 +9,9 @@ object traverse {
 
     /** Acts as a generator providing traversable semantics to programs
      */
-    @free sealed abstract class TraverseM[F[_]] {
-      def empty[A]: FreeS.Par[F, A]
-      def fromTraversable[A](ta: G[A]): FreeS.Par[F, A]
+    @free sealed abstract class TraverseM {
+      def empty[A]: Oper.Par[A]
+      def fromTraversable[A](ta: G[A]): Oper.Par[A]
     }
 
     /** Interpretable as long as Foldable instance for G[_] and a MonadCombine for M[_] exists
@@ -27,11 +27,11 @@ object traverse {
         }
     }
 
-    class TraverseFreeSLift[F[_]: TraverseM] extends FreeSLift[F, G] {
+    class TraverseFreeSLift[F[_]: TraverseM.To] extends FreeSLift[F, G] {
       def liftFSPar[A](fa: G[A]): FreeS.Par[F, A] = TraverseM[F].fromTraversable(fa)
     }
 
-    implicit def freeSLiftTraverse[F[_]: TraverseM]: FreeSLift[F, G] =
+    implicit def freeSLiftTraverse[F[_]: TraverseM.To]: FreeSLift[F, G] =
       new TraverseFreeSLift[F]
 
   }

--- a/freestyle-effects/shared/src/main/scala/effects/validation.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/validation.scala
@@ -10,16 +10,16 @@ object validation {
     type Errors = List[E]
 
     /** An algebra for introducing validation semantics in a program. **/
-    @free sealed trait ValidationM[F[_]] {
-      def valid[A](x: A): FreeS.Par[F, A]
+    @free sealed trait ValidationM {
+      def valid[A](x: A): Oper.Par[A]
 
-      def invalid(err: E): FreeS.Par[F, Unit]
+      def invalid(err: E): Oper.Par[Unit]
 
-      def errors: FreeS.Par[F, Errors]
+      def errors: Oper.Par[Errors]
 
-      def fromEither[A](x: Either[E, A]): FreeS.Par[F, Either[E, A]]
+      def fromEither[A](x: Either[E, A]): Oper.Par[Either[E, A]]
 
-      def fromValidatedNel[A](x: ValidatedNel[E, A]): FreeS.Par[F, ValidatedNel[E, A]]
+      def fromValidatedNel[A](x: ValidatedNel[E, A]): Oper.Par[ValidatedNel[E, A]]
     }
 
     object implicits {
@@ -50,11 +50,15 @@ object validation {
       }
 
       implicit class ValidSyntax[A](private val s: A){
-        def liftValid[F[_] : ValidationM]: FreeS[F, A] = ValidationM[F].valid(s)
+        def liftValid[F[_] : ValidationM.To]: FreeS[F, A] =
+          implicitly[ValidationM.To[F]].valid(s)
       }
+
       implicit class InvalidSyntax[A](private val e: E){
-        def liftInvalid[F[_] : ValidationM]: FreeS[F, Unit] = ValidationM[F].invalid(e)
+        def liftInvalid[F[_] : ValidationM.To]: FreeS[F, Unit] =
+          implicitly[ValidationM.To[F]].invalid(e)
       }
+
     }
   }
 

--- a/freestyle-effects/shared/src/main/scala/effects/writer.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/writer.scala
@@ -7,9 +7,9 @@ object writer {
 
   final class AccumulatorProvider[W] {
 
-    @free sealed abstract class WriterM[F[_]] {
-      def writer[A](aw: (W, A)): FreeS.Par[F, A]
-      def tell(w: W): FreeS.Par[F, Unit]
+    @free sealed abstract class WriterM {
+      def writer[A](aw: (W, A)): Oper.Par[A]
+      def tell(w: W): Oper.Par[Unit]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/main/scala/effects/writer.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/writer.scala
@@ -9,7 +9,7 @@ object writer {
 
     @free sealed abstract class WriterM[F[_]] {
       def writer[A](aw: (W, A)): FreeS.Par[F, A]
-      def tell(w: W): FreeS.Par[F, Unit] = writer((w, ()))
+      def tell(w: W): FreeS.Par[F, Unit]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/test/scala/effects/EffectsTests.scala
+++ b/freestyle-effects/shared/src/test/scala/effects/EffectsTests.scala
@@ -23,7 +23,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     import cats.instances.option._
 
     "allow an Option to be interleaved inside a program monadic flow" in {
-      def program[F[_]: OptionM] =
+      def program[F[_]: OptionM.To] =
         for {
           a <- FreeS.pure(1)
           b <- OptionM[F].option(Option(1))
@@ -33,7 +33,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "allow an Option to shortcircuit inside a program monadic flow" in {
-      def program[F[_]: OptionM] =
+      def program[F[_]: OptionM.To] =
         for {
           a <- FreeS.pure(1)
           b <- OptionM[F].none[Int]
@@ -43,7 +43,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "allow an Option to be interleaved inside a program monadic flow using syntax" in {
-      def program[F[_]: OptionM] =
+      def program[F[_]: OptionM.To] =
         for {
           a <- FreeS.pure(1)
           b <- Option(1).liftFS
@@ -64,7 +64,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     import cats.syntax.either._
 
     "allow an Error to be interleaved inside a program monadic flow" in {
-      def program[F[_]: ErrorM] =
+      def program[F[_]: ErrorM.To] =
         for {
           a <- FreeS.pure(1)
           b <- ErrorM[F].error[Int](ex)
@@ -74,7 +74,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "allow an Exception to be captured inside a program monadic flow" in {
-      def program[F[_]: ErrorM] =
+      def program[F[_]: ErrorM.To] =
         for {
           a <- FreeS.pure(1)
           b <- ErrorM[F].catchNonFatal[Int](Eval.later(throw ex))
@@ -84,7 +84,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "allow an Either to propagate right biased" in {
-      def program[F[_]: ErrorM] =
+      def program[F[_]: ErrorM.To] =
         for {
           a <- FreeS.pure(1)
           b <- ErrorM[F].either[Int](Right(1))
@@ -94,7 +94,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "allow an Either to short circuit" in {
-      def program[F[_]: ErrorM] =
+      def program[F[_]: ErrorM.To] =
         for {
           a <- FreeS.pure(1)
           b <- ErrorM[F].either[Int](Left(ex))
@@ -104,7 +104,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "allow an Either to propagate right biased using syntax" in {
-      def program[F[_]: ErrorM] =
+      def program[F[_]: ErrorM.To] =
         for {
           a <- FreeS.pure(1)
           b <- Either.right[Throwable, Int](1).liftFS
@@ -114,7 +114,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "allow an Either to short circuit using syntax" in {
-      def program[F[_]: ErrorM] =
+      def program[F[_]: ErrorM.To] =
         for {
           a <- FreeS.pure(1)
           b <- Either.left[Throwable, Int](ex).liftFS
@@ -133,7 +133,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     import rd.implicits._
 
     "allow retrieving an environment for a user defined type" in {
-      def program[F[_]: rd.ReaderM] =
+      def program[F[_]: rd.ReaderM.To] =
         for {
           _ <- FreeS.pure(1)
           c <- rd.ReaderM[F].ask
@@ -143,7 +143,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "allow maping over the environment for a user defined type" in {
-      def program[F[_]: rd.ReaderM] =
+      def program[F[_]: rd.ReaderM.To] =
         for {
           _ <- FreeS.pure(1)
           c <- rd.ReaderM[F].reader(_.n)
@@ -162,7 +162,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     import st.implicits._
 
     "get" in {
-      def program[F[_]: st.StateM] =
+      def program[F[_]: st.StateM.To] =
         for {
           a <- FreeS.pure(1)
           b <- st.StateM[F].get
@@ -172,7 +172,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "set" in {
-      def program[F[_]: st.StateM] =
+      def program[F[_]: st.StateM.To] =
         for {
           _ <- st.StateM[F].set(1)
           a <- st.StateM[F].get
@@ -181,7 +181,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "modify" in {
-      def program[F[_]: st.StateM] =
+      def program[F[_]: st.StateM.To] =
         for {
           a <- st.StateM[F].get
           _ <- st.StateM[F].modify(_ + a)
@@ -191,7 +191,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "inspect" in {
-      def program[F[_]: st.StateM] =
+      def program[F[_]: st.StateM.To] =
         for {
           a <- st.StateM[F].get
           b <- st.StateM[F].inspect(_ + a)
@@ -200,7 +200,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "syntax" in {
-      def program[F[_]: st.StateM] =
+      def program[F[_]: st.StateM.To] =
         for {
           a <- st.StateM[F].get
           b <- ((x: Int) => x + a).liftFS
@@ -221,7 +221,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     type Logger[A] = Writer[List[Int], A]
 
     "writer" in {
-      def program[F[_]: wr.WriterM] =
+      def program[F[_]: wr.WriterM.To] =
         for {
           _ <- FreeS.pure(1)
           b <- wr.WriterM[F].writer((Nil, 1))
@@ -231,7 +231,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "tell" in {
-      def program[F[_]: wr.WriterM] =
+      def program[F[_]: wr.WriterM.To] =
         for {
           _ <- FreeS.pure(1)
           b <- wr.WriterM[F].writer((List(1), 1))
@@ -271,7 +271,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     type Logger[A] = StateT[Future, Errors, A]
 
     "valid" in {
-      def program[F[_]: vl.ValidationM] =
+      def program[F[_]: vl.ValidationM.To] =
         for {
           _ <- FreeS.pure(1)
           b <- vl.ValidationM[F].valid(42)
@@ -282,7 +282,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "invalid" in {
-      def program[F[_]: vl.ValidationM] =
+      def program[F[_]: vl.ValidationM.To] =
         for {
           _ <- FreeS.pure(1)
           b <- vl.ValidationM[F].valid(42)
@@ -298,7 +298,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     "errors" in {
       val expectedErrors = List(NotValid("oh"), NotValid("no"))
 
-      def program[F[_]: vl.ValidationM] =
+      def program[F[_]: vl.ValidationM.To] =
         for {
           b <- vl.ValidationM[F].valid(42)
           _ <- vl.ValidationM[F].invalid(NotValid("oh"))
@@ -315,7 +315,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
 
       val expectedErrors = List(MissingFirstName)
 
-      def program[F[_]: vl.ValidationM] =
+      def program[F[_]: vl.ValidationM.To] =
         for {
           a <- vl.ValidationM[F].fromEither(Right(42))
           b <- vl.ValidationM[F].fromEither(Either.left[ValidationException, Unit](MissingFirstName))
@@ -327,7 +327,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     "fromValidatedNel" in {
       import cats.data.Validated
 
-      def program[F[_]: vl.ValidationM] =
+      def program[F[_]: vl.ValidationM.To] =
         for {
           a <- vl.ValidationM[F].fromValidatedNel(Validated.valid(42))
           b <- vl.ValidationM[F].fromValidatedNel(
@@ -339,7 +339,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "syntax" in {
-      def program[F[_]: vl.ValidationM] =
+      def program[F[_]: vl.ValidationM.To] =
         for {
           a <- 42.liftValid
           b <- MissingFirstName.liftInvalid
@@ -360,7 +360,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     import list._, list.implicits._
 
     "fromTraversable" in {
-      def program[F[_]: TraverseM] =
+      def program[F[_]: TraverseM.To] =
         for {
           a <- TraverseM[F].fromTraversable(1 :: 2 :: 3 :: Nil)
           b <- FreeS.pure(a + 1)
@@ -369,7 +369,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "empty" in {
-      def program[F[_]: TraverseM] =
+      def program[F[_]: TraverseM.To] =
         for {
           _ <- TraverseM[F].empty[Int]
           a <- TraverseM[F].fromTraversable(1 :: 2 :: 3 :: Nil)
@@ -380,7 +380,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     }
 
     "syntax" in {
-      def program[F[_]: TraverseM] =
+      def program[F[_]: TraverseM.To] =
         for {
           a <- (1 :: 2 :: 3 :: Nil).liftFS
           b <- FreeS.pure(a + 1)
@@ -399,7 +399,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
     "import option implicits" in {
       import cats.instances.option._
 
-      def program[F[_]: OptionM] =
+      def program[F[_]: OptionM.To] =
         for {
           a <- FreeS.pure(1)
           b <- OptionM[F].none[Int]
@@ -414,7 +414,7 @@ class EffectsTests extends AsyncWordSpec with Matchers {
 
       val ex = new RuntimeException("BOOM")
 
-      def program[F[_]: ErrorM] =
+      def program[F[_]: ErrorM.To] =
         for {
           a <- FreeS.pure(1)
           b <- ErrorM[F].error[Int](ex)
@@ -438,47 +438,47 @@ object collision {
   val rd = reader[Config]
 
   @module
-  trait AppX[F[_]] {
-    val stateM: st.StateM[F]
-    val readerM: rd.ReaderM[F]
+  trait AppX {
+    val stateM: st.StateM
+    val readerM: rd.ReaderM
   }
 
   @free
-  trait B[F[_]] {
-    def x: FreeS[F, Int]
+  trait B {
+    def x: Oper.Seq[Int]
   }
 
   @free
-  trait C[F[_]] {
-    def x: FreeS[F, Int]
+  trait C {
+    def x: Oper.Seq[Int]
   }
 
   @free
-  trait D[F[_]] {
-    def x: FreeS[F, Int]
+  trait D {
+    def x: Oper.Seq[Int]
   }
 
   @free
-  trait E[F[_]] {
-    def x: FreeS[F, Int]
+  trait E {
+    def x: Oper.Seq[Int]
   }
 
   @module
-  trait X[F[_]] {
-    val a: B[F]
-    val b: C[F]
+  trait X {
+    val a: B
+    val b: C
   }
 
   @module
-  trait Y[F[_]] {
-    val c: C[F]
-    val d: D[F]
+  trait Y {
+    val c: C
+    val d: D
   }
 
   @module
-  trait Z[F[_]] {
-    val x: X[F]
-    val y: Y[F]
+  trait Z {
+    val x: X
+    val y: Y
   }
 
 }

--- a/freestyle-fetch/shared/src/main/scala/fetch.scala
+++ b/freestyle-fetch/shared/src/main/scala/fetch.scala
@@ -4,13 +4,13 @@ import _root_.fetch._
 
 object fetch {
 
-  @free sealed trait FetchM[F[_]] {
-    def runA[A](f: Fetch[A]): FreeS.Par[F, A]
-    def runF[A](f: Fetch[A]): FreeS.Par[F, (FetchEnv, A)]
-    def runE[A](f: Fetch[A]): FreeS.Par[F, FetchEnv]
-    def runAWithCache[A](f: Fetch[A], cache: DataSourceCache): FreeS.Par[F, A]
-    def runFWithCache[A](f: Fetch[A], cache: DataSourceCache): FreeS.Par[F, (FetchEnv, A)]
-    def runEWithCache[A](f: Fetch[A], cache: DataSourceCache): FreeS.Par[F, FetchEnv]
+  @free sealed trait FetchM {
+    def runA[A](f: Fetch[A]): Oper.Par[A]
+    def runF[A](f: Fetch[A]): Oper.Par[(FetchEnv, A)]
+    def runE[A](f: Fetch[A]): Oper.Par[FetchEnv]
+    def runAWithCache[A](f: Fetch[A], cache: DataSourceCache): Oper.Par[A]
+    def runFWithCache[A](f: Fetch[A], cache: DataSourceCache): Oper.Par[(FetchEnv, A)]
+    def runEWithCache[A](f: Fetch[A], cache: DataSourceCache): Oper.Par[FetchEnv]
   }
 
   object implicits {
@@ -28,11 +28,11 @@ object fetch {
           fa.runE[M](cache)
       }
 
-    class FetchFreeSLift[F[_]: FetchM] extends FreeSLift[F, Fetch] {
+    class FetchFreeSLift[F[_]: FetchM.To] extends FreeSLift[F, Fetch] {
       def liftFSPar[A](fetch: Fetch[A]): FreeS.Par[F, A] = FetchM[F].runA(fetch)
     }
 
-    implicit def freeSLiftFetch[F[_]: FetchM]: FreeSLift[F, Fetch] = new FetchFreeSLift[F]
+    implicit def freeSLiftFetch[F[_]: FetchM.To]: FreeSLift[F, Fetch] = new FetchFreeSLift[F]
 
   }
 

--- a/freestyle-fetch/shared/src/test/scala/FetchTests.scala
+++ b/freestyle-fetch/shared/src/test/scala/FetchTests.scala
@@ -51,8 +51,8 @@ class FetchTests extends AsyncWordSpec with Matchers {
 
 object algebras {
   @free
-  trait NonFetch[F[_]] {
-    def x: FreeS[F, Int]
+  trait NonFetch {
+    def x: Oper.Seq[Int]
   }
 
   implicit def nonFetchHandler: NonFetch.Handler[Future] =
@@ -61,9 +61,9 @@ object algebras {
     }
 
   @module
-  trait App[F[_]] {
-    val nonFetch: NonFetch[F]
-    val fetchM: FetchM[F]
+  trait App {
+    val nonFetch: NonFetch
+    val fetchM: FetchM
   }
 
   val app = App[App.Op]

--- a/freestyle-fs2/shared/src/main/scala/fs2.scala
+++ b/freestyle-fs2/shared/src/main/scala/fs2.scala
@@ -31,11 +31,11 @@ object fs2 {
     def suspend[A](fa: => Eff[A]): Eff[A] = fa
   }
 
-  @free sealed trait StreamM[F[_]] {
-    def run[A](s: Stream[Eff, A]): FreeS.Par[F, Unit]
-    def runLog[A](s: Stream[Eff, A]): FreeS.Par[F, Vector[A]]
-    def runFold[A, B](z: B, f: (B, A) => B)(s: Stream[Eff, A]): FreeS.Par[F, B]
-    def runLast[A](s: Stream[Eff, A]): FreeS.Par[F, Option[A]]
+  @free sealed trait StreamM {
+    def run[A](s: Stream[Eff, A]): Oper.Par[Unit]
+    def runLog[A](s: Stream[Eff, A]): Oper.Par[Vector[A]]
+    def runFold[A, B](z: B, f: (B, A) => B)(s: Stream[Eff, A]): Oper.Par[B]
+    def runLast[A](s: Stream[Eff, A]): Oper.Par[Option[A]]
   }
 
   object implicits {
@@ -60,10 +60,10 @@ object fs2 {
     }
 
     implicit class Fs2FreeSyntax[A](private val s: Stream[Eff, A]) extends AnyVal {
-      def liftFS[F[_]](implicit MA: Monoid[A], SF: StreamM[F]): FreeS[F, A] =
+      def liftFS[F[_]](implicit MA: Monoid[A], SF: StreamM.To[F]): FreeS[F, A] =
         liftFSPar.freeS
 
-      def liftFSPar[F[_]](implicit MA: Monoid[A], SF: StreamM[F]): FreeS.Par[F, A] =
+      def liftFSPar[F[_]](implicit MA: Monoid[A], SF: StreamM.To[F]): FreeS.Par[F, A] =
         SF.runFold(MA.empty, MA.combine)(s)
     }
   }

--- a/freestyle-fs2/shared/src/test/scala/Fs2Tests.scala
+++ b/freestyle-fs2/shared/src/test/scala/Fs2Tests.scala
@@ -108,8 +108,8 @@ class Fs2Tests extends AsyncWordSpec with Matchers {
 
 object algebras {
   @free
-  trait NonStream[F[_]] {
-    def x: FreeS[F, Int]
+  trait NonStream {
+    def x: Oper.Seq[Int]
   }
 
   implicit def nonStreamHandler: NonStream.Handler[Future] =
@@ -118,9 +118,9 @@ object algebras {
     }
 
   @module
-  trait App[F[_]] {
-    val nonStream: NonStream[F]
-    val streamM: StreamM[F]
+  trait App {
+    val nonStream: NonStream
+    val streamM: StreamM
   }
 
   val app = App[App.Op]

--- a/freestyle-logging/shared/src/main/scala/logging.scala
+++ b/freestyle-logging/shared/src/main/scala/logging.scala
@@ -2,24 +2,23 @@ package freestyle
 
 object logging {
 
-  @free
-  trait LoggingM[F[_]] {
+  @free trait LoggingM {
 
-    def debug(msg: String): FreeS[F, Unit]
+    def debug(msg: String): Oper.Seq[Unit]
 
-    def debugWithCause(msg: String, cause: Throwable): FreeS[F, Unit]
+    def debugWithCause(msg: String, cause: Throwable): Oper.Seq[Unit]
 
-    def error(msg: String): FreeS[F, Unit]
+    def error(msg: String): Oper.Seq[Unit]
 
-    def errorWithCause(msg: String, cause: Throwable): FreeS[F, Unit]
+    def errorWithCause(msg: String, cause: Throwable): Oper.Seq[Unit]
 
-    def info(msg: String): FreeS[F, Unit]
+    def info(msg: String): Oper.Seq[Unit]
 
-    def infoWithCause(msg: String, cause: Throwable): FreeS[F, Unit]
+    def infoWithCause(msg: String, cause: Throwable): Oper.Seq[Unit]
 
-    def warn(msg: String): FreeS[F, Unit]
+    def warn(msg: String): Oper.Seq[Unit]
 
-    def warnWithCause(msg: String, cause: Throwable): FreeS[F, Unit]
+    def warnWithCause(msg: String, cause: Throwable): Oper.Seq[Unit]
   }
 
 }

--- a/freestyle-logging/shared/src/test/scala/algebras.scala
+++ b/freestyle-logging/shared/src/test/scala/algebras.scala
@@ -7,8 +7,8 @@ import scala.concurrent.Future
 object algebras {
 
   @free
-  trait NonLogging[F[_]] {
-    def x: FreeS[F, Int]
+  trait NonLogging{
+    def x: Oper.Seq[Int]
   }
 
   implicit def nonLoggingHandler: NonLogging.Handler[Future] =
@@ -17,9 +17,9 @@ object algebras {
     }
 
   @module
-  trait App[F[_]] {
-    val nonLogging: NonLogging[F]
-    val loggingM: LoggingM[F]
+  trait App {
+    val nonLogging: NonLogging
+    val loggingM: LoggingM
   }
 
   val app = App[App.Op]

--- a/freestyle/shared/src/main/scala/freestyle/free.scala
+++ b/freestyle/shared/src/main/scala/freestyle/free.scala
@@ -78,8 +78,8 @@ object free {
 
       /* A Request declaration in an Effect Trait, such as
        *
-       * @free trait UserRepository[F[_]] {
-       *     def get(id: Long): FreeS[F, User]
+       * @free trait UserRepository {
+       *     def get(id: Long): FreeS[User]
        *
        * gets translated to a Request class such as
        *

--- a/freestyle/shared/src/main/scala/freestyle/package.scala
+++ b/freestyle/shared/src/main/scala/freestyle/package.scala
@@ -56,6 +56,12 @@ package object freestyle {
 
   }
 
+  // Operation Types, used only in the @free macro annotation
+  object Oper {
+    type Par[T]
+    type Seq[T]
+  }
+
   /**
    * Syntax functions for FreeS.Par
    */

--- a/tests/src/main/resources/pcplodtest.scala
+++ b/tests/src/main/resources/pcplodtest.scala
@@ -3,8 +3,8 @@ import freestyle.implicits._
 import cats.implicits._
 
 object pcplodtest {
-  @free trait PcplodTestAlgebra[F[_]] {
-    def test(n: Int): FreeS[F, Int]
+  @free trait PcplodTestAlgebra {
+    def test(n: Int): Oper.Seq[Int]
   }
   implicit val impl = new PcplodTestAlgebra.H@handler@andler[Option] {
     override def test(n:Int): Option[Int] = Some(1)

--- a/tests/src/test/scala/test.scala
+++ b/tests/src/test/scala/test.scala
@@ -17,11 +17,11 @@ class tests extends WordSpec with Matchers {
     }
 
     "provide instances through it's companion `apply`" in {
-      SCtors1[SCtors1.Op].isInstanceOf[SCtors1[SCtors1.Op]] shouldBe true
+      SCtors1[SCtors1.Op].isInstanceOf[SCtors1.To[SCtors1.Op]] shouldBe true
     }
 
     "allow implicit sumoning" in {
-      implicitly[SCtors1[SCtors1.Op]].isInstanceOf[SCtors1[SCtors1.Op]] shouldBe true
+      implicitly[SCtors1.To[SCtors1.Op]].isInstanceOf[SCtors1.To[SCtors1.Op]] shouldBe true
     }
 
     "provide automatic implementations for smart constructors" in {
@@ -59,23 +59,23 @@ class tests extends WordSpec with Matchers {
 
     "allow multiple args in smart constructors" in {
       @free
-      trait MultiArgs[F[_]] {
-        def x(a: Int, b: Int, c: Int): FreeS[F, Int]
+      trait MultiArgs {
+        def x(a: Int, b: Int, c: Int): Oper.Seq[Int]
       }
     }
 
     "allow smart constructors with no args" in {
       @free
-      trait NoArgs[F[_]] {
-        def x: FreeS[F, Int]
+      trait NoArgs {
+        def x: Oper.Seq[Int]
       }
     }
 
     "generate ADTs with friendly names and expose them as dependent types" in {
       @free
-      trait FriendlyFreeS[F[_]] {
-        def sc1(a: Int, b: Int, c: Int): FreeS[F, Int]
-        def sc2(a: Int, b: Int, c: Int): FreeS[F, Int]
+      trait FriendlyFreeS {
+        def sc1(a: Int, b: Int, c: Int): Oper.Seq[Int]
+        def sc2(a: Int, b: Int, c: Int): Oper.Seq[Int]
       }
       implicitly[FriendlyFreeS.Op[_] =:= FriendlyFreeS.Op[_]]
       implicitly[FriendlyFreeS.Sc1OP <:< FriendlyFreeS.Op[Int]]
@@ -85,10 +85,10 @@ class tests extends WordSpec with Matchers {
 
     "allow smart constructors with type arguments" in {
       @free
-      trait KVStore[F[_]] {
-        def put[A](key: String, value: A): FreeS[F, Unit]
-        def get[A](key: String): FreeS[F, Option[A]]
-        def delete(key: String): FreeS[F, Unit]
+      trait KVStore {
+        def put[A](key: String, value: A): Oper.Seq[Unit]
+        def get[A](key: String): Oper.Seq[Option[A]]
+        def delete(key: String): Oper.Seq[Unit]
       }
       val interpreter = new KVStore.Handler[List] {
         def put[A](key: String, value: A): List[Unit] = Nil
@@ -99,10 +99,10 @@ class tests extends WordSpec with Matchers {
 
     "allow evaluation of abstract members that return FreeS.Pars" in {
       @free
-      trait ApplicativesServ[F[_]] {
-        def x(key: String): FreeS.Par[F, String]
-        def y(key: String): FreeS.Par[F, String]
-        def z(key: String): FreeS.Par[F, String]
+      trait ApplicativesServ {
+        def x(key: String): Oper.Par[String]
+        def y(key: String): Oper.Par[String]
+        def z(key: String): Oper.Par[String]
       }
       implicit val interpreter = new ApplicativesServ.Handler[Option] {
         override def x(key: String): Option[String] = Some(key)
@@ -118,10 +118,10 @@ class tests extends WordSpec with Matchers {
 
     "allow sequential evaluation of combined FreeS & FreeS.Par" in {
       @free
-      trait MixedFreeS[F[_]] {
-        def x(key: String): FreeS.Par[F, String]
-        def y(key: String): FreeS.Par[F, String]
-        def z(key: String): FreeS[F, String]
+      trait MixedFreeS {
+        def x(key: String): Oper.Par[String]
+        def y(key: String): Oper.Par[String]
+        def z(key: String): Oper.Seq[String]
       }
       implicit val interpreter = new MixedFreeS.Handler[Option] {
         override def x(key: String): Option[String] = Some(key)
@@ -154,33 +154,33 @@ class tests extends WordSpec with Matchers {
     }
 
     "[simple] provide instances through it's companion `apply`" in {
-      M1[M1.Op].isInstanceOf[M1[M1.Op]] shouldBe true
+      M1[M1.Op].isInstanceOf[M1.To[M1.Op]] shouldBe true
     }
 
     "[onion] provide instances through it's companion `apply`" in {
-      O1[O1.Op].isInstanceOf[O1[O1.Op]] shouldBe true
+      O1[O1.Op].isInstanceOf[O1.To[O1.Op]] shouldBe true
     }
 
     "[simple] implicit sumoning" in {
-      implicitly[M1[M1.Op]].isInstanceOf[M1[M1.Op]] shouldBe true
+      implicitly[M1.To[M1.Op]].isInstanceOf[M1.To[M1.Op]] shouldBe true
     }
 
     "[onion] allow implicit sumoning" in {
-      implicitly[O1[O1.Op]].isInstanceOf[O1[O1.Op]] shouldBe true
+      implicitly[O1.To[O1.Op]].isInstanceOf[O1.To[O1.Op]] shouldBe true
     }
 
     "[simple] autowire implementations of it's contained smart constructors" in {
       val m1 = M1[M1.Op]
-      m1.sctors1.isInstanceOf[SCtors1[M1.Op]] shouldBe true
-      m1.sctors2.isInstanceOf[SCtors2[M1.Op]] shouldBe true
+      m1.sctors1.isInstanceOf[SCtors1.To[M1.Op]] shouldBe true
+      m1.sctors2.isInstanceOf[SCtors2.To[M1.Op]] shouldBe true
     }
 
     "[onion] autowire implementations of it's contained smart constructors" in {
       val o1 = O1[O1.Op]
-      o1.m1.sctors1.isInstanceOf[SCtors1[O1.Op]] shouldBe true
-      o1.m1.sctors2.isInstanceOf[SCtors2[O1.Op]] shouldBe true
-      o1.m2.sctors3.isInstanceOf[SCtors3[O1.Op]] shouldBe true
-      o1.m2.sctors4.isInstanceOf[SCtors4[O1.Op]] shouldBe true
+      o1.m1.sctors1.isInstanceOf[SCtors1.To[O1.Op]] shouldBe true
+      o1.m1.sctors2.isInstanceOf[SCtors2.To[O1.Op]] shouldBe true
+      o1.m2.sctors3.isInstanceOf[SCtors3.To[O1.Op]] shouldBe true
+      o1.m2.sctors4.isInstanceOf[SCtors4.To[O1.Op]] shouldBe true
     }
 
     "[simple] allow composition of it's contained algebras" in {
@@ -290,7 +290,7 @@ class tests extends WordSpec with Matchers {
       import cats.Eval
       import cats.implicits._
 
-      def program[F[_]] =
+      def program =
         for {
           a <- Eval.now(1).freeS
           b <- 2.pure[Eval].freeS
@@ -409,9 +409,9 @@ class tests extends WordSpec with Matchers {
       type ParValidator[A] = Kleisli[Future, String, A]
 
       @free
-      trait Validation[F[_]] {
-        def minSize(n: Int): FreeS.Par[F, Boolean]
-        def hasNumber: FreeS.Par[F, Boolean]
+      trait Validation {
+        def minSize(n: Int): Oper.Par[Boolean]
+        def hasNumber: Oper.Par[ Boolean]
       }
 
       implicit val interpreter = new Validation.Handler[ParValidator] {
@@ -450,44 +450,44 @@ class tests extends WordSpec with Matchers {
 object algebras {
 
   @free
-  trait SCtors1[F[_]] {
-    def x(a: Int): FreeS[F, Int]
-    def y(a: Int): FreeS[F, Int]
+  trait SCtors1 {
+    def x(a: Int): Oper.Seq[Int]
+    def y(a: Int): Oper.Seq[Int]
   }
 
   @free
-  trait SCtors2[F[_]] {
-    def i(a: Int): FreeS[F, Int]
-    def j(a: Int): FreeS[F, Int]
+  trait SCtors2 {
+    def i(a: Int): Oper.Seq[Int]
+    def j(a: Int): Oper.Seq[Int]
   }
 
   @free
-  trait SCtors3[F[_]] {
-    def o(a: Int): FreeS[F, Int]
-    def p(a: Int): FreeS[F, Int]
+  trait SCtors3 {
+    def o(a: Int): Oper.Seq[Int]
+    def p(a: Int): Oper.Seq[Int]
   }
 
   @free
-  trait SCtors4[F[_]] {
-    def k(a: Int): FreeS[F, Int]
-    def m(a: Int): FreeS[F, Int]
+  trait SCtors4 {
+    def k(a: Int): Oper.Seq[Int]
+    def m(a: Int): Oper.Seq[Int]
   }
 
   @free
-  trait MixedFreeS[F[_]] {
-    def x: FreeS.Par[F, Int]
-    def y: FreeS.Par[F, Int]
-    def z: FreeS[F, Int]
+  trait MixedFreeS {
+    def x: Oper.Par[Int]
+    def y: Oper.Par[Int]
+    def z: Oper.Seq[Int]
   }
 
   @free
-  trait S1[F[_]] {
-    def x(n: Int): FreeS[F, Int]
+  trait S1 {
+    def x(n: Int): Oper.Seq[Int]
   }
 
   @free
-  trait S2[F[_]] {
-    def y(n: Int): FreeS[F, Int]
+  trait S2 {
+    def y(n: Int): Oper.Seq[Int]
   }
 
 }
@@ -497,40 +497,40 @@ object modules {
   import algebras._
 
   @module
-  trait M1[F[_]] {
-    val sctors1: SCtors1[F]
-    val sctors2: SCtors2[F]
+  trait M1 {
+    val sctors1: SCtors1
+    val sctors2: SCtors2
   }
 
   @module
-  trait M2[F[_]] {
-    val sctors3: SCtors3[F]
-    val sctors4: SCtors4[F]
+  trait M2 {
+    val sctors3: SCtors3
+    val sctors4: SCtors4
   }
 
   @module
-  trait O1[F[_]] {
-    val m1: M1[F]
-    val m2: M2[F]
+  trait O1 {
+    val m1: M1
+    val m2: M2
   }
 
   @module
-  trait O2[F[_]] {
-    val o1: O1[F]
+  trait O2 {
+    val o1: O1
     val x = 1
     def y = 2
   }
 
   @module
-  trait O3[F[_]] {
+  trait O3 {
     def x = 1
     def y = 2
   }
 
   @module
-  trait StateProp[F[_]] {
-    val s1: S1[F]
-    val s2: S2[F]
+  trait StateProp {
+    val s1: S1
+    val s2: S2
   }
 
 }


### PR DESCRIPTION
This PR shows a proof of concept for #93. The goal of this ticket is to see if we can remove the `F[_]` parameter from the definition of the `@free` algebras. This PR carries the implementation in the core package, and as an example it shows the result of the change for the `doobie` algebra.

* We introduce in the core `freestyle` package a `Oper` package, to describe operations in a `@free` algebra. This is needed only because the `@free` trait may also contain other elements apart from the operations of that algebra.

* This parameter, which represents the _carrier_ type to which the operations are _injected to_, is now only available through the type `To`. For every `@free` and `@module` trait `Foo` the respective companion object provides a class `Foo.To[F[_]]`, which contains the operations (for `@free`) or the algebras (for `@module`).  

Note: For convenience, this PR is based in another branch, which carries other changes to `@free` and `@macro` that do not alter the semantics of these macros.