### PR TITLE
Fixes Publishing Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
+
+[comment]: # (Start Badges)
+
+[![Build Status](https://travis-ci.org/47deg/freestyle.svg?branch=master)](https://travis-ci.org/47deg/freestyle) [![codecov.io](http://codecov.io/github/47deg/freestyle/coverage.svg?branch=master)](http://codecov.io/github/47deg/freestyle?branch=master) [![License](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/47deg/freestyle/master/LICENSE) [![Join the chat at https://gitter.im/47deg/freestyle](https://badges.gitter.im/47deg/freestyle.svg)](https://gitter.im/47deg/freestyle?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![GitHub Issues](https://img.shields.io/github/issues/47deg/freestyle.svg)](https://github.com/47deg/freestyle/issues) 
+
+[comment]: # (End Badges)
+
+
 EXPERIMENTAL, UNRELEASED WIP.
-
-
-[![codecov](https://codecov.io/gh/47deg/freestyle/branch/master/graph/badge.svg)](https://codecov.io/gh/47deg/freestyle) [![Build Status](https://travis-ci.org/47deg/freestyle.svg?branch=master)](https://travis-ci.org/47deg/freestyle) [![Join the chat at https://gitter.im/47deg/freestyle](https://badges.gitter.im/47deg/freestyle.svg)](https://gitter.im/47deg/freestyle?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 A Cohesive & Pragmatic Framework of FP centric Scala libraries
 
@@ -74,9 +79,11 @@ If you wish to add your library here please consider a PR to include it in the l
 --- | --- | ---
 ![scala-exercises](https://www.scala-exercises.org/assets/images/navbar_brand.svg) | [**scala-exercises**](https://www.scala-exercises.org/) | Scala Exercises is an Open Source project for learning different technologies based in the Scala Programming Language.
 
+[comment]: # (Start Copyright)
 # Copyright
 
 freestyle is designed and developed by 47 Degrees
 
 Copyright (C) 2017 47 Degrees. <http://47deg.com>
-      
+
+[comment]: # (End Copyright)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ def loadUser[F[_]]
 }
 ```
 
+## freestyle in the wild
+
+If you wish to add your library here please consider a PR to include it in the list below.
+
+★ | ★ | ★
+--- | --- | ---
+![scala-exercises](https://www.scala-exercises.org/assets/images/navbar_brand.svg) | [**scala-exercises**](https://www.scala-exercises.org/) | Scala Exercises is an Open Source project for learning different technologies based in the Scala Programming Language.
+
 # Copyright
 
 freestyle is designed and developed by 47 Degrees

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,13 @@
 import sbtorgpolicies.model._
 
-addCommandAlias("debug", "; clean ; test")
-
-addCommandAlias("validate", "; +clean ; +test; makeMicrosite")
-
-pgpPassphrase := Some(getEnvVar("PGP_PASSPHRASE").getOrElse("").toCharArray)
-pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
-pgpSecretRing := file(s"$gpgFolder/secring.gpg")
-
-lazy val freestyle = (crossProject in file("freestyle"))
+lazy val freestyle = (project in file("."))
   .settings(name := "freestyle")
+  .settings(noPublishSettings: _*)
+  .aggregate(freestyleModules: _*)
+  .dependsOn(freestyleDependencies: _*)
+
+lazy val freestyleCore = (crossProject in file("freestyle"))
+  .settings(name := "freestyle-core")
   .settings(
     libraryDependencies ++= Seq(
       %("scala-reflect", scalaVersion.value),
@@ -21,184 +19,11 @@ lazy val freestyle = (crossProject in file("freestyle"))
   )
   .jsSettings(sharedJsSettings: _*)
 
-lazy val freestyleJVM = freestyle.jvm
-lazy val freestyleJS  = freestyle.js
-
-lazy val freestyleMonix = (crossProject in file("freestyle-monix"))
-  .settings(name := "freestyle-monix")
-  .settings(
-    libraryDependencies ++= Seq(
-      %%%("monix-eval"),
-      %%%("monix-cats")
-    )
-  )
-  .jsSettings(sharedJsSettings: _*)
-
-lazy val freestyleMonixJVM = freestyleMonix.jvm
-lazy val freestyleMonixJS  = freestyleMonix.js
-
-lazy val freestyleEffects = (crossProject in file("freestyle-effects"))
-  .dependsOn(freestyle)
-  .settings(name := "freestyle-effects")
-  .jsSettings(sharedJsSettings: _*)
-
-lazy val freestyleEffectsJVM = freestyleEffects.jvm
-lazy val freestyleEffectsJS  = freestyleEffects.js
-
-lazy val freestyleAsync = (crossProject in file("async/async"))
-  .dependsOn(freestyle)
-  .settings(name := "freestyle-async")
-  .jsSettings(sharedJsSettings: _*)
-
-lazy val freestyleAsyncJVM = freestyleAsync.jvm
-lazy val freestyleAsyncJS  = freestyleAsync.js
-
-lazy val freestyleAsyncMonix = (crossProject in file("async/monix"))
-  .dependsOn(freestyle, freestyleAsync)
-  .settings(name := "freestyle-async-monix")
-  .settings(
-    libraryDependencies ++= Seq(
-      %%("monix-eval"),
-      %%("monix-cats")
-    )
-  )
-  .jsSettings(sharedJsSettings: _*)
-
-lazy val freestyleAsyncMonixJVM = freestyleAsyncMonix.jvm
-lazy val freestyleAsyncMonixJS  = freestyleAsyncMonix.js
-
-lazy val freestyleAsyncFs = (crossProject in file("async/fs2"))
-  .dependsOn(freestyle, freestyleAsync)
-  .settings(name := "freestyle-async-fs2")
-  .settings(
-    libraryDependencies ++= Seq(
-      %%%("fs2-core"),
-      %%%("fs2-cats")
-    )
-  )
-  .jsSettings(sharedJsSettings: _*)
-
-lazy val freestyleAsyncFsJVM = freestyleAsyncFs.jvm
-lazy val freestyleAsyncFsJS  = freestyleAsyncFs.js
-
-lazy val freestyleCache = (crossProject in file("freestyle-cache"))
-  .dependsOn(freestyle)
-  .settings(
-    name := "freestyle-cache"
-  )
-  .jsSettings(sharedJsSettings: _*)
-
-lazy val freestyleCacheJVM = freestyleCache.jvm
-lazy val freestyleCacheJS  = freestyleCache.js
-
-lazy val freestyleCacheRedis = (crossProject in file("freestyle-cache-redis"))
-  .dependsOn(freestyle, freestyleCache)
-  .settings(
-    name := "freestyle-cache-redis",
-    resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases/",
-    resolvers += Resolver.mavenLocal,
-    libraryDependencies ++= Seq(
-      %%("rediscala"),
-      %%("akka-actor")    % "test",
-      %("embedded-redis") % "test"
-    )
-  )
-  .jsSettings(sharedJsSettings: _*)
-
-lazy val freestyleCacheRedisJVM = freestyleCacheRedis.jvm
-
-lazy val freestyleDoobie = (project in file("freestyle-doobie"))
-  .dependsOn(freestyleJVM)
-  .settings(name := "freestyle-doobie")
-  .settings(
-    libraryDependencies ++= Seq(
-      %%("doobie-core-cats"),
-      %%("doobie-h2-cats") % "test"
-    )
-  )
-
-lazy val freestyleSlick = (project in file("freestyle-slick"))
-  .dependsOn(freestyleJVM, freestyleAsyncJVM)
-  .settings(name := "freestyle-slick")
-  .settings(
-    libraryDependencies ++= Seq(
-      %%("slick"),
-      "com.h2database" % "h2" % "1.4.194" % "test"
-    )
-  )
-
-lazy val freestyleTwitterUtil = (project in file("freestyle-twitter-util"))
-  .dependsOn(freestyleJVM)
-  .settings(name := "freestyle-twitter-util")
-  .settings(
-    libraryDependencies += %%("catbird-util")
-  )
-
-lazy val fixResources = taskKey[Unit]("Fix application.conf presence on first clean build.")
-
-lazy val freestyleConfig = (project in file("freestyle-config"))
-  .dependsOn(freestyleJVM)
-  .settings(
-    name := "freestyle-config",
-    fixResources := {
-      val testConf = (resourceDirectory in Test).value / "application.conf"
-      val targetFile = (classDirectory in (freestyleJVM, Compile)).value / "application.conf"
-      if (testConf.exists) {
-        IO.copyFile(
-          testConf,
-          targetFile
-        )
-      }
-    },
-    compile in Test := ((compile in Test) dependsOn fixResources).value
-  )
-  .settings(
-    libraryDependencies ++= Seq(
-      %("config", "1.2.1")
-    )
-  )
-
-lazy val freestyleFetch = (crossProject in file("freestyle-fetch"))
-  .dependsOn(freestyle)
-  .settings(name := "freestyle-fetch")
-  .settings(
-    libraryDependencies ++= Seq(
-      %%%("fetch"),
-      %%%("fetch-monix")
-    )
-  )
-  .jsSettings(sharedJsSettings: _*)
-
-lazy val freestyleFetchJVM = freestyleFetch.jvm
-lazy val freestyleFetchJS  = freestyleFetch.js
-
-lazy val freestyleLogging = (crossProject in file("freestyle-logging"))
-  .dependsOn(freestyle)
-  .settings(name := "freestyle-logging")
-  .jvmSettings(
-    libraryDependencies += %%("journal-core")
-  )
-  .jsSettings(
-    libraryDependencies += %%%("slogging")
-  )
-  .jsSettings(sharedJsSettings: _*)
-
-lazy val freestyleLoggingJVM = freestyleLogging.jvm
-lazy val freestyleLoggingJS  = freestyleLogging.js
-
-lazy val freestyleFs2 = (crossProject in file("freestyle-fs2"))
-  .dependsOn(freestyle)
-  .settings(name := "freestyle-fs2")
-  .settings(
-    libraryDependencies += %%%("fs2-core")
-  )
-  .jsSettings(sharedJsSettings: _*)
-
-lazy val freestyleFs2JVM = freestyleFs2.jvm
-lazy val freestyleFs2JS  = freestyleFs2.js
+lazy val freestyleCoreJVM = freestyleCore.jvm
+lazy val freestyleCoreJS  = freestyleCore.js
 
 lazy val tests = (project in file("tests"))
-  .dependsOn(freestyleJVM)
+  .dependsOn(freestyleCoreJVM)
   .settings(noPublishSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
@@ -220,20 +45,7 @@ lazy val tests = (project in file("tests"))
   )
 
 lazy val docs = (project in file("docs"))
-  .dependsOn(freestyleJVM)
-  .dependsOn(freestyleEffectsJVM)
-  .dependsOn(freestyleFs2JVM)
-  .dependsOn(freestyleFetchJVM)
-  .dependsOn(freestyleCacheJVM)
-  .dependsOn(freestyleDoobie)
-  .dependsOn(freestyleSlick)
-  .dependsOn(freestyleHttpPlay)
-  .dependsOn(freestyleHttpHttp4s)
-  .dependsOn(freestyleHttpFinch)
-  .dependsOn(freestyleAsyncFsJVM)
-  .dependsOn(freestyleAsyncMonixJVM)
-  .dependsOn(freestyleLoggingJVM)
-  .dependsOn(freestyleConfig)
+  .dependsOn(freestyleDependencies: _*)
   .settings(micrositeSettings: _*)
   .settings(noPublishSettings: _*)
   .settings(
@@ -244,13 +56,184 @@ lazy val docs = (project in file("docs"))
     libraryDependencies ++= Seq(
       %%("doobie-h2-cats"),
       %%("http4s-dsl"),
-      "com.h2database" % "h2" % "1.4.194" % "test"
+      %("h2") % "test"
     )
   )
   .enablePlugins(MicrositesPlugin)
 
+lazy val freestyleMonix = (crossProject in file("freestyle-monix"))
+  .settings(name := "freestyle-monix")
+  .settings(
+    libraryDependencies ++= Seq(
+      %%%("monix-eval"),
+      %%%("monix-cats")
+    )
+  )
+  .jsSettings(sharedJsSettings: _*)
+
+lazy val freestyleMonixJVM = freestyleMonix.jvm
+lazy val freestyleMonixJS  = freestyleMonix.js
+
+lazy val freestyleEffects = (crossProject in file("freestyle-effects"))
+  .dependsOn(freestyleCore)
+  .settings(name := "freestyle-effects")
+  .jsSettings(sharedJsSettings: _*)
+
+lazy val freestyleEffectsJVM = freestyleEffects.jvm
+lazy val freestyleEffectsJS  = freestyleEffects.js
+
+lazy val freestyleAsync = (crossProject in file("async/async"))
+  .dependsOn(freestyleCore)
+  .settings(name := "freestyle-async")
+  .jsSettings(sharedJsSettings: _*)
+
+lazy val freestyleAsyncJVM = freestyleAsync.jvm
+lazy val freestyleAsyncJS  = freestyleAsync.js
+
+lazy val freestyleAsyncMonix = (crossProject in file("async/monix"))
+  .dependsOn(freestyleCore, freestyleAsync)
+  .settings(name := "freestyle-async-monix")
+  .settings(
+    libraryDependencies ++= Seq(
+      %%("monix-eval"),
+      %%("monix-cats")
+    )
+  )
+  .jsSettings(sharedJsSettings: _*)
+
+lazy val freestyleAsyncMonixJVM = freestyleAsyncMonix.jvm
+lazy val freestyleAsyncMonixJS  = freestyleAsyncMonix.js
+
+lazy val freestyleAsyncFs = (crossProject in file("async/fs2"))
+  .dependsOn(freestyleCore, freestyleAsync)
+  .settings(name := "freestyle-async-fs2")
+  .settings(
+    libraryDependencies ++= Seq(
+      %%%("fs2-core"),
+      %%%("fs2-cats")
+    )
+  )
+  .jsSettings(sharedJsSettings: _*)
+
+lazy val freestyleAsyncFsJVM = freestyleAsyncFs.jvm
+lazy val freestyleAsyncFsJS  = freestyleAsyncFs.js
+
+lazy val freestyleCache = (crossProject in file("freestyle-cache"))
+  .dependsOn(freestyleCore)
+  .settings(
+    name := "freestyle-cache"
+  )
+  .jsSettings(sharedJsSettings: _*)
+
+lazy val freestyleCacheJVM = freestyleCache.jvm
+lazy val freestyleCacheJS  = freestyleCache.js
+
+lazy val freestyleCacheRedis = (crossProject in file("freestyle-cache-redis"))
+  .dependsOn(freestyleCore, freestyleCache)
+  .settings(
+    name := "freestyle-cache-redis",
+    resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases/",
+    resolvers += Resolver.mavenLocal,
+    libraryDependencies ++= Seq(
+      %%("rediscala"),
+      %%("akka-actor")    % "test",
+      %("embedded-redis") % "test"
+    )
+  )
+  .jsSettings(sharedJsSettings: _*)
+
+lazy val freestyleCacheRedisJVM = freestyleCacheRedis.jvm
+
+lazy val freestyleDoobie = (project in file("freestyle-doobie"))
+  .dependsOn(freestyleCoreJVM)
+  .settings(name := "freestyle-doobie")
+  .settings(
+    libraryDependencies ++= Seq(
+      %%("doobie-core-cats"),
+      %%("doobie-h2-cats") % "test"
+    )
+  )
+
+lazy val freestyleSlick = (project in file("freestyle-slick"))
+  .dependsOn(freestyleCoreJVM, freestyleAsyncJVM)
+  .settings(name := "freestyle-slick")
+  .settings(
+    libraryDependencies ++= Seq(
+      %%("slick"),
+      %("h2") % "test"
+    )
+  )
+
+lazy val freestyleTwitterUtil = (project in file("freestyle-twitter-util"))
+  .dependsOn(freestyleCoreJVM)
+  .settings(name := "freestyle-twitter-util")
+  .settings(
+    libraryDependencies += %%("catbird-util")
+  )
+
+lazy val freestyleConfig = (project in file("freestyle-config"))
+  .dependsOn(freestyleCoreJVM)
+  .settings(
+    name := "freestyle-config",
+    fixResources := {
+      val testConf   = (resourceDirectory in Test).value / "application.conf"
+      val targetFile = (classDirectory in (freestyleCoreJVM, Compile)).value / "application.conf"
+      if (testConf.exists) {
+        IO.copyFile(
+          testConf,
+          targetFile
+        )
+      }
+    },
+    compile in Test := ((compile in Test) dependsOn fixResources).value
+  )
+  .settings(
+    libraryDependencies ++= Seq(
+      %("config", "1.2.1")
+    )
+  )
+
+lazy val freestyleFetch = (crossProject in file("freestyle-fetch"))
+  .dependsOn(freestyleCore)
+  .settings(name := "freestyle-fetch")
+  .settings(
+    libraryDependencies ++= Seq(
+      %%%("fetch"),
+      %%%("fetch-monix")
+    )
+  )
+  .jsSettings(sharedJsSettings: _*)
+
+lazy val freestyleFetchJVM = freestyleFetch.jvm
+lazy val freestyleFetchJS  = freestyleFetch.js
+
+lazy val freestyleLogging = (crossProject in file("freestyle-logging"))
+  .dependsOn(freestyleCore)
+  .settings(name := "freestyle-logging")
+  .jvmSettings(
+    libraryDependencies += %%("journal-core")
+  )
+  .jsSettings(
+    libraryDependencies += %%%("slogging")
+  )
+  .jsSettings(sharedJsSettings: _*)
+
+lazy val freestyleLoggingJVM = freestyleLogging.jvm
+lazy val freestyleLoggingJS  = freestyleLogging.js
+
+lazy val freestyleFs2 = (crossProject in file("freestyle-fs2"))
+  .dependsOn(freestyleCore)
+  .settings(name := "freestyle-fs2")
+  .settings(
+    libraryDependencies += %%%("fs2-core")
+  )
+  .jsSettings(sharedJsSettings: _*)
+
+lazy val freestyleFs2JVM = freestyleFs2.jvm
+lazy val freestyleFs2JS  = freestyleFs2.js
+
 lazy val freestyleHttpHttp4s = (project in file("http/http4s"))
-  .dependsOn(freestyleJVM)
+  .dependsOn(freestyleCoreJVM)
   .settings(name := "freestyle-http-http4s")
   .settings(
     libraryDependencies ++= Seq(
@@ -260,14 +243,14 @@ lazy val freestyleHttpHttp4s = (project in file("http/http4s"))
   )
 
 lazy val freestyleHttpFinch = (project in file("http/finch"))
-  .dependsOn(freestyleJVM)
+  .dependsOn(freestyleCoreJVM)
   .settings(name := "freestyle-http-finch")
   .settings(
     libraryDependencies += %%("finch-core")
   )
 
 lazy val freestyleHttpAkka = (project in file("http/akka"))
-  .dependsOn(freestyleJVM)
+  .dependsOn(freestyleCoreJVM)
   .settings(name := "freestyle-http-akka")
   .settings(
     libraryDependencies ++= Seq(
@@ -277,7 +260,7 @@ lazy val freestyleHttpAkka = (project in file("http/akka"))
   )
 
 lazy val freestyleHttpPlay = (project in file("http/play"))
-  .dependsOn(freestyleJVM)
+  .dependsOn(freestyleCoreJVM)
   .settings(name := "freestyle-http-play")
   .settings(
     parallelExecution in Test := false,
@@ -287,10 +270,53 @@ lazy val freestyleHttpPlay = (project in file("http/play"))
     )
   )
 
+addCommandAlias("debug", "; clean ; test")
+
+addCommandAlias("validate", "; +clean ; +test; makeMicrosite")
+
+pgpPassphrase := Some(getEnvVar("PGP_PASSPHRASE").getOrElse("").toCharArray)
+pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
+pgpSecretRing := file(s"$gpgFolder/secring.gpg")
+
 orgAfterCISuccessTaskListSetting := List(
   orgCreateFiles.toOrgTask,
   orgCommitPolicyFiles.toOrgTask,
   depUpdateDependencyIssues.toOrgTask,
   (publishMicrosite in docs).toOrgTask,
-  orgPublishRelease.toOrgTask(allModulesScope = true, crossScalaVersionsScope = true)
+  orgPublishReleaseTask.toOrgTask(allModulesScope = true, crossScalaVersionsScope = true)
 )
+
+lazy val freestyleModules: Seq[ProjectReference] = Seq(
+  freestyleCoreJVM,
+  freestyleCoreJS,
+  freestyleMonixJVM,
+  freestyleMonixJS,
+  freestyleEffectsJVM,
+  freestyleEffectsJS,
+  freestyleAsyncJVM,
+  freestyleAsyncJS,
+  freestyleAsyncMonixJVM,
+  freestyleAsyncMonixJS,
+  freestyleAsyncFsJVM,
+  freestyleAsyncFsJS,
+  freestyleCacheJVM,
+  freestyleCacheJS,
+  freestyleCacheRedisJVM,
+  freestyleDoobie,
+  freestyleSlick,
+  freestyleTwitterUtil,
+  freestyleConfig,
+  freestyleFetchJVM,
+  freestyleFetchJS,
+  freestyleLoggingJVM,
+  freestyleLoggingJS,
+  freestyleFs2JVM,
+  freestyleFs2JS,
+  freestyleHttpHttp4s,
+  freestyleHttpFinch,
+  freestyleHttpAkka,
+  freestyleHttpPlay
+)
+
+lazy val freestyleDependencies: Seq[ClasspathDependency] =
+  freestyleModules.map(ClasspathDependency(_, None))

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,5 +1,7 @@
 import com.typesafe.sbt.site.jekyll.JekyllPlugin.autoImport._
+import dependencies.DependenciesPlugin.autoImport.depUpdateDependencyIssues
 import microsites.MicrositeKeys._
+import microsites.MicrositesPlugin.autoImport.publishMicrosite
 import microsites.util.BuildHelper.buildWithoutSuffix
 import sbt.Keys._
 import sbt._
@@ -14,6 +16,9 @@ object ProjectPlugin extends AutoPlugin {
   override def requires: Plugins = OrgPoliciesPlugin
 
   object autoImport {
+
+    lazy val fixResources: TaskKey[Unit] =
+      taskKey[Unit]("Fix application.conf presence on first clean build.")
 
     lazy val micrositeSettings = Seq(
       micrositeName := "Freestyle",
@@ -56,9 +61,8 @@ object ProjectPlugin extends AutoPlugin {
       coverageFailOnMinimum := false,
       description := "A Cohesive & Pragmatic Framework of FP centric Scala libraries",
       startYear := Some(2017),
-      orgGithubTokenSetting := Option(System.getenv().get("GITHUB_TOKEN_REPO")),
+      orgGithubTokenSetting := "GITHUB_TOKEN_REPO",
       resolvers += Resolver.sonatypeRepo("snapshots"),
-      onLoad := (Command.process("project freestyle", _: State)) compose (onLoad in Global).value,
       scalacOptions ++= scalacAdvancedOptions,
       libraryDependencies += %%("scalatest") % "test",
       parallelExecution in Test := false

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -5,9 +5,11 @@ import microsites.MicrositesPlugin.autoImport.publishMicrosite
 import microsites.util.BuildHelper.buildWithoutSuffix
 import sbt.Keys._
 import sbt._
+import sbtorgpolicies.OrgPoliciesKeys.orgBadgeListSetting
 import sbtorgpolicies.OrgPoliciesPlugin
 import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies.model._
+import sbtorgpolicies.templates.badges._
 import scoverage.ScoverageSbtPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
@@ -62,6 +64,14 @@ object ProjectPlugin extends AutoPlugin {
       description := "A Cohesive & Pragmatic Framework of FP centric Scala libraries",
       startYear := Some(2017),
       orgGithubTokenSetting := "GITHUB_TOKEN_REPO",
+      orgBadgeListSetting := List(
+        TravisBadge.apply,
+        CodecovBadge.apply,
+        LicenseBadge.apply,
+        GitterBadge.apply,
+        GitHubIssuesBadge.apply,
+        ScalaJSBadge.apply
+      ),
       resolvers += Resolver.sonatypeRepo("snapshots"),
       scalacOptions ++= scalacAdvancedOptions,
       libraryDependencies += %%("scalatest") % "test",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.4")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.8")


### PR DESCRIPTION
This PR creates a root/parent module for freestyle project, in order to make easier its manageability from there. Details:

* `freestyle` sbt module has been renamed to `freestyleCore`.
* `freestyle` is the name of the parent sbt module (root project).
* From now on, all the new freestyle sbt modules (both jvm and js) should be included in the `freestyleModules` list, in order to be aggregated automatically by the root project and docs module.
* Bumps sbt-org-policies version (`0.4.4` -> to `0.4.8`).
* Includes new sections in the README file, done automatically by sbt-org-policies (copyright, badges sections and freestyle in the wild).
