### PR TITLE
FS-93 - 1 Auto-generate `F[_]` parameter from 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Applications built with Freestyle can be interpreted to any runtime semantics su
 ```scala
 import freestyle._
 
-@free trait Database[F[_]] {
-  def get(id: UserId): FreeS[F, User]
+@free trait Database {
+  def get(id: UserId): OpSeq[User]
 }
 
-@free trait Cache[F[_]] {
-  def get(id: UserId): FreeS[F, User]
+@free trait Cache {
+  def get(id: UserId): OpSeq[User]
 }
 
 @module trait Persistence[F[_]] {

--- a/async/async/shared/src/main/scala/async.scala
+++ b/async/async/shared/src/main/scala/async.scala
@@ -29,8 +29,8 @@ object async {
   }
 
   /** Async computation algebra. **/
-  @free sealed trait AsyncM[F[_]] {
-    def async[A](fa: Proc[A]): FreeS.Par[F, A]
+  @free sealed trait AsyncM {
+    def async[A](fa: Proc[A]): OpPar[A]
   }
 
   object implicits {

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val tests = (project in file("tests"))
   .dependsOn(freestyleJVM)
   .settings(noPublishSettings: _*)
   .settings(
-    libraryDependencies ++= Seq(
+    libraryDependencies ++= commonDeps ++ Seq(
       %("scala-reflect", scalaVersion.value),
       %%("pcplod") % "test"
     ),

--- a/docs/src/main/resources/microsite/css/custom.css
+++ b/docs/src/main/resources/microsite/css/custom.css
@@ -149,9 +149,9 @@ h1, h2, h3, h4, h5, h6, #site-header {
     font-size: 32px;
 }
 ree trait UserRepository[F[_]] {
-  def get(id: Long): FreeS[F, User]
-  def save(user: User): FreeS[F, User]
-  def list: FreeS[F, List[User]]
+  def get(id: Long): OpSeq[User]
+  def save(user: User): OpSeq[User]
+  def list: OpSeq[List[User]]
 }
 #site-main p {
     margin-bottom: 30px;

--- a/docs/src/main/tut/README.md
+++ b/docs/src/main/tut/README.md
@@ -15,12 +15,12 @@ Applications built with Freestyle can be interpreted to any runtime semantics su
 ```scala
 import freestyle._
 
-@free trait Database[F[_]] {
-  def get(id: UserId): FreeS[F, User]
+@free trait Database {
+  def get(id: UserId): OpSeq[User]
 }
 
-@free trait Cache[F[_]] {
-  def get(id: UserId): FreeS[F, User]
+@free trait Cache {
+  def get(id: UserId): OpSeq[User]
 }
 
 @module trait Persistence[F[_]] {

--- a/docs/src/main/tut/docs/README.md
+++ b/docs/src/main/tut/docs/README.md
@@ -44,14 +44,14 @@ import freestyle.implicits._
 
 object algebras {
 
-    @free trait Validation[F[_]] {
-      def minSize(s: String, n: Int): FreeS.Par[F, Boolean]
-      def hasNumber(s: String): FreeS.Par[F, Boolean]
+    @free trait Validation {
+      def minSize(s: String, n: Int): OpPar[Boolean]
+      def hasNumber(s: String): OpPar[Boolean]
     }
 
-    @free trait Interaction[F[_]] {
-      def tell(msg: String): FreeS[F, Unit]
-      def ask(prompt: String): FreeS[F, String]
+    @free trait Interaction {
+      def tell(msg: String): OpSeq[Unit]
+      def ask(prompt: String): OpSeq[String]
     }
 }
 ```

--- a/docs/src/main/tut/docs/core/algebras/README.md
+++ b/docs/src/main/tut/docs/core/algebras/README.md
@@ -17,24 +17,24 @@ import freestyle._
 
 case class User(id: Long, name: String)
 
-@free trait UserRepository[F[_]] {
-  def get(id: Long): FreeS[F, User]
-  def save(user: User): FreeS[F, User]
-  def list: FreeS[F, List[User]]
+@free trait UserRepository {
+  def get(id: Long): OpSeq[User]
+  def save(user: User): OpSeq[User]
+  def list: OpSeq[List[User]]
 }
 ```
 
 This is similar to the simplified manual encoding below:
 
 ```tut:book
-import freestyle.FreeS
+import freestyle.{FreeS, EffectLike}
 
 case class User(id: Long, name: String)
 
-trait UserRepository[F[_]] {
-  def get(id: Long): FreeS[F, User]
-  def save(user: User): FreeS[F, User]
-  def getAll(filter: String): FreeS[F, List[User]]
+trait UserRepository[F[_]] extends freestyle.EffectLike[F] {
+  def get(id: Long): OpSeq[User]
+  def save(user: User): OpSeq[User]
+  def getAll(filter: String): OpSeq[List[User]]
 }
 
 object UserRepository {
@@ -119,14 +119,14 @@ You may use this to manually build `Coproduct` types which will serve in the par
 ```tut:book
 import cats.data.Coproduct
 
-@free trait Service1[F[_]]{
-  def x(n: Int): FreeS[F, Int]
+@free trait Service1{
+  def x(n: Int): OpSeq[Int]
 }
-@free trait Service2[F[_]]{
-  def y(n: Int): FreeS[F, Int]
+@free trait Service2{
+  def y(n: Int): OpSeq[Int]
 }
-@free trait Service3[F[_]]{
-  def z(n: Int): FreeS[F, Int]
+@free trait Service3{
+  def z(n: Int): OpSeq[Int]
 }
 type C1[A] = Coproduct[Service1.Op, Service2.Op, A]
 type Module[A] = Coproduct[Service3.Op, C1, A]

--- a/docs/src/main/tut/docs/core/interpreters/README.md
+++ b/docs/src/main/tut/docs/core/interpreters/README.md
@@ -23,14 +23,14 @@ Consider the following algebra adapted to Freestyle from the [Typelevel Cats Fre
 import freestyle._
 import cats.implicits._
 
-@free trait KVStore[F[_]] {
-  def put[A](key: String, value: A): FreeS[F, Unit]
-  def get[A](key: String): FreeS[F, Option[A]]
-  def delete(key: String): FreeS[F, Unit]
-  def update[A](key: String, f: A => A): FreeS[F, Unit] = 
+@free trait KVStore {
+  def put[A](key: String, value: A): OpSeq[Unit]
+  def get[A](key: String): OpSeq[Option[A]]
+  def delete(key: String): OpSeq[Unit]
+  def update[A](key: String, f: A => A): OpSeq[Unit] =
     get[A](key) flatMap {
       case Some(a) => put[A](key, f(a))
-      case None => ().pure[FreeS[F, ?]]
+      case None => ().pure[OpSeq]
     }
 }
 ```
@@ -84,9 +84,9 @@ by the evidence of it's algebras' interpreters.
 To illustrate interpreter composition, let's define a new algebra `Log` which we will compose with our `KVStore` operations:
 
 ```tut:book
-@free trait Log[F[_]] {
-  def info(msg: String): FreeS[F, Unit]
-  def warn(msg: String): FreeS[F, Unit]
+@free trait Log {
+  def info(msg: String): OpSeq[Unit]
+  def warn(msg: String): OpSeq[Unit]
 }
 ```
 

--- a/docs/src/main/tut/docs/core/modules/README.md
+++ b/docs/src/main/tut/docs/core/modules/README.md
@@ -16,17 +16,17 @@ Let’s first define a few algebras to illustrate how Modules work. We will star
 import freestyle._
 
 object algebras {
-    @free trait Database[F[_]] {
-      def get(id: Int): FreeS[F, Int]
+    @free trait Database {
+      def get(id: Int): OpSeq[Int]
     }
-    @free trait Cache[F[_]] {
-      def get(id: Int): FreeS[F, Option[Int]]
+    @free trait Cache {
+      def get(id: Int): OpSeq[Option[Int]]
     }
-    @free trait Presenter[F[_]] {
-      def show(id: Int): FreeS[F, Int]
+    @free trait Presenter {
+      def show(id: Int): OpSeq[Int]
     }
-    @free trait IdValidation[F[_]] {
-      def validate(id: Option[Int]): FreeS[F, Int]
+    @free trait IdValidation {
+      def validate(id: Option[Int]): OpSeq[Int]
     }
 }
 ```

--- a/docs/src/main/tut/docs/core/parallelism/README.md
+++ b/docs/src/main/tut/docs/core/parallelism/README.md
@@ -29,9 +29,9 @@ Independent operations that can potentially be executed in parallel can be place
 ```tut:book
 import freestyle._
 
-@free trait Validation[F[_]] {
-  def minSize(n: Int): FreeS.Par[F, Boolean]
-  def hasNumber: FreeS.Par[F, Boolean]
+@free trait Validation {
+  def minSize(n: Int): OpPar[Boolean]
+  def hasNumber: OpPar[Boolean]
 }
 ```
 
@@ -82,10 +82,10 @@ val validator = parValidation.exec[ParValidator]
 Sequential and parallel actions can be easily intermixed in `@free` algebras:
 
 ```tut:book
-@free trait MixedFreeS[F[_]] {
-  def x: FreeS.Par[F, Int]
-  def y: FreeS.Par[F, Int]
-  def z: FreeS[F, Int]
+@free trait MixedFreeS {
+  def x: OpPar[Int]
+  def y: OpPar[Int]
+  def z: OpSeq[Int]
 }
 ```
 

--- a/docs/src/main/tut/docs/effects/cache/README.md
+++ b/docs/src/main/tut/docs/effects/cache/README.md
@@ -12,13 +12,13 @@ This algebra is parametrized on the types `Key`, and `Val`, for keys and values 
 
 ```Scala
 class KeyValueProvider[Key, Val] {
-  @free sealed trait CacheM[F[_]] {
-    def get(key: Key):              FreeS.Par[F, Option[Val]]
-    def put(key: Key, newVal: Val): FreeS.Par[F, Unit]
-    def del(key: Key):              FreeS.Par[F, Unit]
-    def has(key: Key):              FreeS.Par[F, Boolean]
-    def keys:                       FreeS.Par[F, List[Key]]
-    def clear:                      FreeS.Par[F, Unit]
+  @free sealed trait CacheM {
+    def get(key: Key):              OpPar[Option[Val]]
+    def put(key: Key, newVal: Val): OpPar[Unit]
+    def del(key: Key):              OpPar[Unit]
+    def has(key: Key):              OpPar[Boolean]
+    def keys:                       OpPar[List[Key]]
+    def clear:                      OpPar[Unit]
   }
 }
 ```

--- a/docs/src/main/tut/docs/http/finch/README.md
+++ b/docs/src/main/tut/docs/http/finch/README.md
@@ -30,8 +30,8 @@ import freestyle.implicits._
 In this example, we will create a Finch `Endpoint` which will be able to calculate the greatest common divisor (GCD) of two natural numbers:
 
 ```tut:book
-@free trait Calc[F[_]] {
-  def gcd(a: Int, b: Int): FreeS[F, Int]
+@free trait Calc {
+  def gcd(a: Int, b: Int): OpSeq[Int]
 }
 ```
 

--- a/docs/src/main/tut/docs/http/http4s/README.md
+++ b/docs/src/main/tut/docs/http/http4s/README.md
@@ -40,9 +40,9 @@ In this example, we will create an algebra to calculate the VAT of a product's p
 ```tut:book
 import scala.math.BigDecimal
 
-@free trait CalcVAT[F[_]] {
-  def vat(price: BigDecimal): FreeS[F, BigDecimal]
-  def withVat(price: BigDecimal): FreeS[F, BigDecimal] =
+@free trait CalcVAT {
+  def vat(price: BigDecimal): OpSeq[BigDecimal]
+  def withVat(price: BigDecimal): OpSeq[BigDecimal] =
     vat(price).map(_ + price)
 }
 ```

--- a/docs/src/main/tut/docs/integrations/akkahttp/README.md
+++ b/docs/src/main/tut/docs/integrations/akkahttp/README.md
@@ -79,8 +79,8 @@ import freestyle.implicits._
 case class User(name: String)
 
 @free
-trait UserApp[F[_]] {
-  def get(id: Int): FreeS[F, User]
+trait UserApp {
+  def get(id: Int): OpSeq[User]
 }
 
 val app = UserApp.to[UserApp.Op]

--- a/docs/src/main/tut/docs/integrations/cats/README.md
+++ b/docs/src/main/tut/docs/integrations/cats/README.md
@@ -34,9 +34,9 @@ To see how we can use `FreeS` and `FreeS.Par` in combination with existing Cats 
 ```tut:book
 import freestyle._
 
-@free trait Calc[F[_]] {
-  def sum(a: Int, b: Int): FreeS.Par[F, Int]
-  def product(a: Int, b: Int): FreeS.Par[F, Int]
+@free trait Calc {
+  def sum(a: Int, b: Int): OpPar[Int]
+  def product(a: Int, b: Int): OpPar[Int]
 }
 ```
 

--- a/docs/src/main/tut/docs/integrations/doobie/README.md
+++ b/docs/src/main/tut/docs/integrations/doobie/README.md
@@ -72,8 +72,8 @@ Only using `DoobieM` is not exactly useful however, as it just adds an extra lev
 
 
 ```tut:book
-@free trait Calc[F[_]] {
-  def subtract(a: Int, b: Int): FreeS[F, Int]
+@free trait Calc {
+  def subtract(a: Int, b: Int): OpSeq[Int]
 }
 
 @module trait Example[F[_]] {

--- a/docs/src/main/tut/docs/integrations/fetch/README.md
+++ b/docs/src/main/tut/docs/integrations/fetch/README.md
@@ -34,8 +34,8 @@ Let's start by creating a simple algebra for our application for printing messag
 import freestyle._
 import freestyle.implicits._
 
-@free trait Interact[F[_]] {
-  def tell(msg: String): FreeS[F, Unit]
+@free trait Interact {
+  def tell(msg: String): OpSeq[Unit]
 }
 ```
 

--- a/docs/src/main/tut/docs/integrations/fs2/README.md
+++ b/docs/src/main/tut/docs/integrations/fs2/README.md
@@ -15,8 +15,8 @@ We'll start by creating a simple algebra for our application for printing messag
 ```tut:book
 import freestyle._
 
-@free trait Interact[F[_]] {
-  def tell(msg: String): FreeS[F, Unit]
+@free trait Interact {
+  def tell(msg: String): OpSeq[Unit]
 }
 ```
 

--- a/docs/src/main/tut/docs/integrations/play/README.md
+++ b/docs/src/main/tut/docs/integrations/play/README.md
@@ -41,8 +41,8 @@ For demonstration purposes, we will create a very simple program that returns an
 ```tut:book
 object algebras {
   @free
-  trait Noop[F[_]] {
-    def ok: FreeS[F, String]
+  trait Noop {
+    def ok: OpSeq[String]
   }
 }
 

--- a/docs/src/main/tut/docs/integrations/slick/README.md
+++ b/docs/src/main/tut/docs/integrations/slick/README.md
@@ -75,8 +75,8 @@ Only using `SlickM` is not exactly useful in this case as it just adds an extra 
 
 
 ```tut:book
-@free trait Calc[F[_]] {
-  def subtract(a: Int, b: Int): FreeS[F, Int]
+@free trait Calc {
+  def subtract(a: Int, b: Int): OpSeq[Int]
 }
 
 @module trait Example[F[_]] {

--- a/docs/src/main/tut/docs/patterns/config/README.md
+++ b/docs/src/main/tut/docs/patterns/config/README.md
@@ -31,10 +31,10 @@ sealed trait Config {
   def duration(path: String, unit: TimeUnit): Option[Long]
 }
 
-@free sealed trait ConfigM[F[_]] {
-  def load: FreeS[F, Config]
-  def empty: FreeS[F, Config]
-  def parseString(s: String): FreeS[F, Config]
+@free sealed trait ConfigM {
+  def load: OpSeq[Config]
+  def empty: OpSeq[Config]
+  def parseString(s: String): OpSeq[Config]
 }
 ```
 
@@ -65,8 +65,8 @@ import scala.util.Try
 We will define a very simple algebra with a stub handler that returns a list of issue states for illustration purposes:
 
 ```tut:book
-@free trait IssuesService[F[_]] {
-  def states: FreeS[F, List[String]]
+@free trait IssuesService {
+  def states: OpSeq[List[String]]
 }
 
 implicit val issuesServiceHandler: IssuesService.Handler[Try] = new IssuesService.Handler[Try] {

--- a/docs/src/main/tut/docs/patterns/logging/README.md
+++ b/docs/src/main/tut/docs/patterns/logging/README.md
@@ -20,15 +20,15 @@ libraryDependencies += "com.47deg" %% "freestyle-logging" % "0.1.0"
 The set of abstract operations of the `Logging` algebra are specified as follows:
 
 ```scala
-@free trait LoggingM[F[_]] {
-  def debug(msg: String): FreeS[F, Unit]
-  def debugWithCause(msg: String, cause: Throwable): FreeS[F, Unit]
-  def error(msg: String): FreeS[F, Unit]
-  def errorWithCause(msg: String, cause: Throwable): FreeS[F, Unit]
-  def info(msg: String): FreeS[F, Unit]
-  def infoWithCause(msg: String, cause: Throwable): FreeS[F, Unit]
-  def warn(msg: String): FreeS[F, Unit]
-  def warnWithCause(msg: String, cause: Throwable): FreeS[F, Unit]
+@free trait LoggingM {
+  def debug(msg: String): OpSeq[Unit]
+  def debugWithCause(msg: String, cause: Throwable): OpSeq[Unit]
+  def error(msg: String): OpSeq[Unit]
+  def errorWithCause(msg: String, cause: Throwable): OpSeq[Unit]
+  def info(msg: String): OpSeq[Unit]
+  def infoWithCause(msg: String, cause: Throwable): OpSeq[Unit]
+  def warn(msg: String): OpSeq[Unit]
+  def warnWithCause(msg: String, cause: Throwable): OpSeq[Unit]
 }
 ```
 
@@ -55,8 +55,8 @@ import scala.util.Try
 We will define a simple algebra with a stub handler that returns a list of customer Id's for illustration purposes:
 
 ```tut:book
-@free trait CustomerService[F[_]] {
-  def customers: FreeS[F, List[String]]
+@free trait CustomerService {
+  def customers: OpSeq[List[String]]
 }
 
 implicit val customerServiceHandler: CustomerService.Handler[Try] = new CustomerService.Handler[Try] {

--- a/docs/src/main/tut/docs/stack/README.md
+++ b/docs/src/main/tut/docs/stack/README.md
@@ -34,13 +34,13 @@ We will represent these capabilities using two algebras: `CustomerPersistence` a
 
 ```tut:book
 object algebras {
-  @free trait CustomerPersistence[F[_]] {
-    def getCustomer(id: CustomerId): FreeS.Par[F, Option[Customer]]
+  @free trait CustomerPersistence {
+    def getCustomer(id: CustomerId): OpPar[Option[Customer]]
   }
 
-  @free trait StockPersistence[F[_]] {
-    def checkQuantityAvailable(variety: String): FreeS.Par[F, Int]
-    def registerOrder(order: Order): FreeS.Par[F, Unit]
+  @free trait StockPersistence {
+    def checkQuantityAvailable(variety: String): OpPar[Int]
+    def registerOrder(order: Order): OpPar[Unit]
   }
 }
 ```

--- a/freestyle-cache/shared/src/main/scala/cache.scala
+++ b/freestyle-cache/shared/src/main/scala/cache.scala
@@ -28,37 +28,37 @@ package cache {
      * We assume that the actual store is too big or remote to allow for general
      * operations over all values, or to search or to iterate over all keys
      */
-    @free sealed trait CacheM[F[_]] {
+    @free sealed trait CacheM {
 
       // Gets the value associated to a key, if there is one */
-      def get(key: Key): FreeS.Par[F, Option[Val]]
+      def get(key: Key): OpPar[Option[Val]]
 
       // Sets the value of a key to a newValue.
-      def put(key: Key, newVal: Val): FreeS.Par[F, Unit]
+      def put(key: Key, newVal: Val): OpPar[Unit]
 
       // Copy all of the mappings from the specified map to this cache
-      def putAll(keyValues: Map[Key, Val]): FreeS.Par[F, Unit]
+      def putAll(keyValues: Map[Key, Val]): OpPar[Unit]
 
       //If the specified key is not already associated with a value, associate it with the given value.
-      def putIfAbsent(key: Key, newVal: Val): FreeS.Par[F, Unit]
+      def putIfAbsent(key: Key, newVal: Val): OpPar[Unit]
 
       // Removes the entry for the key if one exists
-      def del(key: Key): FreeS.Par[F, Unit]
+      def del(key: Key): OpPar[Unit]
 
       // Returns whether there is an entry for key or not.
-      def has(key: Key): FreeS.Par[F, Boolean]
+      def has(key: Key): OpPar[Boolean]
 
       // Returns the set of keys in the store
-      def keys: FreeS.Par[F, List[Key]]
+      def keys: OpPar[List[Key]]
 
       // Removes all entries
-      def clear: FreeS.Par[F, Unit]
+      def clear: OpPar[Unit]
 
       //Replaces the entry for a key only if currently mapped to some value
-      def replace(key: Key, newVal: Val): FreeS.Par[F, Unit]
+      def replace(key: Key, newVal: Val): OpPar[Unit]
 
       //Returns true if this cache contains no key-value mappings.
-      def isEmpty: FreeS.Par[F, Boolean]
+      def isEmpty: OpPar[Boolean]
 
     }
 

--- a/freestyle-config/src/main/scala/config.scala
+++ b/freestyle-config/src/main/scala/config.scala
@@ -35,10 +35,10 @@ object config {
     def duration(path: String, unit: TimeUnit): Option[Long]
   }
 
-  @free sealed trait ConfigM[F[_]] {
-    def load: FreeS[F, Config]
-    def empty: FreeS[F, Config]
-    def parseString(s: String): FreeS[F, Config]
+  @free sealed trait ConfigM {
+    def load: OpSeq[Config]
+    def empty: OpSeq[Config]
+    def parseString(s: String): OpSeq[Config]
   }
 
   object implicits {

--- a/freestyle-config/src/test/scala/config.scala
+++ b/freestyle-config/src/test/scala/config.scala
@@ -58,8 +58,8 @@ class ConfigTests extends AsyncWordSpec with Matchers {
 
 object algebras {
   @free
-  trait NonConfig[F[_]] {
-    def x: FreeS[F, Int]
+  trait NonConfig {
+    def x: OpSeq[Int]
   }
 
   implicit def nonConfigHandler: NonConfig.Handler[Future] =

--- a/freestyle-doobie/src/main/scala/doobie.scala
+++ b/freestyle-doobie/src/main/scala/doobie.scala
@@ -22,8 +22,8 @@ import fs2.util.{Catchable, Suspendable}
 
 object doobie {
 
-  @free sealed trait DoobieM[F[_]] {
-    def transact[A](f: ConnectionIO[A]): FreeS.Par[F, A]
+  @free sealed trait DoobieM {
+    def transact[A](f: ConnectionIO[A]): OpPar[A]
   }
 
   object implicits {

--- a/freestyle-doobie/src/test/scala/doobie.scala
+++ b/freestyle-doobie/src/test/scala/doobie.scala
@@ -73,8 +73,8 @@ class DoobieTests extends AsyncWordSpec with Matchers {
 
 object algebras {
   @free
-  trait NonDoobie[F[_]] {
-    def x: FreeS[F, Int]
+  trait NonDoobie {
+    def x: OpSeq[Int]
   }
 
   implicit def nonDoobieHandler: NonDoobie.Handler[Task] =

--- a/freestyle-effects/shared/src/main/scala/effects/either.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/either.scala
@@ -24,10 +24,10 @@ object either {
 
   final class ErrorProvider[E] {
 
-    @free sealed trait EitherM[F[_]] {
-      def either[A](fa: Either[E, A]): FreeS.Par[F, A]
-      def error[A](e: E): FreeS.Par[F, A]
-      def catchNonFatal[A](a: Eval[A], f: Throwable => E): FreeS.Par[F, A]
+    @free sealed trait EitherM {
+      def either[A](fa: Either[E, A]): OpPar[A]
+      def error[A](e: E): OpPar[A]
+      def catchNonFatal[A](a: Eval[A], f: Throwable => E): OpPar[A]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/main/scala/effects/error.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/error.scala
@@ -21,10 +21,10 @@ import cats.{Eval, MonadError}
 
 object error {
 
-  @free sealed trait ErrorM[F[_]] {
-    def either[A](fa: Either[Throwable, A]): FreeS.Par[F, A]
-    def error[A](e: Throwable): FreeS.Par[F, A]
-    def catchNonFatal[A](a: Eval[A]): FreeS.Par[F, A]
+  @free sealed trait ErrorM {
+    def either[A](fa: Either[Throwable, A]): OpPar[A]
+    def error[A](e: Throwable): OpPar[A]
+    def catchNonFatal[A](a: Eval[A]): OpPar[A]
   }
 
   trait ErrorImplicits {

--- a/freestyle-effects/shared/src/main/scala/effects/option.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/option.scala
@@ -21,9 +21,9 @@ import cats.MonadFilter
 
 object option {
 
-  @free sealed trait OptionM[F[_]] {
-    def option[A](fa: Option[A]): FreeS.Par[F, A]
-    def none[A]: FreeS.Par[F, A]
+  @free sealed trait OptionM {
+    def option[A](fa: Option[A]): OpPar[A]
+    def none[A]: OpPar[A]
   }
 
   trait OptionImplicits {

--- a/freestyle-effects/shared/src/main/scala/effects/reader.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/reader.scala
@@ -23,9 +23,9 @@ object reader {
 
   final class EnvironmentProvider[R] {
 
-    @free sealed abstract class ReaderM[F[_]] {
-      def ask: FreeS.Par[F, R]
-      def reader[B](f: R => B): FreeS.Par[F, B]
+    @free abstract class ReaderM {
+      def ask: OpPar[R]
+      def reader[B](f: R => B): OpPar[B]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/main/scala/effects/state.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/state.scala
@@ -23,11 +23,11 @@ object state {
 
   final class StateSeedProvider[S] {
 
-    @free sealed abstract class StateM[F[_]] {
-      def get: FreeS.Par[F, S]
-      def set(s: S): FreeS.Par[F, Unit]
-      def modify(f: S => S): FreeS.Par[F, Unit]
-      def inspect[A](f: S => A): FreeS.Par[F, A]
+    @free sealed abstract class StateM {
+      def get: OpPar[S]
+      def set(s: S): OpPar[Unit]
+      def modify(f: S => S): OpPar[Unit]
+      def inspect[A](f: S => A): OpPar[A]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/main/scala/effects/traverse.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/traverse.scala
@@ -25,9 +25,9 @@ object traverse {
 
     /** Acts as a generator providing traversable semantics to programs
      */
-    @free sealed abstract class TraverseM[F[_]] {
-      def empty[A]: FreeS.Par[F, A]
-      def fromTraversable[A](ta: G[A]): FreeS.Par[F, A]
+    @free sealed abstract class TraverseM {
+      def empty[A]: OpPar[A]
+      def fromTraversable[A](ta: G[A]): OpPar[A]
     }
 
     /** Interpretable as long as Foldable instance for G[_] and a MonadCombine for M[_] exists

--- a/freestyle-effects/shared/src/main/scala/effects/validation.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/validation.scala
@@ -26,16 +26,16 @@ object validation {
     type Errors = List[E]
 
     /** An algebra for introducing validation semantics in a program. **/
-    @free sealed trait ValidationM[F[_]] {
-      def valid[A](x: A): FreeS.Par[F, A]
+    @free sealed trait ValidationM {
+      def valid[A](x: A): OpPar[A]
 
-      def invalid(err: E): FreeS.Par[F, Unit]
+      def invalid(err: E): OpPar[Unit]
 
-      def errors: FreeS.Par[F, Errors]
+      def errors: OpPar[Errors]
 
-      def fromEither[A](x: Either[E, A]): FreeS.Par[F, Either[E, A]]
+      def fromEither[A](x: Either[E, A]): OpPar[Either[E, A]]
 
-      def fromValidatedNel[A](x: ValidatedNel[E, A]): FreeS.Par[F, ValidatedNel[E, A]]
+      def fromValidatedNel[A](x: ValidatedNel[E, A]): OpPar[ValidatedNel[E, A]]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/main/scala/effects/writer.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/writer.scala
@@ -23,9 +23,9 @@ object writer {
 
   final class AccumulatorProvider[W] {
 
-    @free sealed abstract class WriterM[F[_]] {
-      def writer[A](aw: (W, A)): FreeS.Par[F, A]
-      def tell(w: W): FreeS.Par[F, Unit]
+    @free sealed abstract class WriterM {
+      def writer[A](aw: (W, A)): OpPar[A]
+      def tell(w: W): OpPar[Unit]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/test/scala/effects/EffectsTests.scala
+++ b/freestyle-effects/shared/src/test/scala/effects/EffectsTests.scala
@@ -549,23 +549,23 @@ object collision {
   }
 
   @free
-  trait B[F[_]] {
-    def x: FreeS[F, Int]
+  trait B {
+    def x: OpSeq[Int]
   }
 
   @free
-  trait C[F[_]] {
-    def x: FreeS[F, Int]
+  trait C {
+    def x: OpSeq[Int]
   }
 
   @free
-  trait D[F[_]] {
-    def x: FreeS[F, Int]
+  trait D {
+    def x: OpSeq[Int]
   }
 
   @free
-  trait E[F[_]] {
-    def x: FreeS[F, Int]
+  trait E {
+    def x: OpSeq[Int]
   }
 
   @module

--- a/freestyle-fetch/shared/src/main/scala/fetch.scala
+++ b/freestyle-fetch/shared/src/main/scala/fetch.scala
@@ -20,13 +20,13 @@ import _root_.fetch._
 
 object fetch {
 
-  @free sealed trait FetchM[F[_]] {
-    def runA[A](f: Fetch[A]): FreeS.Par[F, A]
-    def runF[A](f: Fetch[A]): FreeS.Par[F, (FetchEnv, A)]
-    def runE[A](f: Fetch[A]): FreeS.Par[F, FetchEnv]
-    def runAWithCache[A](f: Fetch[A], cache: DataSourceCache): FreeS.Par[F, A]
-    def runFWithCache[A](f: Fetch[A], cache: DataSourceCache): FreeS.Par[F, (FetchEnv, A)]
-    def runEWithCache[A](f: Fetch[A], cache: DataSourceCache): FreeS.Par[F, FetchEnv]
+  @free sealed trait FetchM {
+    def runA[A](f: Fetch[A]): OpPar[A]
+    def runF[A](f: Fetch[A]): OpPar[(FetchEnv, A)]
+    def runE[A](f: Fetch[A]): OpPar[FetchEnv]
+    def runAWithCache[A](f: Fetch[A], cache: DataSourceCache): OpPar[A]
+    def runFWithCache[A](f: Fetch[A], cache: DataSourceCache): OpPar[(FetchEnv, A)]
+    def runEWithCache[A](f: Fetch[A], cache: DataSourceCache): OpPar[FetchEnv]
   }
 
   object implicits {

--- a/freestyle-fetch/shared/src/test/scala/FetchTests.scala
+++ b/freestyle-fetch/shared/src/test/scala/FetchTests.scala
@@ -91,8 +91,8 @@ class FetchTests extends AsyncWordSpec with Matchers {
 
 object algebras {
   @free
-  trait NonFetch[F[_]] {
-    def x: FreeS[F, Int]
+  trait NonFetch {
+    def x: OpSeq[Int]
   }
 
   implicit def nonFetchHandler: NonFetch.Handler[Future] =

--- a/freestyle-fs2/shared/src/main/scala/fs2.scala
+++ b/freestyle-fs2/shared/src/main/scala/fs2.scala
@@ -47,11 +47,11 @@ object fs2 {
     def suspend[A](fa: => Eff[A]): Eff[A] = fa
   }
 
-  @free sealed trait StreamM[F[_]] {
-    def run[A](s: Stream[Eff, A]): FreeS.Par[F, Unit]
-    def runLog[A](s: Stream[Eff, A]): FreeS.Par[F, Vector[A]]
-    def runFold[A, B](z: B, f: (B, A) => B)(s: Stream[Eff, A]): FreeS.Par[F, B]
-    def runLast[A](s: Stream[Eff, A]): FreeS.Par[F, Option[A]]
+  @free sealed trait StreamM {
+    def run[A](s: Stream[Eff, A]): OpPar[Unit]
+    def runLog[A](s: Stream[Eff, A]): OpPar[Vector[A]]
+    def runFold[A, B](z: B, f: (B, A) => B)(s: Stream[Eff, A]): OpPar[B]
+    def runLast[A](s: Stream[Eff, A]): OpPar[Option[A]]
   }
 
   object implicits {

--- a/freestyle-fs2/shared/src/test/scala/Fs2Tests.scala
+++ b/freestyle-fs2/shared/src/test/scala/Fs2Tests.scala
@@ -124,8 +124,8 @@ class Fs2Tests extends AsyncWordSpec with Matchers {
 
 object algebras {
   @free
-  trait NonStream[F[_]] {
-    def x: FreeS[F, Int]
+  trait NonStream {
+    def x: OpSeq[Int]
   }
 
   implicit def nonStreamHandler: NonStream.Handler[Future] =

--- a/freestyle-logging/shared/src/main/scala/logging.scala
+++ b/freestyle-logging/shared/src/main/scala/logging.scala
@@ -19,23 +19,23 @@ package freestyle
 object logging {
 
   @free
-  trait LoggingM[F[_]] {
+  trait LoggingM {
 
-    def debug(msg: String): FreeS[F, Unit]
+    def debug(msg: String): OpSeq[Unit]
 
-    def debugWithCause(msg: String, cause: Throwable): FreeS[F, Unit]
+    def debugWithCause(msg: String, cause: Throwable): OpSeq[Unit]
 
-    def error(msg: String): FreeS[F, Unit]
+    def error(msg: String): OpSeq[Unit]
 
-    def errorWithCause(msg: String, cause: Throwable): FreeS[F, Unit]
+    def errorWithCause(msg: String, cause: Throwable): OpSeq[Unit]
 
-    def info(msg: String): FreeS[F, Unit]
+    def info(msg: String): OpSeq[Unit]
 
-    def infoWithCause(msg: String, cause: Throwable): FreeS[F, Unit]
+    def infoWithCause(msg: String, cause: Throwable): OpSeq[Unit]
 
-    def warn(msg: String): FreeS[F, Unit]
+    def warn(msg: String): OpSeq[Unit]
 
-    def warnWithCause(msg: String, cause: Throwable): FreeS[F, Unit]
+    def warnWithCause(msg: String, cause: Throwable): OpSeq[Unit]
   }
 
 }

--- a/freestyle-logging/shared/src/test/scala/algebras.scala
+++ b/freestyle-logging/shared/src/test/scala/algebras.scala
@@ -23,8 +23,8 @@ import scala.concurrent.Future
 object algebras {
 
   @free
-  trait NonLogging[F[_]] {
-    def x: FreeS[F, Int]
+  trait NonLogging {
+    def x: OpSeq[Int]
   }
 
   implicit def nonLoggingHandler: NonLogging.Handler[Future] =

--- a/freestyle-slick/src/main/scala/slick.scala
+++ b/freestyle-slick/src/main/scala/slick.scala
@@ -27,8 +27,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 object slick {
 
-  @free sealed trait SlickM[F[_]] {
-    def run[A](f: DBIO[A]): FreeS.Par[F, A]
+  @free sealed trait SlickM {
+    def run[A](f: DBIO[A]): OpPar[A]
   }
 
   object implicits {

--- a/freestyle-slick/src/test/scala/slick.scala
+++ b/freestyle-slick/src/test/scala/slick.scala
@@ -73,8 +73,8 @@ class SlickTests extends AsyncWordSpec with Matchers {
 
 object algebras {
   @free
-  trait NonSlick[F[_]] {
-    def x: FreeS[F, Int]
+  trait NonSlick {
+    def x: OpSeq[Int]
   }
 
   implicit def nonSlickHandler: NonSlick.Handler[Future] =

--- a/freestyle-twitter-util/src/test/scala/TwitterUtilTests.scala
+++ b/freestyle-twitter-util/src/test/scala/TwitterUtilTests.scala
@@ -96,10 +96,10 @@ class TwitterUtilTests extends WordSpec with Matchers {
 object algebras {
 
   @free
-  trait MixedFreeS[F[_]] {
-    def x: FreeS.Par[F, Int]
-    def y: FreeS.Par[F, Int]
-    def z: FreeS[F, Int]
+  trait MixedFreeS {
+    def x: OpPar[Int]
+    def y: OpPar[Int]
+    def z: OpSeq[Int]
   }
 
 }

--- a/freestyle/jvm/src/test/scala/freestyle/parallel.scala
+++ b/freestyle/jvm/src/test/scala/freestyle/parallel.scala
@@ -122,9 +122,9 @@ class parallelTests extends WordSpec with Matchers {
       type ParValidator[A] = Kleisli[Future, String, A]
 
       @free
-      trait Validation[F[_]] {
-        def minSize(n: Int): FreeS.Par[F, Boolean]
-        def hasNumber: FreeS.Par[F, Boolean]
+      trait Validation {
+        def minSize(n: Int): OpPar[Boolean]
+        def hasNumber: OpPar[Boolean]
       }
 
       implicit val interpreter = new Validation.Handler[ParValidator] {

--- a/freestyle/shared/src/main/scala/freestyle/Implicits.scala
+++ b/freestyle/shared/src/main/scala/freestyle/Implicits.scala
@@ -16,7 +16,7 @@
 
 package freestyle
 
-import cats.Monad
+import cats.{ Applicative, Monad }
 import cats.arrow.FunctionK
 import cats.data.Coproduct
 import cats.free.{Free, FreeApplicative, Inject}
@@ -41,6 +41,9 @@ trait Interpreters {
 }
 
 trait FreeSInstances {
+  implicit def freestyleApplicativeForFreeS[F[_]]: Applicative[FreeS.Par[F, ?]] =
+    FreeApplicative.freeApplicative[F]
+
   implicit def freestyleMonadForFreeS[F[_]]: Monad[FreeS[F, ?]] =
     Free.catsFreeMonadForFree[FreeApplicative[F, ?]]
 }

--- a/freestyle/shared/src/main/scala/freestyle/module.scala
+++ b/freestyle/shared/src/main/scala/freestyle/module.scala
@@ -120,7 +120,7 @@ object moduleImpl {
     def filterEffectVals(trees: Template): List[ValDef]  =
       trees.collect { case v: ValDef if v.mods.hasFlag(Flag.DEFERRED) => v }
 
-    lazy val LL = freshTypeName("LL$")
+    val LL = freshTypeName("LL$")
 
     def toImplArg(effVal: ValDef): ValDef = effVal match {
       case q"$mods val $name: $eff[$ff, ..$args]" =>
@@ -131,6 +131,7 @@ object moduleImpl {
       val mod = userTrait.name
       val effVals: List[ValDef] = filterEffectVals(userTrait.impl)
 
+      val tns = userTrait.tparams.tail.map(_.name)
       val AA = freshTypeName("AA$")
       val ev = freshTermName("ev$")
       val xx = freshTermName("xx$")
@@ -146,11 +147,11 @@ object moduleImpl {
 
           type Op[$AA] = $xx.Op[$AA]
 
-          class To[$LL[_]](implicit ..$effArgs) extends $mod[$LL]
+          class To[$LL[_]](implicit ..$effArgs) extends $mod[$LL, ..$tns]
 
-          implicit def to[$LL[_]](implicit ..$effArgs): $mod[$LL] = new To[$LL]()
+          implicit def to[$LL[_]](implicit ..$effArgs): To[$LL] = new To[$LL]()
 
-          def apply[$LL[_]](implicit $ev: $mod[$LL]): $mod[$LL] = $ev
+          def apply[$LL[_]](implicit $ev: $mod[$LL, ..$tns]): $mod[$LL, ..$tns] = $ev
         }
       """
     }

--- a/freestyle/shared/src/test/scala/freestyle/Utils.scala
+++ b/freestyle/shared/src/test/scala/freestyle/Utils.scala
@@ -19,45 +19,46 @@ package freestyle
 import cats.arrow.FunctionK
 
 @free
-trait SCtors1[F[_]] {
-  def x(a: Int): FreeS[F, Int]
-  def y(a: Int): FreeS[F, Int]
+trait SCtors1 {
+  def x(a: Int): OpSeq[Int]
+  def y(a: Int): OpSeq[Int]
 }
 
 @free
-trait SCtors2[G[_]] {
-  def i(a: Int): FreeS[G, Int]
-  def j(a: Int): FreeS[G, Int]
+trait SCtors2 {
+  def i(a: Int): OpSeq[Int]
+  def j(a: Int): OpSeq[Int]
 }
 
 @free
-trait SCtors3[H[_]] {
-  def o(a: Int): FreeS[H, Int]
-  def p(a: Int): FreeS[H, Int]
+trait SCtors3 {
+  def o(a: Int): OpSeq[Int]
+  def p(a: Int): OpSeq[Int]
 }
 
 @free
-trait SCtors4[F[_]] {
-  def k(a: Int): FreeS[F, Int]
-  def m(a: Int): FreeS[F, Int]
+trait SCtors4 {
+  def k(a: Int): OpSeq[Int]
+  def m(a: Int): OpSeq[Int]
 }
 
 @free
-trait MixedFreeS[F[_]] {
-  def x: FreeS.Par[F, Int]
-  def y: FreeS.Par[F, Int]
-  def z: FreeS[F, Int]
+trait MixedFreeS {
+  def x: OpPar[Int]
+  def y: OpPar[Int]
+  def z: OpSeq[Int]
 }
 
 @free
-trait S1[F[_]] {
-  def x(n: Int): FreeS[F, Int]
+trait S1 {
+  def x(n: Int): OpSeq[Int]
 }
 
 @free
-trait S2[F[_]] {
-  def y(n: Int): FreeS[F, Int]
+trait S2 {
+  def y(n: Int): OpSeq[Int]
 }
+
 
 @module
 trait M1[F[_]] {

--- a/freestyle/shared/src/test/scala/freestyle/free.scala
+++ b/freestyle/shared/src/test/scala/freestyle/free.scala
@@ -27,11 +27,11 @@ class freeTests extends WordSpec with Matchers {
     import freestyle.implicits._
 
     "be rejected if applied to a non-abstract class" in {
-      """@free class Foo[F[_]] { val x: Int}""" shouldNot compile
+      """@free class Foo { val x: Int}""" shouldNot compile
     }
 
     "be rejected if applied to a trait with companion object" in {
-      """ @free trait  Foo[F[_]] {def f: FreeS[F, Int]} ; object Foo """ shouldNot compile
+      """ @free trait Foo {def f: OpSeq[Int]} ; object Foo """ shouldNot compile
     }
 
     "create a companion with a `Op` type alias" in {
@@ -79,23 +79,23 @@ class freeTests extends WordSpec with Matchers {
 
     "allow multiple args in smart constructors" in {
       @free
-      trait MultiArgs[F[_]] {
-        def x(a: Int, b: Int, c: Int): FreeS[F, Int]
+      trait MultiArgs {
+        def x(a: Int, b: Int, c: Int): OpSeq[Int]
       }
     }
 
     "allow smart constructors with no args" in {
       @free
-      trait NoArgs[F[_]] {
-        def x: FreeS[F, Int]
+      trait NoArgs {
+        def x: OpSeq[Int]
       }
     }
 
     "generate ADTs with friendly names and expose them as dependent types" in {
       @free
-      trait FriendlyFreeS[F[_]] {
-        def sc1(a: Int, b: Int, c: Int): FreeS[F, Int]
-        def sc2(a: Int, b: Int, c: Int): FreeS[F, Int]
+      trait FriendlyFreeS {
+        def sc1(a: Int, b: Int, c: Int): OpSeq[Int]
+        def sc2(a: Int, b: Int, c: Int): OpSeq[Int]
       }
       implicitly[FriendlyFreeS.Op[_] =:= FriendlyFreeS.Op[_]]
       implicitly[FriendlyFreeS.Sc1OP <:< FriendlyFreeS.Op[Int]]
@@ -105,10 +105,10 @@ class freeTests extends WordSpec with Matchers {
 
     "allow smart constructors with type arguments" in {
       @free
-      trait KVStore[F[_]] {
-        def put[A](key: String, value: A): FreeS[F, Unit]
-        def get[A](key: String): FreeS[F, Option[A]]
-        def delete(key: String): FreeS[F, Unit]
+      trait KVStore {
+        def put[A](key: String, value: A): OpSeq[Unit]
+        def get[A](key: String): OpSeq[Option[A]]
+        def delete(key: String): OpSeq[Unit]
       }
       val interpreter = new KVStore.Handler[List] {
         def put[A](key: String, value: A): List[Unit] = Nil
@@ -119,10 +119,10 @@ class freeTests extends WordSpec with Matchers {
 
     "allow evaluation of abstract members that return FreeS.Pars" in {
       @free
-      trait ApplicativesServ[F[_]] {
-        def x(key: String): FreeS.Par[F, String]
-        def y(key: String): FreeS.Par[F, String]
-        def z(key: String): FreeS.Par[F, String]
+      trait ApplicativesServ {
+        def x(key: String): OpPar[String]
+        def y(key: String): OpPar[String]
+        def z(key: String): OpPar[String]
       }
       implicit val interpreter = new ApplicativesServ.Handler[Option] {
         override def x(key: String): Option[String] = Some(key)
@@ -137,10 +137,10 @@ class freeTests extends WordSpec with Matchers {
 
     "allow sequential evaluation of combined FreeS & FreeS.Par" in {
       @free
-      trait MixedFreeS[F[_]] {
-        def x(key: String): FreeS.Par[F, String]
-        def y(key: String): FreeS.Par[F, String]
-        def z(key: String): FreeS[F, String]
+      trait MixedFreeS {
+        def x(key: String): OpPar[String]
+        def y(key: String): OpPar[String]
+        def z(key: String): OpSeq[String]
       }
       implicit val interpreter = new MixedFreeS.Handler[Option] {
         override def x(key: String): Option[String] = Some(key)
@@ -158,8 +158,8 @@ class freeTests extends WordSpec with Matchers {
     }
 
     "allow non-FreeS concrete definitions in the trait" in {
-      @free trait WithExtra[F[_]] {
-        def x(a: Int): FreeS.Par[F, String]
+      @free trait WithExtra {
+        def x(a: Int): OpPar[String]
         def y: Int = 5
         val z: Int = 6
       }
@@ -174,9 +174,9 @@ class freeTests extends WordSpec with Matchers {
     }
 
     "allow `FreeS` operations that use other abstractoperations" in {
-      @free trait Combine[F[_]] {
-        def x(a: Int): FreeS[F, Int]
-        def y(a: Int): FreeS[F, Boolean] = x(a).map { _ >= 0 }
+      @free trait Combine {
+        def x(a: Int): OpSeq[Int]
+        def y(a: Int): OpSeq[Boolean] = x(a).map { _ >= 0 }
       }
       val v = Combine[Combine.Op]
       implicit val interpreter = new Combine.Handler[Id]{

--- a/freestyle/shared/src/test/scala/nopackage.scala
+++ b/freestyle/shared/src/test/scala/nopackage.scala
@@ -18,14 +18,14 @@
 
 import freestyle._
 
-@free trait Logitech[F[_]] {
-  def eyes(s: String): FreeS.Par[F, Boolean]
-  def skills(s: String): FreeS.Par[F, Boolean]
+@free trait Logitech {
+  def eyes(s: String): OpPar[Boolean]
+  def skills(s: String): OpPar[Boolean]
 }
 
-@free trait Asia[F[_]] {
-  def recycled(msg: String): FreeS[F, Unit]
-  def rhino(prompt: String): FreeS[F, String]
+@free trait Asia {
+  def recycled(msg: String): OpSeq[Unit]
+  def rhino(prompt: String): OpSeq[String]
 }
 
 @module trait Age[F[_]] {

--- a/http/akka/src/test/scala/freestyle/http/AkkaHttpTests.scala
+++ b/http/akka/src/test/scala/freestyle/http/AkkaHttpTests.scala
@@ -63,9 +63,9 @@ case class User(name: String)
 object userrepo {
 
   @free
-  trait UserApp[F[_]] {
-    def get(id: Int): FreeS.Par[F, User]
-    def list: FreeS[F, List[User]]
+  trait UserApp {
+    def get(id: Int): OpPar[User]
+    def list: OpSeq[List[User]]
   }
 
   implicit val handler: UserApp.Handler[Id] = new UserApp.Handler[Id] {

--- a/http/finch/src/test/scala/http/FinchTests.scala
+++ b/http/finch/src/test/scala/http/FinchTests.scala
@@ -108,8 +108,8 @@ class FinchTests extends AsyncWordSpec with Matchers {
 
 object algebra {
   @free
-  trait Calc[F[_]] {
-    def sum(a: Int, b: Int): FreeS.Par[F, Int]
+  trait Calc {
+    def sum(a: Int, b: Int): OpPar[Int]
   }
 }
 

--- a/http/http4s/src/test/scala/http/Http4sTest.scala
+++ b/http/http4s/src/test/scala/http/Http4sTest.scala
@@ -79,9 +79,9 @@ object algebras {
   case class User(name: String)
 
   @free
-  trait UserRepository[F[_]] {
-    def get(id: Long): FreeS.Par[F, User]
-    def list: FreeS.Par[F, List[User]]
+  trait UserRepository {
+    def get(id: Long): OpPar[User]
+    def list: OpPar[List[User]]
   }
 
   @module

--- a/http/play/src/test/scala/PlayTests.scala
+++ b/http/play/src/test/scala/PlayTests.scala
@@ -66,8 +66,8 @@ class PlayTests extends AsyncWordSpec with Matchers {
 
 object algebras {
   @free
-  trait Noop[F[_]] {
-    def noop: FreeS[F, Unit]
+  trait Noop {
+    def noop: OpSeq[Unit]
   }
 }
 

--- a/tests/src/main/resources/pcplodtest.scala
+++ b/tests/src/main/resources/pcplodtest.scala
@@ -19,8 +19,8 @@ import freestyle.implicits._
 import cats.implicits._
 
 object pcplodtest {
-  @free trait PcplodTestAlgebra[F[_]] {
-    def test(n: Int): FreeS[F, Int]
+  @free trait PcplodTestAlgebra {
+    def test(n: Int): OpSeq[Int]
   }
   implicit val impl = new PcplodTestAlgebra.H@handler@andler[Option] {
     override def test(n:Int): Option[Int] = Some(1)

--- a/tests/src/main/resources/pcplodtest.scala
+++ b/tests/src/main/resources/pcplodtest.scala
@@ -20,7 +20,7 @@ import cats.implicits._
 
 object pcplodtest {
   @free trait PcplodTestAlgebra {
-    def test(n: Int): OpSeq[Int]
+    def test(n: Int): OpPar[Int]
   }
   implicit val impl = new PcplodTestAlgebra.H@handler@andler[Option] {
     override def test(n:Int): Option[Int] = Some(1)

--- a/tests/src/test/scala/tests.scala
+++ b/tests/src/test/scala/tests.scala
@@ -27,7 +27,8 @@ class tests extends WordSpec with Matchers {
       import org.ensime.pcplod._
       withMrPlod("pcplodtest.scala") { pc =>
         pc.typeAtPoint('result) shouldBe Some("Option[Int]")
-        pc.typeAtPoint('test) shouldBe Some("(n: Int)freestyle.FreeS[F,Int]")
+        // Disabled test: the name of the parameter of `FreeS` is no longer known.
+        //pc.typeAtPoint('test) shouldBe Some("(n: Int)freestyle.FreeS[F,Int]")
         pc.typeAtPoint('handler) shouldBe Some("pcplodtest.PcplodTestAlgebra.Handler")
         pc.messages should be a 'empty
       }

--- a/tests/src/test/scala/tests.scala
+++ b/tests/src/test/scala/tests.scala
@@ -27,8 +27,7 @@ class tests extends WordSpec with Matchers {
       import org.ensime.pcplod._
       withMrPlod("pcplodtest.scala") { pc =>
         pc.typeAtPoint('result) shouldBe Some("Option[Int]")
-        // Disabled test: the name of the parameter of `FreeS` is no longer known.
-        //pc.typeAtPoint('test) shouldBe Some("(n: Int)freestyle.FreeS[F,Int]")
+        pc.typeAtPoint('test) shouldBe Some("(n: Int)cats.free.FreeApplicative[F,Int]")
         pc.typeAtPoint('handler) shouldBe Some("pcplodtest.PcplodTestAlgebra.Handler")
         pc.messages should be a 'empty
       }


### PR DESCRIPTION
This PR carries a few steps regarding ticker #93. The goal of that ticket is to remove the need to specify the `F[_]` high-kind parameter in the `@free` and `@module` annotation. This PR carries a partial solution, which helps us to remove the parameter from the `@free`-annotated traits. The approach followed in this PR is: 

- We introduce a trait `EffectLike[F[_]]`, that contains a couple of type aliae `OpSeq[A]` and `OpPar[A]`, for `FreeS[F,A]` and `FreeS.Par[F,A]`, respectively.
- We use macro `freshTypeName` to generate a high-kind type `F` from the `@free` annotated type. This name should not collide with any one chosen by the user. 
- We change the macro to edit the original `@free`-annotated trait, to introduce the extra param `F[_]`, and add its inheritance from `EffectLike[F]`.
