### PR TITLE
Custom implicit not found messages that don't suck

### DIFF
--- a/freestyle/shared/src/main/scala/freestyle/AnnotationMessages.java
+++ b/freestyle/shared/src/main/scala/freestyle/AnnotationMessages.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle;
+
+interface AnnotationMessages {
+
+ public static final String handlerNotFoundMsg = "\n-------" +
+  "\n\nHandler not found to transform `${F}` to `${G}`" +
+  "\n                                               " +
+  "\nFor automatic handler resolution to work, ensure you provide an implicit handler for each one of your defined @free algebras." +
+  "\nUber handlers considered for evaluating grouped algebras in `@module` or `Coproduct` are automatically derived and implicitly provided" +
+  "\nthere is a Handler for each one of the `@free` algebras available in the implicit scope." +
+  "\n\n To learn more about `handlers` and how they relate to `@free` algebras visit:" +
+  "\n\n http://frees.io/docs/core/interpreters/\n\n" +
+  "\n-------";
+
+ public static final String freeSLiftInstanceNotFoundMsg = "\n-------" +
+  "\nNo FreeSLift instance found for `${G}`" +
+  "\nThe following stub is provided for convenience:" +
+  "\n\nimplicit def instance[F[_]]: FreeSLift[F, ${G}] = new FreeSLift[F, ${G}] {" +
+  "\n  def liftFSPar[A](ga: ${G}[A]): FreeS.Par[F, A] = ???" +
+  "\n}" +
+  "\n-------";
+
+ public static final String captureInstanceNotFoundMsg = "\n-------" +
+  "\nNo Capture instance found for ${F}" +
+  "\nThe following stub is provided for convenience:" +
+  "\n\nimplicit val ${F}CaptureInstance: Capture[${F}] = new Capture[${F}] {" +
+  "\n  def capture[A](a: => A): ${F}[A] = ???" +
+  "\n}" +
+  "\n-------";
+ 
+
+}

--- a/freestyle/shared/src/main/scala/freestyle/Capture.scala
+++ b/freestyle/shared/src/main/scala/freestyle/Capture.scala
@@ -21,6 +21,7 @@ import simulacrum.typeclass
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
+import annotation.implicitNotFound
 
 /*
  * The method `Applicative#pure` in `cats.Applicative` is strict on its parameter. Thus, it
@@ -30,6 +31,7 @@ import scala.util.Try
  *  define a `Capture` type-class..
  */
 @typeclass
+@implicitNotFound(msg = AnnotationMessages.captureInstanceNotFoundMsg)
 trait Capture[F[_]] {
   def capture[A](a: => A): F[A]
 }

--- a/freestyle/shared/src/main/scala/freestyle/Implicits.scala
+++ b/freestyle/shared/src/main/scala/freestyle/Implicits.scala
@@ -26,12 +26,12 @@ import shapeless.Lazy
 trait Interpreters {
 
   implicit def interpretCoproduct[F[_], G[_], M[_]](
-      implicit fm: FunctionK[F, M],
-      gm: Lazy[FunctionK[G, M]]): FunctionK[Coproduct[F, G, ?], M] =
+      implicit fm: FSHandler[F, M],
+      gm: Lazy[FSHandler[G, M]]): FSHandler[Coproduct[F, G, ?], M] =
     fm or gm.value
 
   implicit def interpretAp[F[_], M[_]: Monad](
-      implicit fInterpreter: FunctionK[F, M]): FunctionK[FreeApplicative[F, ?], M] =
+      implicit fInterpreter: FSHandler[F, M]): FSHandler[FreeApplicative[F, ?], M] =
     λ[FunctionK[FreeApplicative[F, ?], M]](_.foldMap(fInterpreter))
 
   // workaround for https://github.com/typelevel/cats/issues/1505

--- a/freestyle/shared/src/main/scala/freestyle/Lift.scala
+++ b/freestyle/shared/src/main/scala/freestyle/Lift.scala
@@ -16,6 +16,9 @@
 
 package freestyle
 
+import annotation.implicitNotFound
+
+@implicitNotFound(AnnotationMessages.freeSLiftInstanceNotFoundMsg)
 trait FreeSLift[F[_], G[_]] {
   def liftFS[A](ga: G[A]): FreeS[F, A] = liftFSPar[A](ga).freeS
   def liftFSPar[A](ga: G[A]): FreeS.Par[F, A]

--- a/freestyle/shared/src/main/scala/freestyle/package.scala
+++ b/freestyle/shared/src/main/scala/freestyle/package.scala
@@ -16,6 +16,7 @@
 
 import cats.free.{Free, FreeApplicative, Inject}
 import cats.{~>, Applicative, Monad}
+import annotation.implicitNotFound
 
 package object freestyle {
 
@@ -28,8 +29,12 @@ package object freestyle {
    */
   type FreeS[F[_], A] = Free[FreeApplicative[F, ?], A]
 
+  @implicitNotFound(msg = AnnotationMessages.handlerNotFoundMsg)
+  type FSHandler[F[_], G[_]] = F ~> G
+
   /** Interprets a parallel fragment `f` into `g` */
-  type ParInterpreter[F[_], G[_]] = FreeApplicative[F, ?] ~> G
+  @implicitNotFound(msg = AnnotationMessages.handlerNotFoundMsg)
+  type ParInterpreter[F[_], G[_]] = FSHandler[FreeApplicative[F, ?], G]
 
   /**
    * Optimizes a parallel fragment `f` into a sequential series of parallel

--- a/freestyle/shared/src/test/scala/freestyle/implicits.scala
+++ b/freestyle/shared/src/test/scala/freestyle/implicits.scala
@@ -45,5 +45,24 @@ class implicitsTests extends WordSpec with Matchers {
       val program = List(s.x(1), s.x(2)).sequence[FreeS[SCtors1.Op, ?], Int]
       program.exec[Option] shouldBe (Some(List(1, 2)))
     }
-  }
+
+    "provide a custom implicit not found message for a missing implicit Handler" in {
+      shapeless.test.illTyped(
+        """Capture[Option]""",
+        ".*No Capture instance found for Option.*")
+    }
+
+    "provide a custom implicit not found message for a missing Capture instance" in {
+      shapeless.test.illTyped(
+        """SCtors1[SCtors1.Op].x(1).exec[scala.util.Try]""",
+        ".*Handler not found to transform.*")
+    }
+
+    "provide a custom implicit not found message for a missing FreeSLift instance" in {
+      shapeless.test.illTyped(
+        """implicitly[FreeSLift[SCtors1.Op, List]]""",
+        ".*No FreeSLift instance found for.*")
+    }
+
+   }
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -61,6 +61,7 @@ object ProjectPlugin extends AutoPlugin {
       onLoad := (Command.process("project freestyle", _: State)) compose (onLoad in Global).value,
       scalacOptions ++= scalacAdvancedOptions,
       libraryDependencies += %%("scalatest") % "test",
-      parallelExecution in Test := false
+      parallelExecution in Test := false,
+      compileOrder in Compile := CompileOrder.JavaThenScala
     ) ++ scalaMacroDependencies
 }


### PR DESCRIPTION
Fixes #191 

The following PR brings nicer messages for `Handler`, `Capture` and `FreeSLift` implicit instances not found. For example when missing an implicit handler for Option for any given algebra the user instead of seeing the classical scala `implicit not found...`

```
[error]  -------
[error] Handler not found to transform `freestyle.algebras.SCtors1.Op` to `List`
[error]                                                
[error] For automatic handler resolution to work, ensure you provide an implicit handler for each one of your defined @free algebras.
[error] Uber handlers considered for evaluating grouped algebras in `@module` or `Coproduct` are automatically derived and implicitly provided there is a Handler for each one of the `@free` algebras available in the implicit scope.
[error] 
[error]  To learn more about `handlers` and how they relate to `@free` algebras visit:
[error] 
[error]  http://frees.io/docs/core/interpreters/
[error]  -------
[error]       implicitly[FSHandler[SCtors1.Op, List]]
```