### PR TITLE
Dependency Injection docs

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -59,7 +59,7 @@ options:
         url: docs/effects/Cache/
 
       - title: Dependency Injection
-        url: TODO.html
+        url: docs/patterns/dependency-injection
 
       - title: Configuration
         url: docs/patterns/config

--- a/docs/src/main/tut/docs/http/finch.md
+++ b/docs/src/main/tut/docs/http/finch.md
@@ -74,8 +74,6 @@ import shapeless.::
 We can use a  freestyle program within `Endpoint#apply`.
 
 ```tut:book
-cats.Monad[Future]
-
 val gcdEndpointTwo = get(int :: int) { (a: Int, b: Int) =>
   Calc[Calc.Op].gcd(a, b).map(Ok(_))
 }

--- a/docs/src/main/tut/docs/patterns/dependency-injection/README.md
+++ b/docs/src/main/tut/docs/patterns/dependency-injection/README.md
@@ -1,0 +1,24 @@
+---
+layout: docs
+title: Dependency Injection
+permalink: /docs/patterns/dependency-injection/
+---
+
+## Dependency Injection
+
+Freestyle makes it easy to create programs where the business logic is separated from specific implementation concerns like error handling, configuration, (asynchronous) communication with (remote) services, etc. The business logic is written using the operations from one or more algebras and every algebra by itself is implemented in a handler (interpreter).
+
+As the business logic is built by glueing together simple algebra operations, it is just a pure description and only at the edge of the program (a main method, a http route, a UI handler, etc) a handler is needed, that can translate the description to a more concrete data type. These pure descriptions are also easy to test by supplying an appropriate test handler (eg a simpler one using just `Id`).
+
+If you are using more than one algebra, freestyle makes it easy to execute or translate your resulting program because it will provide a handler for your combined algebra by combining all the individual handlers (see the [modules](/docs/core/modules/)) section).
+
+Pairing up the right interpreter when you want to execute a program happens at compile time, so compiling your projects using freestyle may take a bit longer, but you don't need to worry about something going wrong at runtime.
+
+
+### Runtime Dependency using Reader
+
+For runtime dependency injection you can use a `Reader` data type.
+
+Freestyle has a [`reader` effect algebra](/docs/effects/#reader), that is used in [the target stack example](/docs/stack/). However there are also cases where you don't want to put this dependency on some environment explicitly in your algebra and then you can use `Reader` or `ReaderT` (`Kleisli`) as part of you target type.
+
+Imagine you are writing a `Persistence` algebra, you would not want to pollute it with implementation details like which connection pool is used to execute the persistence operations.


### PR DESCRIPTION
Did I miss something, or do we need something else?

I tried to come up with a simple but not too trivial example of using `Reader` / `Kleisli` as target data type where you do not want the environment or config to be part of your algebra (like with `ReaderM`), but I couldn't come up with something small but still useful.

I don't know if it makes sense to add something trivial like : 

```scala
@free trait Calc[F[_]] {
  def sum(a: Int, b: Int): FreeS[F, Int]
}

type IntReader[A] = Reader[Int, A]

implicit val handler: Calc.Handler[IntReader] = new Calc.Handler[IntReader] {
  def sum(a: Int, b: Int): IntReader[Int] = Reader(n => a + (b * n))
}

Calc[Calc.Op].sum(1, 2).exec[IntReader].run(5) // 11 (= 1 + 2 x 5)
```

Resolves #132.