### PR TITLE
EitherM effect algebra

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -24,25 +24,28 @@ options:
     nested_options:
 
       - title: Error
-        url: docs/effects/#Error
+        url: docs/effects/#errorm
+
+      - title: Either
+        url: docs/effects/#eithermg
 
       - title: Option
-        url: docs/effects/#Option
+        url: docs/effects/#optionm
 
       - title: Reader
-        url: docs/effects/#Reader
+        url: docs/effects/#readerm
 
       - title: Writer
-        url: docs/effects/#Writer
+        url: docs/effects/#writerm
 
       - title: State
-        url: docs/effects/#State
+        url: docs/effects/#statem
 
       - title: Traverse
-        url: docs/effects/#Traverse
+        url: docs/effects/#traversem
 
       - title: Validation
-        url: docs/effects/#Validation
+        url: docs/effects/#validationm
 
       - title: Async Callbacks
         url: docs/effects/async

--- a/freestyle-effects/shared/src/main/scala/effects/either.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/either.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle
+package effects
+
+import cats.{Eval, MonadError}
+import scala.util.control.NonFatal
+
+object either {
+
+  final class ErrorProvider[E] {
+
+    @free sealed trait EitherM[F[_]] {
+      def either[A](fa: Either[E, A]): FreeS.Par[F, A]
+      def error[A](e: E): FreeS.Par[F, A]
+      def catchNonFatal[A](a: Eval[A], f: Throwable => E): FreeS.Par[F, A]
+    }
+
+    object implicits {
+      implicit def freeStyleEitherMHandler[M[_]](
+          implicit ME: MonadError[M, E]): EitherM.Handler[M] = new EitherM.Handler[M] {
+        def either[A](fa: Either[E, A]): M[A] = fa.fold(ME.raiseError[A], ME.pure[A])
+        def error[A](e: E): M[A]              = ME.raiseError[A](e)
+        def catchNonFatal[A](a: Eval[A], f: Throwable => E): M[A] =
+          try ME.pure(a.value)
+          catch {
+            case NonFatal(e) => ME.raiseError(f(e))
+          }
+      }
+
+      class EitherFreeSLift[F[_]: EitherM] extends FreeSLift[F, Either[E, ?]] {
+        def liftFSPar[A](fa: Either[E, A]): FreeS.Par[F, A] = EitherM[F].either(fa)
+      }
+
+      implicit def freeSLiftEither[F[_]: EitherM]: FreeSLift[F, Either[E, ?]] =
+        new EitherFreeSLift[F]
+    }
+
+  }
+
+  def apply[E]: ErrorProvider[E] = new ErrorProvider
+}


### PR DESCRIPTION
This new algebra allows the same semantics as the `ErrorM` effect algebra but allows the user to set `E` to something else beside `Throwable`