### PR TITLE
sbt-org-policies Plugin Milestone 1 Integration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,146 +1,101 @@
-import catext.Dependencies._
-import microsites.util.BuildHelper._
-
 addCommandAlias("debug", "; clean ; test")
 
 addCommandAlias("validate", "; +clean ; +test; makeMicrosite")
 
-lazy val micrositeSettings = Seq(
-  micrositeName := "Freestyle",
-  micrositeDescription := "A Cohesive & Pragmatic Framework of FP centric Scala libraries",
-  micrositeDocumentationUrl := "/docs/",
-  micrositeGithubOwner := "47deg",
-  micrositeGithubRepo := "freestyle",
-  micrositeHighlightTheme := "dracula",
-  micrositeExternalLayoutsDirectory := (resourceDirectory in Compile).value / "microsite" / "layouts",
-  micrositeExternalIncludesDirectory := (resourceDirectory in Compile).value / "microsite" / "includes",
-  includeFilter in Jekyll := ("*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "CNAME"),
-  micrositePalette := Map(
-    "brand-primary"     -> "#01C2C2",
-    "brand-secondary"   -> "#142236",
-    "brand-tertiary"    -> "#202D40",
-    "gray-dark"         -> "#383D44",
-    "gray"              -> "#646D7B",
-    "gray-light"        -> "#E6E7EC",
-    "gray-lighter"      -> "#F4F5F9",
-    "white-color"       -> "#E6E7EC"),
-  micrositeKazariCodeMirrorTheme := "dracula",
-  micrositeKazariDependencies := Seq(microsites.KazariDependency("com.fortysevendeg", "freestyle", buildWithoutSuffix(scalaVersion.value), version.value),
-  microsites.KazariDependency("org.scalamacros", "paradise", scalaVersion.value, "2.1.0")),
-  micrositeKazariResolvers := Seq("https://oss.sonatype.org/content/repositories/snapshots", "https://oss.sonatype.org/content/repositories/releases")
-)
-
-pgpPassphrase := Some(sys.env.getOrElse("PGP_PASSPHRASE", "").toCharArray)
-pgpPublicRing := file(s"${sys.env.getOrElse("PGP_FOLDER", ".")}/pubring.gpg")
-pgpSecretRing := file(s"${sys.env.getOrElse("PGP_FOLDER", ".")}/secring.gpg")
+pgpSettings
 
 lazy val freestyle = (crossProject in file("freestyle")).
   settings(name := "freestyle").
   settings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-free" % "0.9.0",
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "io.monix" %%% "monix-eval" % "2.2.1" % "test",
-      "io.monix" %%% "monix-cats" % "2.2.1" % "test",
-      "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-      "com.chuusai" %%% "shapeless" % "2.3.2"
+      %("scala-reflect", scalaVersion.value),
+      %%%("cats-free"),
+      %%%("shapeless"),
+      %%("monix-eval") % "test",
+      %%("monix-cats") % "test"
     )
   ).
   jsSettings(sharedJsSettings: _*)
 
 lazy val freestyleJVM = freestyle.jvm
-lazy val freestyleJS  = freestyle.js
+lazy val freestyleJS = freestyle.js
 
 lazy val freestyleMonix = (crossProject in file("freestyle-monix")).
   settings(name := "freestyle-monix").
   settings(
     libraryDependencies ++= Seq(
-      "io.monix" %%% "monix-eval" % "2.2.1",
-      "io.monix" %%% "monix-cats" % "2.2.1"
+      %%%("monix-eval"),
+      %%%("monix-cats")
     )
   ).
   jsSettings(sharedJsSettings: _*)
 
 lazy val freestyleMonixJVM = freestyleMonix.jvm
-lazy val freestyleMonixJS  = freestyleMonix.js
+lazy val freestyleMonixJS = freestyleMonix.js
 
 lazy val freestyleEffects = (crossProject in file("freestyle-effects")).
   dependsOn(freestyle).
   settings(name := "freestyle-effects").
-  settings(
-    libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.1"      % "test"
-    )
-  ).
   jsSettings(sharedJsSettings: _*)
 
 lazy val freestyleEffectsJVM = freestyleEffects.jvm
-lazy val freestyleEffectsJS  = freestyleEffects.js
+lazy val freestyleEffectsJS = freestyleEffects.js
 
 lazy val freestyleAsync = (crossProject in file("freestyle-async")).
   dependsOn(freestyle).
   settings(name := "freestyle-async").
-  settings(
-    libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.1"      % "test"
-    )
-  ).
   jsSettings(sharedJsSettings: _*)
 
 lazy val freestyleAsyncJVM = freestyleAsync.jvm
-lazy val freestyleAsyncJS  = freestyleAsync.js
+lazy val freestyleAsyncJS = freestyleAsync.js
 
 lazy val freestyleAsyncMonix = (crossProject in file("freestyle-async-monix")).
   dependsOn(freestyle, freestyleAsync).
   settings(name := "freestyle-async-monix").
   settings(
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-      "io.monix" %%% "monix-eval" % "2.2.1",
-      "io.monix" %%% "monix-cats" % "2.2.1"
+      %%("monix-eval"),
+      %%("monix-cats")
     )
   ).
   jsSettings(sharedJsSettings: _*)
 
 lazy val freestyleAsyncMonixJVM = freestyleAsyncMonix.jvm
-lazy val freestyleAsyncMonixJS  = freestyleAsyncMonix.js
+lazy val freestyleAsyncMonixJS = freestyleAsyncMonix.js
 
 lazy val freestyleAsyncFs = (crossProject in file("freestyle-async-fs2")).
   dependsOn(freestyle, freestyleAsync).
   settings(name := "freestyle-async-fs2").
   settings(
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-      "co.fs2" %%% "fs2-core" % "0.9.2",
-      "co.fs2" %% "fs2-cats" % "0.3.0"
+      %%%("fs2-core"),
+      %%%("fs2-cats")
     )
   )
 
 lazy val freestyleAsyncFsJVM = freestyleAsyncFs.jvm
-lazy val freestyleAsyncFsJS  = freestyleAsyncFs.js
+lazy val freestyleAsyncFsJS = freestyleAsyncFs.js
 
 lazy val freestyleCache = (crossProject in file("freestyle-cache")).
   dependsOn(freestyle).
   settings(
-    name := "freestyle-cache",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+    name := "freestyle-cache"
   ).
   jsSettings(sharedJsSettings: _*)
 
 lazy val freestyleCacheJVM = freestyleCache.jvm
-lazy val freestyleCacheJS  = freestyleCache.js
+lazy val freestyleCacheJS = freestyleCache.js
 
 lazy val freestyleCacheRedis = (crossProject in file("freestyle-cache-redis")).
   dependsOn(freestyle, freestyleCache).
   settings(
     name := "freestyle-cache-redis",
-    resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases/" ,
+    resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases/",
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
-      "com.github.etaty" %% "rediscala" % "1.8.0",
-      "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-      "com.typesafe.akka" %% "akka-actor" % "2.4.17" % "test",
-      "com.orange.redis-embedded" % "embedded-redis" % "0.6" % "test"
+      %%("rediscala"),
+      %%("akka-actor") % "test",
+      %("embedded-redis") % "test"
     )
   ).
   jsSettings(sharedJsSettings: _*)
@@ -152,14 +107,13 @@ lazy val freestyleDoobie = (project in file("freestyle-doobie")).
   settings(name := "freestyle-doobie").
   settings(
     libraryDependencies ++= Seq(
-      "org.tpolecat"  %% "doobie-core-cats" % "0.4.1",
-      "org.tpolecat"  %% "doobie-h2-cats"   % "0.4.1" % "test",
-      "org.scalatest" %% "scalatest"        % "3.0.1" % "test"
+      %%("doobie-core-cats"),
+      %%("doobie-h2-cats") % "test"
     )
   )
 
 lazy val fixResources = taskKey[Unit](
-    "Fix application.conf presence on first clean build.")
+  "Fix application.conf presence on first clean build.")
 
 lazy val freestyleConfig = (crossProject in file("freestyle-config")).
   dependsOn(freestyle).
@@ -178,13 +132,12 @@ lazy val freestyleConfig = (crossProject in file("freestyle-config")).
   ).
   settings(
     libraryDependencies ++= Seq(
-      "eu.unicredit" %%% "shocon" % "0.1.7",
-      "org.scalatest" %%% "scalatest" % "3.0.1" % "test"
+      %%%("shocon")
     )
   )
 
 lazy val freestyleConfigJVM = freestyleConfig.jvm
-lazy val freestyleConfigJS  = freestyleConfig.js
+lazy val freestyleConfigJS = freestyleConfig.js
 
 
 lazy val freestyleFetch = (crossProject in file("freestyle-fetch")).
@@ -192,46 +145,42 @@ lazy val freestyleFetch = (crossProject in file("freestyle-fetch")).
   settings(name := "freestyle-fetch").
   settings(
     libraryDependencies ++= Seq(
-      "com.fortysevendeg" %%% "fetch" % "0.5.0",
-      "org.scalatest" %%% "scalatest" % "3.0.1" % "test",
-      "com.fortysevendeg" %%% "fetch-monix" % "0.5.0"
-     )
+      %%%("fetch"),
+      %%%("fetch-monix")
+    )
   ).
   jsSettings(sharedJsSettings: _*)
 
 lazy val freestyleFetchJVM = freestyleFetch.jvm
-lazy val freestyleFetchJS  = freestyleFetch.js
+lazy val freestyleFetchJS = freestyleFetch.js
 
 lazy val freestyleLogging = (crossProject in file("freestyle-logging")).
   dependsOn(freestyle).
   settings(name := "freestyle-logging").
-  settings(
-    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.1" % "test"
-  ).
   jvmSettings(
-    libraryDependencies += "io.verizon.journal" %% "core" % "3.0.18"
+    libraryDependencies += %%("journal-core")
   ).
   jsSettings(
-    libraryDependencies += "biz.enef" %%% "slogging" % "0.5.2"
+    libraryDependencies += %%%("slogging")
   ).
   jsSettings(sharedJsSettings: _*)
 
 lazy val freestyleLoggingJVM = freestyleLogging.jvm
-lazy val freestyleLoggingJS  = freestyleLogging.js
+lazy val freestyleLoggingJS = freestyleLogging.js
 
 lazy val freestyleFs2 = (crossProject in file("freestyle-fs2")).
   dependsOn(freestyle).
   settings(name := "freestyle-fs2").
   settings(
     libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % "3.0.1" % "test",
-      "co.fs2" %%% "fs2-core" % "0.9.2"
-     )
+
+      %%%("fs2-core")
+    )
   ).
   jsSettings(sharedJsSettings: _*)
 
 lazy val freestyleFs2JVM = freestyleFs2.jvm
-lazy val freestyleFs2JS  = freestyleFs2.js
+lazy val freestyleFs2JS = freestyleFs2.js
 
 lazy val freestylePlay = (project in file("freestyle-play")).
   dependsOn(freestyleJVM).
@@ -240,8 +189,7 @@ lazy val freestylePlay = (project in file("freestyle-play")).
     parallelExecution in Test := false,
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play" % "2.6.0-M2",
-      "com.typesafe.play" %% "play-test" % "2.6.0-M2" % "test",
-      "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+      "com.typesafe.play" %% "play-test" % "2.6.0-M2" % "test"
     )
   )
 
@@ -250,20 +198,20 @@ lazy val tests = (project in file("tests")).
   settings(noPublishSettings: _*).
   settings(
     libraryDependencies ++= Seq(
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "org.scalatest" %%% "scalatest" % "3.0.1" % "test",
-      "org.ensime" %% "pcplod" % "1.2.0" % "test"
+      %("scala-reflect", scalaVersion.value),
+      %%("pcplod") % "test"
     ),
     fork in Test := true,
     javaOptions in Test ++= {
-      val options = (scalacOptions in Test).value.distinct.mkString(",")
+      val excludedScalacOptions: List[String] = List("-Yliteral-types", "-Ypartial-unification")
+      val options = (scalacOptions in Test).value.distinct.filterNot(excludedScalacOptions.contains).mkString(",")
       val cp = (fullClasspath in Test).value.map(_.data).filter(_.exists()).distinct.mkString(",")
       Seq(
         s"""-Dpcplod.settings=$options""",
         s"""-Dpcplod.classpath=$cp"""
       )
     }
-   )
+  )
 
 lazy val docs = (project in file("docs")).
   dependsOn(freestyleJVM).
@@ -279,8 +227,8 @@ lazy val docs = (project in file("docs")).
   ).
   settings(
     libraryDependencies ++= Seq(
-      "co.fs2" %% "fs2-io"   % "0.9.2",
-      "co.fs2" %% "fs2-cats" % "0.3.0"
+      %%("fs2-io"),
+      %%("fs2-cats")
     )
   )
   .enablePlugins(MicrositesPlugin)
@@ -291,10 +239,9 @@ lazy val freestyleHttpHttp4s = (project in file("freestyle-http-http4s")).
   settings(
     resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % "3.0.1" % "test",
-      "org.http4s" %%% "http4s-core" % "0.16.0-cats-SNAPSHOT",
-      "org.http4s" %%% "http4s-dsl" % "0.16.0-cats-SNAPSHOT" % "test"
-     )
+      %%("http4s-core"),
+      %%("http4s-dsl") % "test"
+    )
   )
 
 lazy val freestyleHttpFinch = (project in file("freestyle-http-finch")).
@@ -302,7 +249,6 @@ lazy val freestyleHttpFinch = (project in file("freestyle-http-finch")).
   settings(name := "freestyle-http-finch").
   settings(
     libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % "3.0.1" % "test",
       "com.github.finagle" %% "finch-core" % "0.13.0"
      )
   )

--- a/freestyle-http-finch/src/main/scala/http/finch.scala
+++ b/freestyle-http-finch/src/main/scala/http/finch.scala
@@ -15,56 +15,60 @@ object finch extends FinchMapperFrees
 
 private[http] trait FinchMapperFrees extends FinchMapperFreeS1 {
 
-  implicit def mapperFromFreeSOutputHFunction[Op[_], A, B, F, FOB](f: F)(implicit
-    ftp: FnToProduct.Aux[F, (A) => FOB],
-    ev: FOB <:< FreeS[Op, Output[B]],
-    I: Op ~> Future
-  ): Mapper.Aux[A, B] = mapperFromFreeSOutputFunction(a => ev(ftp(f)(a)))
+  implicit def mapperFromFreeSOutputHFunction[Op[_], A, B, F, FOB](f: F)(
+      implicit ftp: FnToProduct.Aux[F, (A) => FOB],
+      ev: FOB <:< FreeS[Op, Output[B]],
+      I: Op ~> Future): Mapper.Aux[A, B] = mapperFromFreeSOutputFunction(a => ev(ftp(f)(a)))
 
-  implicit def mapperFromFreeSOutputHFunctionId[Op[_], A, B, F, FOB](f: F)(implicit
-    ftp: FnToProduct.Aux[F, (A) => FOB],
-    ev: FOB <:< FreeS[Op, Output[B]],
-    I: Op ~> Id
-  ): Mapper.Aux[A, B] = mapperFromFreeSOutputFunctionId(a => ev(ftp(f)(a)))
+  implicit def mapperFromFreeSOutputHFunctionId[Op[_], A, B, F, FOB](f: F)(
+      implicit ftp: FnToProduct.Aux[F, (A) => FOB],
+      ev: FOB <:< FreeS[Op, Output[B]],
+      I: Op ~> Id): Mapper.Aux[A, B] = mapperFromFreeSOutputFunctionId(a => ev(ftp(f)(a)))
 
-  implicit def mapperFromFreeSParOutputHFunction[Op[_], A, B, F, FPOB](f: F)(implicit
-    ftp: FnToProduct.Aux[F, (A) => FPOB],
-    ev: FPOB <:< FreeS.Par[Op, Output[B]],
-    I: Op ~> Future
-  ): Mapper.Aux[A, B] = mapperFromFreeSOutputFunction(a => ev(ftp(f)(a)).freeS)
+  implicit def mapperFromFreeSParOutputHFunction[Op[_], A, B, F, FPOB](f: F)(
+      implicit ftp: FnToProduct.Aux[F, (A) => FPOB],
+      ev: FPOB <:< FreeS.Par[Op, Output[B]],
+      I: Op ~> Future): Mapper.Aux[A, B] = mapperFromFreeSOutputFunction(a => ev(ftp(f)(a)).freeS)
 
-  implicit def mapperFromFreeSParOutputHFunctionId[Op[_], A, B, F, FPOB](f: F)(implicit
-    ftp: FnToProduct.Aux[F, (A) => FPOB],
-    ev: FPOB <:< FreeS.Par[Op, Output[B]],
-    I: Op ~> Id
-  ): Mapper.Aux[A, B] = mapperFromFreeSOutputFunctionId(a => ev(ftp(f)(a)).freeS)
+  implicit def mapperFromFreeSParOutputHFunctionId[Op[_], A, B, F, FPOB](f: F)(
+      implicit ftp: FnToProduct.Aux[F, (A) => FPOB],
+      ev: FPOB <:< FreeS.Par[Op, Output[B]],
+      I: Op ~> Id): Mapper.Aux[A, B] = mapperFromFreeSOutputFunctionId(a => ev(ftp(f)(a)).freeS)
 
-  implicit def mapperFromFreeSOutputValue[Op[_], A](fo: FreeS[Op, Output[A]])(implicit I: Op ~> Future): Mapper.Aux[HNil, A] =
+  implicit def mapperFromFreeSOutputValue[Op[_], A](fo: FreeS[Op, Output[A]])(
+      implicit I: Op ~> Future): Mapper.Aux[HNil, A] =
     Mapper.mapperFromFutureOutputValue(fo.exec[Future])
 
-  implicit def mapperFromFreeSOutputValueId[Op[_], A](fo: FreeS[Op, Output[A]])(implicit I: Op ~> Id): Mapper.Aux[HNil, A] =
+  implicit def mapperFromFreeSOutputValueId[Op[_], A](fo: FreeS[Op, Output[A]])(
+      implicit I: Op ~> Id): Mapper.Aux[HNil, A] =
     Mapper.mapperFromOutputValue(fo.exec[Id])
 
-  implicit def mapperFromFreeSParOutputValue[Op[_], A](fpo: FreeS.Par[Op, Output[A]])(implicit I: Op ~> Future): Mapper.Aux[HNil, A] =
+  implicit def mapperFromFreeSParOutputValue[Op[_], A](fpo: FreeS.Par[Op, Output[A]])(
+      implicit I: Op ~> Future): Mapper.Aux[HNil, A] =
     mapperFromFreeSOutputValue(fpo.freeS)
 
-  implicit def mapperFromFreeSParOutputValueId[Op[_], A](fpo: FreeS.Par[Op, Output[A]])(implicit I: Op ~> Id): Mapper.Aux[HNil, A] =
+  implicit def mapperFromFreeSParOutputValueId[Op[_], A](fpo: FreeS.Par[Op, Output[A]])(
+      implicit I: Op ~> Id): Mapper.Aux[HNil, A] =
     mapperFromFreeSOutputValueId(fpo.freeS)
 
 }
 
 private[http] trait FinchMapperFreeS1 {
 
-  implicit def mapperFromFreeSOutputFunction[Op[_], A, B](f: A => FreeS[Op, Output[B]])(implicit I: Op ~> Future): Mapper.Aux[A, B] =
+  implicit def mapperFromFreeSOutputFunction[Op[_], A, B](f: A => FreeS[Op, Output[B]])(
+      implicit I: Op ~> Future): Mapper.Aux[A, B] =
     Mapper.mapperFromFutureOutputFunction(a => f(a).exec[Future])
 
-  implicit def mapperFromFreeSOutputFunctionId[Op[_], A, B](f: A => FreeS[Op, Output[B]])(implicit I: Op ~> Id): Mapper.Aux[A, B] =
+  implicit def mapperFromFreeSOutputFunctionId[Op[_], A, B](f: A => FreeS[Op, Output[B]])(
+      implicit I: Op ~> Id): Mapper.Aux[A, B] =
     Mapper.mapperFromOutputFunction(a => f(a).exec[Id])
 
-  implicit def mapperFromFreeSParOutputFunction[Op[_], A, B](f: A => FreeS.Par[Op, Output[B]])(implicit I: Op ~> Future): Mapper.Aux[A, B] =
+  implicit def mapperFromFreeSParOutputFunction[Op[_], A, B](f: A => FreeS.Par[Op, Output[B]])(
+      implicit I: Op ~> Future): Mapper.Aux[A, B] =
     mapperFromFreeSOutputFunction(f.andThen(_.freeS))
 
-  implicit def mapperFromFreeSParOutputFunctionId[Op[_], A, B](f: A => FreeS.Par[Op, Output[B]])(implicit I: Op ~> Id): Mapper.Aux[A, B] =
+  implicit def mapperFromFreeSParOutputFunctionId[Op[_], A, B](f: A => FreeS.Par[Op, Output[B]])(
+      implicit I: Op ~> Id): Mapper.Aux[A, B] =
     mapperFromFreeSOutputFunctionId(f.andThen(_.freeS))
 
 }

--- a/freestyle-http-finch/src/test/scala/http/FinchTests.scala
+++ b/freestyle-http-finch/src/test/scala/http/FinchTests.scala
@@ -27,8 +27,12 @@ class FinchTests extends AsyncWordSpec with Matchers {
       import futureHandlers._
 
       val endpoint0 = get(/) { sumOk(1, 2) }
-      val endpoint1 = post(int) { i: Int => sumOk(1, i) }
-      val endpoint2 = post(int :: int) { (a: Int, b: Int) => sumOk(a, b) }
+      val endpoint1 = post(int) { i: Int =>
+        sumOk(1, i)
+      }
+      val endpoint2 = post(int :: int) { (a: Int, b: Int) =>
+        sumOk(a, b)
+      }
 
       endpoint0(Input.get("/")).awaitValueUnsafe() shouldBe Some(3)
       endpoint1(Input.post("/2")).awaitValueUnsafe() shouldBe Some(3)
@@ -39,8 +43,12 @@ class FinchTests extends AsyncWordSpec with Matchers {
       import futureHandlers._
 
       val endpoint0 = get(/) { sumParOk(1, 2) }
-      val endpoint1 = post(int) { i: Int => sumParOk(1, i) }
-      val endpoint2 = post(int :: int) { (a: Int, b: Int) => sumParOk(a, b) }
+      val endpoint1 = post(int) { i: Int =>
+        sumParOk(1, i)
+      }
+      val endpoint2 = post(int :: int) { (a: Int, b: Int) =>
+        sumParOk(a, b)
+      }
 
       endpoint0(Input.get("/")).awaitValueUnsafe() shouldBe Some(3)
       endpoint1(Input.post("/2")).awaitValueUnsafe() shouldBe Some(3)
@@ -51,8 +59,12 @@ class FinchTests extends AsyncWordSpec with Matchers {
       import idHandlers._
 
       val endpoint0 = get(/) { sumOk(1, 2) }
-      val endpoint1 = post(int) { i: Int => sumOk(1, i) }
-      val endpoint2 = post(int :: int) { (a: Int, b: Int) => sumOk(a, b) }
+      val endpoint1 = post(int) { i: Int =>
+        sumOk(1, i)
+      }
+      val endpoint2 = post(int :: int) { (a: Int, b: Int) =>
+        sumOk(a, b)
+      }
 
       endpoint0(Input.get("/")).awaitValueUnsafe() shouldBe Some(3)
       endpoint1(Input.post("/2")).awaitValueUnsafe() shouldBe Some(3)
@@ -63,8 +75,12 @@ class FinchTests extends AsyncWordSpec with Matchers {
       import idHandlers._
 
       val endpoint0 = get(/) { sumParOk(1, 2) }
-      val endpoint1 = post(int) { i: Int => sumParOk(1, i) }
-      val endpoint2 = post(int :: int) { (a: Int, b: Int) => sumParOk(a, b) }
+      val endpoint1 = post(int) { i: Int =>
+        sumParOk(1, i)
+      }
+      val endpoint2 = post(int :: int) { (a: Int, b: Int) =>
+        sumParOk(a, b)
+      }
 
       endpoint0(Input.get("/")).awaitValueUnsafe() shouldBe Some(3)
       endpoint1(Input.post("/2")).awaitValueUnsafe() shouldBe Some(3)
@@ -75,7 +91,8 @@ class FinchTests extends AsyncWordSpec with Matchers {
 }
 
 object algebra {
-  @free trait Calc[F[_]] {
+  @free
+  trait Calc[F[_]] {
     def sum(a: Int, b: Int): FreeS.Par[F, Int]
   }
 }

--- a/freestyle-http-http4s/src/main/scala/http/http4s.scala
+++ b/freestyle-http-http4s/src/main/scala/http/http4s.scala
@@ -9,7 +9,9 @@ import freestyle.implicits._
 object http4s {
 
   implicit def freeSEntityEncoder[F[_], G[_], A](
-      implicit NT: F ~> G, G: Monad[G], EE: EntityEncoder[G[A]]): EntityEncoder[FreeS[F, A]] =
+      implicit NT: F ~> G,
+      G: Monad[G],
+      EE: EntityEncoder[G[A]]): EntityEncoder[FreeS[F, A]] =
     EE.contramap((f: FreeS[F, A]) => f.exec[G])
 
 }

--- a/freestyle-http-http4s/src/test/scala/http/Http4sTest.scala
+++ b/freestyle-http-http4s/src/test/scala/http/Http4sTest.scala
@@ -35,7 +35,7 @@ class Http4sTests extends AsyncWordSpec with Matchers {
         case GET -> Root / "users" =>
           Ok(getUsers[App.Op].map(_.mkString("\n")))
       }
-  
+
       val reqUser1 = Request(Method.GET, uri("/user/1"))
 
       (for {
@@ -43,7 +43,7 @@ class Http4sTests extends AsyncWordSpec with Matchers {
         body <- EntityDecoder.decodeString(resp)
       } yield {
         resp.status shouldBe (Status.Ok)
-        body should startWith ("User")
+        body should startWith("User")
       }).unsafeRunAsyncFuture
 
       val reqUsers = Request(Method.GET, uri("/users"))
@@ -53,7 +53,7 @@ class Http4sTests extends AsyncWordSpec with Matchers {
         body <- EntityDecoder.decodeString(resp)
       } yield {
         resp.status shouldBe (Status.Ok)
-        all (body.split("\n")) should startWith ("User")
+        all(body.split("\n")) should startWith("User")
       }).unsafeRunAsyncFuture
     }
   }
@@ -62,12 +62,14 @@ class Http4sTests extends AsyncWordSpec with Matchers {
 object algebras {
   case class User(name: String)
 
-  @free trait UserRepository[F[_]] {
+  @free
+  trait UserRepository[F[_]] {
     def get(id: Long): FreeS.Par[F, User]
     def list: FreeS.Par[F, List[User]]
   }
 
-  @module trait App[F[_]] {
+  @module
+  trait App[F[_]] {
     val userRepo: UserRepository[F]
   }
 }
@@ -80,7 +82,7 @@ object handlers {
     2L -> User("bar")
   )
 
-  implicit val userRepoHandler: UserRepository.Handler[Task] = 
+  implicit val userRepoHandler: UserRepository.Handler[Task] =
     new UserRepository.Handler[Task] {
       def get(id: Long): Task[User] =
         Task.now(users.get(id).getOrElse(User("default")))

--- a/freestyle-play/src/main/scala/play.scala
+++ b/freestyle-play/src/main/scala/play.scala
@@ -9,12 +9,10 @@ import scala.concurrent._
 import _root_.play.api.mvc._
 import _root_.play.api.http._
 
-
 object play {
   object FreeSAction {
     def apply[F[_]](prog: FreeS[F, Result])(
-      implicit
-        MF: Monad[Future],
+        implicit MF: Monad[Future],
         I: ParInterpreter[F, Future],
         EC: ExecutionContext
     ): Action[AnyContent] = {
@@ -24,8 +22,7 @@ object play {
     }
 
     def apply[A, F[_]](fn: Request[AnyContent] => FreeS[F, Result])(
-      implicit
-        MF: Monad[Future],
+        implicit MF: Monad[Future],
         I: ParInterpreter[F, Future],
         EC: ExecutionContext
     ): Action[AnyContent] = {

--- a/freestyle-play/src/test/scala/PlayTests.scala
+++ b/freestyle-play/src/test/scala/PlayTests.scala
@@ -24,15 +24,14 @@ class PlayTests extends AsyncWordSpec with Matchers {
 
   // play
 
-  implicit def unitWr(implicit C: Codec): Writeable[Unit] = {
+  implicit def unitWr(implicit C: Codec): Writeable[Unit] =
     Writeable(data => C.encode(data.toString))
-  }
 
   implicit val unitCT: ContentTypeOf[Unit] = new ContentTypeOf(Option("text/plain"))
 
   // akka
 
-  implicit val actorSys: ActorSystem = ActorSystem("test")
+  implicit val actorSys: ActorSystem      = ActorSystem("test")
   implicit val materializer: Materializer = ActorMaterializer()
 
   "Play integration" should {
@@ -41,9 +40,10 @@ class PlayTests extends AsyncWordSpec with Matchers {
     import algebras._
     import handlers._
 
-    def program[F[_] : Noop]: FreeS[F, Result] = for {
-      x <- Noop[F].noop
-    } yield Results.Ok(x)
+    def program[F[_]: Noop]: FreeS[F, Result] =
+      for {
+        x <- Noop[F].noop
+      } yield Results.Ok(x)
 
     "FreeSAction creates an action from a program" in {
       FreeSAction { program[Noop.Op] }.isInstanceOf[Action[Result]] shouldBe true
@@ -58,8 +58,8 @@ class PlayTests extends AsyncWordSpec with Matchers {
     "The resulting action writes the result in the response" in {
       import Helpers._
 
-      val action: EssentialAction = FreeSAction { program[Noop.Op] }
-      val request = FakeRequest()
+      val action: EssentialAction  = FreeSAction { program[Noop.Op] }
+      val request                  = FakeRequest()
       val response: Future[Result] = Helpers.call(action, request)
 
       status(response) shouldBe 200
@@ -79,8 +79,7 @@ object handlers {
   import algebras._
 
   implicit def noopHandler[M[_]](
-    implicit
-      MM: Monad[M]
+      implicit MM: Monad[M]
   ): Noop.Handler[M] = new Noop.Handler[M] {
     def noop: M[Unit] = MM.pure(())
   }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -40,7 +40,7 @@ object ProjectPlugin extends AutoPlugin {
   override def projectSettings = Seq(
     description := "A Cohesive & Pragmatic Framework of FP centric Scala libraries",
     onLoad := (Command.process("project freestyle", _: State)) compose (onLoad in Global).value,
-    scalacOptions ++= scalacAdvancedOptions
+    scalacOptions ++= scalacAdvancedOptions,
     libraryDependencies += %%("scalatest") % "test"
   ) ++ scalaMacroDependencies
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,76 +1,46 @@
-import sbt._
 import sbt.Keys._
-
-import catext.Dependencies._
-import catext.CatExtPlugin.autoImport._
-import org.scalafmt.sbt.ScalaFmtPlugin.autoImport._
+import sbt._
+import microsites.MicrositeKeys._
+import microsites.util.BuildHelper.buildWithoutSuffix
+import sbtorgpolicies._
+import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
+import com.typesafe.sbt.site.jekyll.JekyllPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
-  override def trigger = allRequirements
+  override def trigger: PluginTrigger = allRequirements
 
-  val dev  = Seq(Dev("47 Degrees (twitter: @47deg)", "47 Degrees"))
-  val gh   = GitHubSettings("com.fortysevendeg", "freestyle", "47 Degrees", apache)
-  val vAll = Versions(versions, libraries, scalacPlugins)
+  object autoImport {
 
-  override def globalSettings = Seq(
-    onLoad := (Command.process("project freestyle", _: State)) compose (onLoad in Global).value
-  )
-
-  override def buildSettings = Seq(
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
-    scalaVersion := crossScalaVersions.value.last,
-    scalaOrganization := "org.typelevel",
-    organization  := gh.org,
-    organizationName  := gh.publishOrg
-  )
+    lazy val micrositeSettings = Seq(
+      micrositeName := "Freestyle",
+      micrositeDescription := "A Cohesive & Pragmatic Framework of FP centric Scala libraries",
+      micrositeDocumentationUrl := "/docs/",
+      micrositeGithubOwner := "47deg",
+      micrositeGithubRepo := "freestyle",
+      micrositeHighlightTheme := "dracula",
+      micrositeExternalLayoutsDirectory := (resourceDirectory in Compile).value / "microsite" / "layouts",
+      micrositeExternalIncludesDirectory := (resourceDirectory in Compile).value / "microsite" / "includes",
+      includeFilter in Jekyll := ("*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "CNAME"),
+      micrositePalette := Map(
+        "brand-primary"     -> "#01C2C2",
+        "brand-secondary"   -> "#142236",
+        "brand-tertiary"    -> "#202D40",
+        "gray-dark"         -> "#383D44",
+        "gray"              -> "#646D7B",
+        "gray-light"        -> "#E6E7EC",
+        "gray-lighter"      -> "#F4F5F9",
+        "white-color"       -> "#E6E7EC"),
+      micrositeKazariCodeMirrorTheme := "dracula",
+      micrositeKazariDependencies := Seq(microsites.KazariDependency("com.fortysevendeg", "freestyle", buildWithoutSuffix(scalaVersion.value), version.value),
+        microsites.KazariDependency("org.scalamacros", "paradise", scalaVersion.value, "2.1.0")),
+      micrositeKazariResolvers := Seq("https://oss.sonatype.org/content/repositories/snapshots", "https://oss.sonatype.org/content/repositories/releases")
+    )
+  }
 
   override def projectSettings = Seq(
-    homepage := Option(url("http://www.47deg.com")),
-    organizationHomepage := Some(new URL("http://47deg.com")),
-    startYear := Some(2016),
     description := "A Cohesive & Pragmatic Framework of FP centric Scala libraries",
-    scalacOptions in ThisBuild ++= Seq(
-      "-Ypartial-unification", // enable fix for SI-2712
-      "-Yliteral-types",       // enable SIP-23 implementation
-      "-Xplugin-require:macroparadise",
-      "-deprecation",
-      "-encoding", "UTF-8",
-      "-feature",
-      "-language:existentials",
-      "-language:higherKinds",
-      "-language:implicitConversions",
-      "-language:reflectiveCalls",
-      "-language:experimental.macros",
-      "-unchecked",
-      //"-Xfatal-warnings",
-      //"-Xlint",
-      "-Yno-adapted-args",
-      "-Ywarn-dead-code",
-      "-Ywarn-numeric-widen",
-      "-Ywarn-value-discard",
-      "-Xfuture"
-        //"-Xlog-implicits"
-        //"-Xprint:typer"
-        //"-Ymacro-debug-lite"
-    ),
-    dependencyOverrides ++= Set(
-      // scala-lang is still used during transitive ivy resolution (and eventually thrown out...)
-      "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-      "org.scala-lang" % "scala-library" % scalaVersion.value,
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "org.scala-lang" % "scalap" % scalaVersion.value,
-      scalaOrganization.value % "scala-compiler" % scalaVersion.value,
-      scalaOrganization.value % "scala-library" % scalaVersion.value,
-      scalaOrganization.value % "scala-reflect" % scalaVersion.value,
-      scalaOrganization.value % "scalap" % scalaVersion.value
-    ),
-    scalafmtConfig in ThisBuild := Some(file(".scalafmt.conf"))
-  ) ++
-  reformatOnCompileSettings ++
-  sharedCommonSettings ++
-  sharedReleaseProcess ++
-  credentialSettings ++
-  sharedPublishSettings(gh, dev) ++
-  addCompilerPlugins(vAll, "paradise", "kind-projector")
-
+    onLoad := (Command.process("project freestyle", _: State)) compose (onLoad in Global).value,
+    scalacOptions ++= scalacAdvancedOptions
+    libraryDependencies += %%("scalatest") % "test"
+  ) ++ scalaMacroDependencies
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 resolvers += ("snapshots" at
   "https://oss.sonatype.org/content/repositories/snapshots")
-resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.2.1")
-
-addSbtPlugin("com.fortysevendeg" % "sbt-microsites" % "0.5.0-SNAPSHOT")
+addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.2.1")
+addSbtPlugin("com.fortysevendeg" % "sbt-microsites"   % "0.5.0-SNAPSHOT")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,12 +2,6 @@ resolvers += ("snapshots" at
   "https://oss.sonatype.org/content/repositories/snapshots")
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("com.fortysevendeg" % "sbt-catalysts-extras" % "0.1.3")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.2.1")
 
 addSbtPlugin("com.fortysevendeg" % "sbt-microsites" % "0.5.0-SNAPSHOT")
-
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.4.10")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
-
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")

--- a/tests/src/test/scala/tests.scala
+++ b/tests/src/test/scala/tests.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 
 class tests extends WordSpec with Matchers {
 
-  "Applicative Parallel Support" should {
+  "Presentation Compiler Support" should {
 
     "generate code that works in the presentation compiler" in {
       import org.ensime.pcplod._


### PR DESCRIPTION
This PR is a join-effort from @fedefernandez  and I . It integrates the first `sbt-org-policies` milestone, version `0.2.1`.

As a default setting that the plugin is providing, moves the artifacts from `com.fortysevendeg` to `com.47deg`.

Please, @raulraja could you review? Thanks.