### PR TITLE
FS-177 Make the `@module` and `@free` macros hygienic

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,14 +1,12 @@
-# Cats jvmopts
-# see https://weblogs.java.net/blog/kcpeppe/archive/2013/12/11/case-study-jvm-hotspot-flags
+# Cats jvmopts see https://weblogs.java.net/blog/kcpeppe/archive/2013/12/11/case-study-jvm-hotspot-flags
 -Dfile.encoding=UTF8
--Xms1G
-#-Xmx6G
+-Xms2G
 -Xmx2G
--XX:MaxPermSize=512M
--XX:ReservedCodeCacheSize=250M
+-XX:MaxMetaspaceSize=512M
+-XX:ReservedCodeCacheSize=128M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit
 # effectively adds GC to Perm space
+-XX:+UseConcMarkSweepGC
 -XX:+CMSClassUnloadingEnabled
 # must be enabled for CMSClassUnloadingEnabled to work
--XX:+UseConcMarkSweepGC

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
 - gem install sass
 - gem install jekyll -v 3.2.1
 script:
+- sbt ++$TRAVIS_SCALA_VERSION update
 - sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport
 - sbt ++$TRAVIS_SCALA_VERSION "docs/tut"
 

--- a/freestyle/shared/src/main/scala/freestyle/annotations.scala
+++ b/freestyle/shared/src/main/scala/freestyle/annotations.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle
+
+import scala.annotation.{compileTimeOnly, StaticAnnotation}
+import scala.language.experimental.macros
+
+@compileTimeOnly("enable macro paradise to expand @free macro annotations")
+class free extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro freeImpl.free
+}
+
+@compileTimeOnly("enable macro paradise to expand @module macro annotations")
+class module extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro moduleImpl.impl
+}
+

--- a/freestyle/shared/src/test/scala/freestyle/Utils.scala
+++ b/freestyle/shared/src/test/scala/freestyle/Utils.scala
@@ -27,15 +27,15 @@ object algebras {
   }
 
   @free
-  trait SCtors2[F[_]] {
-    def i(a: Int): FreeS[F, Int]
-    def j(a: Int): FreeS[F, Int]
+  trait SCtors2[G[_]] {
+    def i(a: Int): FreeS[G, Int]
+    def j(a: Int): FreeS[G, Int]
   }
 
   @free
-  trait SCtors3[F[_]] {
-    def o(a: Int): FreeS[F, Int]
-    def p(a: Int): FreeS[F, Int]
+  trait SCtors3[H[_]] {
+    def o(a: Int): FreeS[H, Int]
+    def p(a: Int): FreeS[H, Int]
   }
 
   @free
@@ -74,15 +74,15 @@ object modules {
   }
 
   @module
-  trait M2[F[_]] {
-    val sctors3: SCtors3[F]
-    val sctors4: SCtors4[F]
+  trait M2[G[_]] {
+    val sctors3: SCtors3[G]
+    val sctors4: SCtors4[G]
   }
 
   @module
-  trait O1[F[_]] {
-    val m1: M1[F]
-    val m2: M2[F]
+  trait O1[H[_]] {
+    val m1: M1[H]
+    val m2: M2[H]
   }
 
   @module

--- a/freestyle/shared/src/test/scala/freestyle/free.scala
+++ b/freestyle/shared/src/test/scala/freestyle/free.scala
@@ -27,6 +27,14 @@ class freeTests extends WordSpec with Matchers {
     import algebras._
     import freestyle.implicits._
 
+    "be rejected if applied to a non-abstract class" in {
+      """@free class Foo[F[_]] { val x: Int}""" shouldNot compile
+    }
+
+    "be rejected if applied to a trait with companion object" in {
+      """ @free trait  Foo[F[_]] {def f: FreeS[F, Int]} ; object Foo """ shouldNot compile
+    }
+
     "create a companion with a `Op` type alias" in {
       type Op[A] = SCtors1.Op[A]
     }

--- a/freestyle/shared/src/test/scala/freestyle/module.scala
+++ b/freestyle/shared/src/test/scala/freestyle/module.scala
@@ -29,6 +29,15 @@ class moduleTests extends WordSpec with Matchers {
     import freestyle.implicits._
     import interps._
 
+    "be rejected if applied to a non-abstract class" in {
+      """@module class Foo[F[_]] { val x: Int}""" shouldNot compile
+    }
+
+    "be rejected if applied to a trait with companion object" in {
+      """@module trait  Foo[F[_]] { val x: Int} ; object Foo """ shouldNot compile
+    }
+
+
     "[simple] create a companion with a `T` type alias" in {
       type T[A] = M1.Op[A]
     }


### PR DESCRIPTION
This PR fulfills issue #177. We 

Intuitively, [macro hygiene](http://docs.scala-lang.org/overviews/quasiquotes/hygiene) refers to ensuring that the names used in the generated code for values, types, or imports, do not collide with those of the context in which the macro is used. In our case, that means: 
- The names of the type parameters used in the definitions of the `Handler` or the `To` should not be     confused with those of the context; but more important, should not shadow (accidentally _capture_) the type parameters given by the user for the `trait`. To achieve this, we use `freshTypename`. 
- The names for the auxiliary members inside the generated companion objects should not collide with those members defined by the user in the trait.  We use `freshTermName` for this. 
- The imports in the generated code should be those referred to in the macro implementation code, and not in the context of the call. We solve this by qualifying imports with `_root_`.   

Along the way, we found a bug in the `@macro` implementation: the type name `F[_]` was hard-coded into the macro, so it was not possible to define a `@macro`-annotated trait whose parameter was, say, `G[_]`. We have repaired that. 