### PR TITLE
Fix WriterM.tell

### DIFF
--- a/freestyle-effects/shared/src/main/scala/effects/writer.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/writer.scala
@@ -9,7 +9,7 @@ object writer {
 
     @free sealed abstract class WriterM[F[_]] {
       def writer[A](aw: (W, A)): FreeS.Par[F, A]
-      def tell(w: W): FreeS.Par[F, Unit] = writer((w, ()))
+      def tell(w: W): FreeS.Par[F, Unit]
     }
 
     object implicits {


### PR DESCRIPTION
This adds a TellOp in the algebra and the `MonadWriter.tell` function will be used in the handler/interpreter.

Like mentioned in #106.