### PR TITLE
FS-221 Remove wrapper objects in tests

### DIFF
--- a/freestyle/jvm/src/test/scala/freestyle/parallel.scala
+++ b/freestyle/jvm/src/test/scala/freestyle/parallel.scala
@@ -27,8 +27,6 @@ class parallelTests extends WordSpec with Matchers {
 
   "Applicative Parallel Support" should {
 
-    import algebras._
-
     class NonDeterminismTestShared {
       import freestyle.nondeterminism._
       import freestyle.implicits._

--- a/freestyle/shared/src/test/scala/freestyle/Utils.scala
+++ b/freestyle/shared/src/test/scala/freestyle/Utils.scala
@@ -18,97 +18,85 @@ package freestyle
 
 import cats.arrow.FunctionK
 
-object algebras {
-
-  @free
-  trait SCtors1[F[_]] {
-    def x(a: Int): FreeS[F, Int]
-    def y(a: Int): FreeS[F, Int]
-  }
-
-  @free
-  trait SCtors2[G[_]] {
-    def i(a: Int): FreeS[G, Int]
-    def j(a: Int): FreeS[G, Int]
-  }
-
-  @free
-  trait SCtors3[H[_]] {
-    def o(a: Int): FreeS[H, Int]
-    def p(a: Int): FreeS[H, Int]
-  }
-
-  @free
-  trait SCtors4[F[_]] {
-    def k(a: Int): FreeS[F, Int]
-    def m(a: Int): FreeS[F, Int]
-  }
-
-  @free
-  trait MixedFreeS[F[_]] {
-    def x: FreeS.Par[F, Int]
-    def y: FreeS.Par[F, Int]
-    def z: FreeS[F, Int]
-  }
-
-  @free
-  trait S1[F[_]] {
-    def x(n: Int): FreeS[F, Int]
-  }
-
-  @free
-  trait S2[F[_]] {
-    def y(n: Int): FreeS[F, Int]
-  }
-
+@free
+trait SCtors1[F[_]] {
+  def x(a: Int): FreeS[F, Int]
+  def y(a: Int): FreeS[F, Int]
 }
 
-object modules {
+@free
+trait SCtors2[G[_]] {
+  def i(a: Int): FreeS[G, Int]
+  def j(a: Int): FreeS[G, Int]
+}
 
-  import algebras._
+@free
+trait SCtors3[H[_]] {
+  def o(a: Int): FreeS[H, Int]
+  def p(a: Int): FreeS[H, Int]
+}
 
-  @module
-  trait M1[F[_]] {
-    val sctors1: SCtors1[F]
-    val sctors2: SCtors2[F]
-  }
+@free
+trait SCtors4[F[_]] {
+  def k(a: Int): FreeS[F, Int]
+  def m(a: Int): FreeS[F, Int]
+}
 
-  @module
-  trait M2[G[_]] {
-    val sctors3: SCtors3[G]
-    val sctors4: SCtors4[G]
-  }
+@free
+trait MixedFreeS[F[_]] {
+  def x: FreeS.Par[F, Int]
+  def y: FreeS.Par[F, Int]
+  def z: FreeS[F, Int]
+}
 
-  @module
-  trait O1[H[_]] {
-    val m1: M1[H]
-    val m2: M2[H]
-  }
+@free
+trait S1[F[_]] {
+  def x(n: Int): FreeS[F, Int]
+}
 
-  @module
-  trait O2[F[_]] {
-    val o1: O1[F]
-    val x = 1
-    def y = 2
-  }
+@free
+trait S2[F[_]] {
+  def y(n: Int): FreeS[F, Int]
+}
 
-  @module
-  trait O3[F[_]] {
-    def x = 1
-    def y = 2
-  }
+@module
+trait M1[F[_]] {
+  val sctors1: SCtors1[F]
+  val sctors2: SCtors2[F]
+}
 
-  @module
-  trait StateProp[F[_]] {
-    val s1: S1[F]
-    val s2: S2[F]
-  }
+@module
+trait M2[G[_]] {
+  val sctors3: SCtors3[G]
+  val sctors4: SCtors4[G]
+}
 
+@module
+trait O1[H[_]] {
+  val m1: M1[H]
+  val m2: M2[H]
+}
+
+@module
+trait O2[F[_]] {
+  val o1: O1[F]
+  val x = 1
+  def y = 2
+}
+
+@module
+trait O3[F[_]] {
+  def x = 1
+  def y = 2
+}
+
+@module
+trait StateProp[F[_]] {
+  val s1: S1[F]
+  val s2: S2[F]
 }
 
 object interps {
-
-  import algebras._
 
   implicit val optionHandler1: FunctionK[SCtors1.Op, Option] = new SCtors1.Handler[Option] {
     def x(a: Int): Option[Int] = Some(a)

--- a/freestyle/shared/src/test/scala/freestyle/free.scala
+++ b/freestyle/shared/src/test/scala/freestyle/free.scala
@@ -24,7 +24,6 @@ class freeTests extends WordSpec with Matchers {
 
   "the @free annotation" should {
 
-    import algebras._
     import freestyle.implicits._
 
     "be rejected if applied to a non-abstract class" in {

--- a/freestyle/shared/src/test/scala/freestyle/implicits.scala
+++ b/freestyle/shared/src/test/scala/freestyle/implicits.scala
@@ -24,7 +24,6 @@ class implicitsTests extends WordSpec with Matchers {
 
   "Implicits" should {
 
-    import algebras._
     import freestyle.implicits._
 
     "provide a Monad for FreeS" in {

--- a/freestyle/shared/src/test/scala/freestyle/module.scala
+++ b/freestyle/shared/src/test/scala/freestyle/module.scala
@@ -24,8 +24,6 @@ class moduleTests extends WordSpec with Matchers {
 
   "the @module annotation" should {
 
-    import algebras._
-    import modules._
     import freestyle.implicits._
     import interps._
 

--- a/freestyle/shared/src/test/scala/nopackage.scala
+++ b/freestyle/shared/src/test/scala/nopackage.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The purpose of this test is to see if freestyle still compiles classes in _root_ package. 
+
+import freestyle._
+
+@free trait Logitech[F[_]] {
+  def eyes(s: String): FreeS.Par[F, Boolean]
+  def skills(s: String): FreeS.Par[F, Boolean]
+}
+
+@free trait Asia[F[_]] {
+  def recycled(msg: String): FreeS[F, Unit]
+  def rhino(prompt: String): FreeS[F, String]
+}
+
+@module trait Age[F[_]] {
+  val logitech: Logitech[F]
+  val asia: Asia[F]
+}


### PR DESCRIPTION
This ticket tries to address the possible problems mentioned in ticket #221. This issue was whether it is possible to define `@free` and `@module` without having to wrap these in an `object`, which was failing at a Kazari instance. In this PR, we change the tests of the core module so as to use an organization without those wrapper objects. We also add some comments for the code of the `@module` macro.