### PR TITLE
FS-234 Unify OpPar and OpSeq

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Applications built with Freestyle can be interpreted to any runtime semantics su
 import freestyle._
 
 @free trait Database {
-  def get(id: UserId): OpSeq[User]
+  def get(id: UserId): FS[User]
 }
 
 @free trait Cache {
-  def get(id: UserId): OpSeq[User]
+  def get(id: UserId): FS[User]
 }
 
 @module trait Persistence[F[_]] {

--- a/async/async/shared/src/main/scala/async.scala
+++ b/async/async/shared/src/main/scala/async.scala
@@ -30,7 +30,7 @@ object async {
 
   /** Async computation algebra. **/
   @free sealed trait AsyncM {
-    def async[A](fa: Proc[A]): OpPar[A]
+    def async[A](fa: Proc[A]): FS[A]
   }
 
   object implicits {

--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ lazy val docs = (project in file("docs"))
   )
   .settings(
     libraryDependencies ++= Seq(
+      %%("play") % "test",
       %%("doobie-h2-cats"),
       %%("http4s-dsl"),
       %("h2") % "test"
@@ -256,7 +257,7 @@ lazy val httpPlay = (project in file("http/play"))
   .settings(
     parallelExecution in Test := false,
     libraryDependencies ++= Seq(
-      %%("play"),
+      %%("play") % "test",
       %%("play-test") % "test"
     ) ++ commonDeps
   )

--- a/docs/src/main/resources/microsite/css/custom.css
+++ b/docs/src/main/resources/microsite/css/custom.css
@@ -149,9 +149,9 @@ h1, h2, h3, h4, h5, h6, #site-header {
     font-size: 32px;
 }
 ree trait UserRepository[F[_]] {
-  def get(id: Long): OpSeq[User]
-  def save(user: User): OpSeq[User]
-  def list: OpSeq[List[User]]
+  def get(id: Long): FS[User]
+  def save(user: User): FS[User]
+  def list: FS[List[User]]
 }
 #site-main p {
     margin-bottom: 30px;

--- a/docs/src/main/tut/README.md
+++ b/docs/src/main/tut/README.md
@@ -16,11 +16,11 @@ Applications built with Freestyle can be interpreted to any runtime semantics su
 import freestyle._
 
 @free trait Database {
-  def get(id: UserId): OpSeq[User]
+  def get(id: UserId): FS[User]
 }
 
 @free trait Cache {
-  def get(id: UserId): OpSeq[User]
+  def get(id: UserId): FS[User]
 }
 
 @module trait Persistence[F[_]] {

--- a/docs/src/main/tut/docs/README.md
+++ b/docs/src/main/tut/docs/README.md
@@ -43,13 +43,13 @@ import freestyle._
 import freestyle.implicits._
 
 @free trait Validation {
-  def minSize(s: String, n: Int): OpPar[Boolean]
-  def hasNumber(s: String): OpPar[Boolean]
+  def minSize(s: String, n: Int): FS[Boolean]
+  def hasNumber(s: String): FS[Boolean]
 }
 
 @free trait Interaction {
-  def tell(msg: String): OpSeq[Unit]
-  def ask(prompt: String): OpSeq[String]
+  def tell(msg: String): FS[Unit]
+  def ask(prompt: String): FS[String]
 }
 ```
 

--- a/docs/src/main/tut/docs/core/interpreters/README.md
+++ b/docs/src/main/tut/docs/core/interpreters/README.md
@@ -24,12 +24,12 @@ import freestyle._
 import cats.implicits._
 
 @free trait KVStore {
-  def put[A](key: String, value: A): OpSeq[Unit]
-  def get[A](key: String): OpSeq[Option[A]]
-  def delete(key: String): OpSeq[Unit]
+  def put[A](key: String, value: A): FS[Unit]
+  def get[A](key: String): FS[Option[A]]
+  def delete(key: String): FS[Unit]
   def update[A](key: String, f: A => A): OpSeq[Unit] =
-    get[A](key) flatMap {
-      case Some(a) => put[A](key, f(a))
+    get[A](key).freeS flatMap {
+      case Some(a) => put[A](key, f(a)).freeS
       case None => ().pure[OpSeq]
     }
 }
@@ -85,8 +85,8 @@ To illustrate interpreter composition, let's define a new algebra `Log` which we
 
 ```tut:book
 @free trait Log {
-  def info(msg: String): OpSeq[Unit]
-  def warn(msg: String): OpSeq[Unit]
+  def info(msg: String): FS[Unit]
+  def warn(msg: String): FS[Unit]
 }
 ```
 

--- a/docs/src/main/tut/docs/core/interpreters/README.md
+++ b/docs/src/main/tut/docs/core/interpreters/README.md
@@ -27,10 +27,10 @@ import cats.implicits._
   def put[A](key: String, value: A): FS[Unit]
   def get[A](key: String): FS[Option[A]]
   def delete(key: String): FS[Unit]
-  def update[A](key: String, f: A => A): OpSeq[Unit] =
+  def update[A](key: String, f: A => A): FS.Seq[Unit] =
     get[A](key).freeS flatMap {
       case Some(a) => put[A](key, f(a)).freeS
-      case None => ().pure[OpSeq]
+      case None => ().pure[FS.Seq]
     }
 }
 ```

--- a/docs/src/main/tut/docs/core/modules/README.md
+++ b/docs/src/main/tut/docs/core/modules/README.md
@@ -17,16 +17,16 @@ import freestyle._
 
 object algebras {
     @free trait Database {
-      def get(id: Int): OpSeq[Int]
+      def get(id: Int): FS[Int]
     }
     @free trait Cache {
-      def get(id: Int): OpSeq[Option[Int]]
+      def get(id: Int): FS[Option[Int]]
     }
     @free trait Presenter {
-      def show(id: Int): OpSeq[Int]
+      def show(id: Int): FS[Int]
     }
     @free trait IdValidation {
-      def validate(id: Option[Int]): OpSeq[Int]
+      def validate(id: Option[Int]): FS[Int]
     }
 }
 ```

--- a/docs/src/main/tut/docs/core/parallelism/README.md
+++ b/docs/src/main/tut/docs/core/parallelism/README.md
@@ -30,8 +30,8 @@ Independent operations that can potentially be executed in parallel can be place
 import freestyle._
 
 @free trait Validation {
-  def minSize(n: Int): OpPar[Boolean]
-  def hasNumber: OpPar[Boolean]
+  def minSize(n: Int): FS[Boolean]
+  def hasNumber: FS[Boolean]
 }
 ```
 
@@ -83,9 +83,9 @@ Sequential and parallel actions can be easily intermixed in `@free` algebras:
 
 ```tut:book
 @free trait MixedFreeS {
-  def x: OpPar[Int]
-  def y: OpPar[Int]
-  def z: OpSeq[Int]
+  def x: FS[Int]
+  def y: FS[Int]
+  def z: FS[Int]
 }
 ```
 

--- a/docs/src/main/tut/docs/core/parallelism/README.md
+++ b/docs/src/main/tut/docs/core/parallelism/README.md
@@ -50,12 +50,10 @@ The code below illustrates a handler that will allow parallel executions thanks 
 
 ```tut:book
 import cats.data.Kleisli
-import cats.implicits._
-import scala.concurrent._
+import cats.syntax.cartesian._
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
-
-import freestyle.implicits._
 
 type ParValidator[A] = Kleisli[Future, String, A]
 
@@ -92,17 +90,14 @@ Sequential and parallel actions can be easily intermixed in `@free` algebras:
 Using the [cats cartesian builder operator \|@\|](http://eed3si9n.com/herding-cats/Cartesian.html#The+Applicative+Style) we can easily describe steps that run in parallel:
 
 ```tut:book
-import freestyle.implicits._
-import cats.implicits._
-
 def program[F[_]](implicit M: MixedFreeS[F]) = {
   import M._
   for {
     a <- z //3
-    bc <- (x |@| y).tupled.freeS //(1,2) potentially x and y run in parallel
-	(b, c) = bc
-	d <- z //3
-  } yield a :: b :: c :: d :: Nil // List(3,1,2,3)
+    bc <- (x |@| y).tupled.freeS
+    (b, c) = bc
+    d <- z //3
+  } yield List(a,b,c,d)
 }
 ```
 

--- a/docs/src/main/tut/docs/effects/cache/README.md
+++ b/docs/src/main/tut/docs/effects/cache/README.md
@@ -13,12 +13,12 @@ This algebra is parametrized on the types `Key`, and `Val`, for keys and values 
 ```Scala
 class KeyValueProvider[Key, Val] {
   @free sealed trait CacheM {
-    def get(key: Key):              OpPar[Option[Val]]
-    def put(key: Key, newVal: Val): OpPar[Unit]
-    def del(key: Key):              OpPar[Unit]
-    def has(key: Key):              OpPar[Boolean]
-    def keys:                       OpPar[List[Key]]
-    def clear:                      OpPar[Unit]
+    def get(key: Key):              FS[Option[Val]]
+    def put(key: Key, newVal: Val): FS[Unit]
+    def del(key: Key):              FS[Unit]
+    def has(key: Key):              FS[Boolean]
+    def keys:                       FS[List[Key]]
+    def clear:                      FS[Unit]
   }
 }
 ```

--- a/docs/src/main/tut/docs/http/finch/README.md
+++ b/docs/src/main/tut/docs/http/finch/README.md
@@ -31,7 +31,7 @@ In this example, we will create a Finch `Endpoint` which will be able to calcula
 
 ```tut:book
 @free trait Calc {
-  def gcd(a: Int, b: Int): OpSeq[Int]
+  def gcd(a: Int, b: Int): FS[Int]
 }
 ```
 

--- a/docs/src/main/tut/docs/http/http4s/README.md
+++ b/docs/src/main/tut/docs/http/http4s/README.md
@@ -41,8 +41,8 @@ In this example, we will create an algebra to calculate the VAT of a product's p
 import scala.math.BigDecimal
 
 @free trait CalcVAT {
-  def vat(price: BigDecimal): OpSeq[BigDecimal]
-  def withVat(price: BigDecimal): OpSeq[BigDecimal] =
+  def vat(price: BigDecimal): FS[BigDecimal]
+  def withVat(price: BigDecimal): FS[BigDecimal] =
     vat(price).map(_ + price)
 }
 ```

--- a/docs/src/main/tut/docs/integrations/akkahttp/README.md
+++ b/docs/src/main/tut/docs/integrations/akkahttp/README.md
@@ -80,7 +80,7 @@ case class User(name: String)
 
 @free
 trait UserApp {
-  def get(id: Int): OpSeq[User]
+  def get(id: Int): FS[User]
 }
 
 val app = UserApp.to[UserApp.Op]

--- a/docs/src/main/tut/docs/integrations/cats/README.md
+++ b/docs/src/main/tut/docs/integrations/cats/README.md
@@ -35,8 +35,8 @@ To see how we can use `FreeS` and `FreeS.Par` in combination with existing Cats 
 import freestyle._
 
 @free trait Calc {
-  def sum(a: Int, b: Int): OpPar[Int]
-  def product(a: Int, b: Int): OpPar[Int]
+  def sum(a: Int, b: Int): FS[Int]
+  def product(a: Int, b: Int): FS[Int]
 }
 ```
 

--- a/docs/src/main/tut/docs/integrations/doobie/README.md
+++ b/docs/src/main/tut/docs/integrations/doobie/README.md
@@ -73,7 +73,7 @@ Only using `DoobieM` is not exactly useful however, as it just adds an extra lev
 
 ```tut:book
 @free trait Calc {
-  def subtract(a: Int, b: Int): OpSeq[Int]
+  def subtract(a: Int, b: Int): FS[Int]
 }
 
 @module trait Example[F[_]] {

--- a/docs/src/main/tut/docs/integrations/fetch/README.md
+++ b/docs/src/main/tut/docs/integrations/fetch/README.md
@@ -35,7 +35,7 @@ import freestyle._
 import freestyle.implicits._
 
 @free trait Interact {
-  def tell(msg: String): OpSeq[Unit]
+  def tell(msg: String): FS[Unit]
 }
 ```
 

--- a/docs/src/main/tut/docs/integrations/fs2/README.md
+++ b/docs/src/main/tut/docs/integrations/fs2/README.md
@@ -16,7 +16,7 @@ We'll start by creating a simple algebra for our application for printing messag
 import freestyle._
 
 @free trait Interact {
-  def tell(msg: String): OpSeq[Unit]
+  def tell(msg: String): FS[Unit]
 }
 ```
 

--- a/docs/src/main/tut/docs/integrations/play/README.md
+++ b/docs/src/main/tut/docs/integrations/play/README.md
@@ -42,7 +42,7 @@ For demonstration purposes, we will create a very simple program that returns an
 object algebras {
   @free
   trait Noop {
-    def ok: OpSeq[String]
+    def ok: FS[String]
   }
 }
 

--- a/docs/src/main/tut/docs/integrations/slick/README.md
+++ b/docs/src/main/tut/docs/integrations/slick/README.md
@@ -76,7 +76,7 @@ Only using `SlickM` is not exactly useful in this case as it just adds an extra 
 
 ```tut:book
 @free trait Calc {
-  def subtract(a: Int, b: Int): OpSeq[Int]
+  def subtract(a: Int, b: Int): FS[Int]
 }
 
 @module trait Example[F[_]] {

--- a/docs/src/main/tut/docs/patterns/config/README.md
+++ b/docs/src/main/tut/docs/patterns/config/README.md
@@ -32,9 +32,9 @@ sealed trait Config {
 }
 
 @free sealed trait ConfigM {
-  def load: OpSeq[Config]
-  def empty: OpSeq[Config]
-  def parseString(s: String): OpSeq[Config]
+  def load: FS[Config]
+  def empty: FS[Config]
+  def parseString(s: String): FS[Config]
 }
 ```
 
@@ -66,7 +66,7 @@ We will define a very simple algebra with a stub handler that returns a list of 
 
 ```tut:book
 @free trait IssuesService {
-  def states: OpSeq[List[String]]
+  def states: FS[List[String]]
 }
 
 implicit val issuesServiceHandler: IssuesService.Handler[Try] = new IssuesService.Handler[Try] {

--- a/docs/src/main/tut/docs/patterns/logging/README.md
+++ b/docs/src/main/tut/docs/patterns/logging/README.md
@@ -21,14 +21,14 @@ The set of abstract operations of the `Logging` algebra are specified as follows
 
 ```scala
 @free trait LoggingM {
-  def debug(msg: String): OpSeq[Unit]
-  def debugWithCause(msg: String, cause: Throwable): OpSeq[Unit]
-  def error(msg: String): OpSeq[Unit]
-  def errorWithCause(msg: String, cause: Throwable): OpSeq[Unit]
-  def info(msg: String): OpSeq[Unit]
-  def infoWithCause(msg: String, cause: Throwable): OpSeq[Unit]
-  def warn(msg: String): OpSeq[Unit]
-  def warnWithCause(msg: String, cause: Throwable): OpSeq[Unit]
+  def debug(msg: String): FS[Unit]
+  def debugWithCause(msg: String, cause: Throwable): FS[Unit]
+  def error(msg: String): FS[Unit]
+  def errorWithCause(msg: String, cause: Throwable): FS[Unit]
+  def info(msg: String): FS[Unit]
+  def infoWithCause(msg: String, cause: Throwable): FS[Unit]
+  def warn(msg: String): FS[Unit]
+  def warnWithCause(msg: String, cause: Throwable): FS[Unit]
 }
 ```
 
@@ -56,7 +56,7 @@ We will define a simple algebra with a stub handler that returns a list of custo
 
 ```tut:book
 @free trait CustomerService {
-  def customers: OpSeq[List[String]]
+  def customers: FS[List[String]]
 }
 
 implicit val customerServiceHandler: CustomerService.Handler[Try] = new CustomerService.Handler[Try] {

--- a/docs/src/main/tut/docs/stack/README.md
+++ b/docs/src/main/tut/docs/stack/README.md
@@ -35,12 +35,12 @@ We will represent these capabilities using two algebras: `CustomerPersistence` a
 ```tut:book
 object algebras {
   @free trait CustomerPersistence {
-    def getCustomer(id: CustomerId): OpPar[Option[Customer]]
+    def getCustomer(id: CustomerId): FS[Option[Customer]]
   }
 
   @free trait StockPersistence {
-    def checkQuantityAvailable(variety: String): OpPar[Int]
-    def registerOrder(order: Order): OpPar[Unit]
+    def checkQuantityAvailable(variety: String): FS[Int]
+    def registerOrder(order: Order): FS[Unit]
   }
 }
 ```

--- a/freestyle-cache/shared/src/main/scala/cache.scala
+++ b/freestyle-cache/shared/src/main/scala/cache.scala
@@ -31,34 +31,34 @@ package cache {
     @free sealed trait CacheM {
 
       // Gets the value associated to a key, if there is one */
-      def get(key: Key): OpPar[Option[Val]]
+      def get(key: Key): FS[Option[Val]]
 
       // Sets the value of a key to a newValue.
-      def put(key: Key, newVal: Val): OpPar[Unit]
+      def put(key: Key, newVal: Val): FS[Unit]
 
       // Copy all of the mappings from the specified map to this cache
-      def putAll(keyValues: Map[Key, Val]): OpPar[Unit]
+      def putAll(keyValues: Map[Key, Val]): FS[Unit]
 
       //If the specified key is not already associated with a value, associate it with the given value.
-      def putIfAbsent(key: Key, newVal: Val): OpPar[Unit]
+      def putIfAbsent(key: Key, newVal: Val): FS[Unit]
 
       // Removes the entry for the key if one exists
-      def del(key: Key): OpPar[Unit]
+      def del(key: Key): FS[Unit]
 
       // Returns whether there is an entry for key or not.
-      def has(key: Key): OpPar[Boolean]
+      def has(key: Key): FS[Boolean]
 
       // Returns the set of keys in the store
-      def keys: OpPar[List[Key]]
+      def keys: FS[List[Key]]
 
       // Removes all entries
-      def clear: OpPar[Unit]
+      def clear: FS[Unit]
 
       //Replaces the entry for a key only if currently mapped to some value
-      def replace(key: Key, newVal: Val): OpPar[Unit]
+      def replace(key: Key, newVal: Val): FS[Unit]
 
       //Returns true if this cache contains no key-value mappings.
-      def isEmpty: OpPar[Boolean]
+      def isEmpty: FS[Boolean]
 
     }
 

--- a/freestyle-config/src/main/scala/config.scala
+++ b/freestyle-config/src/main/scala/config.scala
@@ -36,9 +36,9 @@ object config {
   }
 
   @free sealed trait ConfigM {
-    def load: OpSeq[Config]
-    def empty: OpSeq[Config]
-    def parseString(s: String): OpSeq[Config]
+    def load: FS[Config]
+    def empty: FS[Config]
+    def parseString(s: String): FS[Config]
   }
 
   object implicits {

--- a/freestyle-config/src/test/scala/config.scala
+++ b/freestyle-config/src/test/scala/config.scala
@@ -59,7 +59,7 @@ class ConfigTests extends AsyncWordSpec with Matchers {
 object algebras {
   @free
   trait NonConfig {
-    def x: OpSeq[Int]
+    def x: FS[Int]
   }
 
   implicit def nonConfigHandler: NonConfig.Handler[Future] =

--- a/freestyle-doobie/src/main/scala/doobie.scala
+++ b/freestyle-doobie/src/main/scala/doobie.scala
@@ -23,7 +23,7 @@ import fs2.util.{Catchable, Suspendable}
 object doobie {
 
   @free sealed trait DoobieM {
-    def transact[A](f: ConnectionIO[A]): OpPar[A]
+    def transact[A](f: ConnectionIO[A]): FS[A]
   }
 
   object implicits {

--- a/freestyle-doobie/src/test/scala/doobie.scala
+++ b/freestyle-doobie/src/test/scala/doobie.scala
@@ -74,7 +74,7 @@ class DoobieTests extends AsyncWordSpec with Matchers {
 object algebras {
   @free
   trait NonDoobie {
-    def x: OpSeq[Int]
+    def x: FS[Int]
   }
 
   implicit def nonDoobieHandler: NonDoobie.Handler[Task] =

--- a/freestyle-effects/shared/src/main/scala/effects/either.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/either.scala
@@ -25,9 +25,9 @@ object either {
   final class ErrorProvider[E] {
 
     @free sealed trait EitherM {
-      def either[A](fa: Either[E, A]): OpPar[A]
-      def error[A](e: E): OpPar[A]
-      def catchNonFatal[A](a: Eval[A], f: Throwable => E): OpPar[A]
+      def either[A](fa: Either[E, A]): FS[A]
+      def error[A](e: E): FS[A]
+      def catchNonFatal[A](a: Eval[A], f: Throwable => E): FS[A]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/main/scala/effects/error.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/error.scala
@@ -22,9 +22,9 @@ import cats.{Eval, MonadError}
 object error {
 
   @free sealed trait ErrorM {
-    def either[A](fa: Either[Throwable, A]): OpPar[A]
-    def error[A](e: Throwable): OpPar[A]
-    def catchNonFatal[A](a: Eval[A]): OpPar[A]
+    def either[A](fa: Either[Throwable, A]): FS[A]
+    def error[A](e: Throwable): FS[A]
+    def catchNonFatal[A](a: Eval[A]): FS[A]
   }
 
   trait ErrorImplicits {

--- a/freestyle-effects/shared/src/main/scala/effects/option.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/option.scala
@@ -22,8 +22,8 @@ import cats.MonadFilter
 object option {
 
   @free sealed trait OptionM {
-    def option[A](fa: Option[A]): OpPar[A]
-    def none[A]: OpPar[A]
+    def option[A](fa: Option[A]): FS[A]
+    def none[A]: FS[A]
   }
 
   trait OptionImplicits {

--- a/freestyle-effects/shared/src/main/scala/effects/reader.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/reader.scala
@@ -24,8 +24,8 @@ object reader {
   final class EnvironmentProvider[R] {
 
     @free abstract class ReaderM {
-      def ask: OpPar[R]
-      def reader[B](f: R => B): OpPar[B]
+      def ask: FS[R]
+      def reader[B](f: R => B): FS[B]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/main/scala/effects/state.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/state.scala
@@ -24,10 +24,10 @@ object state {
   final class StateSeedProvider[S] {
 
     @free sealed abstract class StateM {
-      def get: OpPar[S]
-      def set(s: S): OpPar[Unit]
-      def modify(f: S => S): OpPar[Unit]
-      def inspect[A](f: S => A): OpPar[A]
+      def get: FS[S]
+      def set(s: S): FS[Unit]
+      def modify(f: S => S): FS[Unit]
+      def inspect[A](f: S => A): FS[A]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/main/scala/effects/traverse.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/traverse.scala
@@ -26,8 +26,8 @@ object traverse {
     /** Acts as a generator providing traversable semantics to programs
      */
     @free sealed abstract class TraverseM {
-      def empty[A]: OpPar[A]
-      def fromTraversable[A](ta: G[A]): OpPar[A]
+      def empty[A]: FS[A]
+      def fromTraversable[A](ta: G[A]): FS[A]
     }
 
     /** Interpretable as long as Foldable instance for G[_] and a MonadCombine for M[_] exists

--- a/freestyle-effects/shared/src/main/scala/effects/validation.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/validation.scala
@@ -27,15 +27,15 @@ object validation {
 
     /** An algebra for introducing validation semantics in a program. **/
     @free sealed trait ValidationM {
-      def valid[A](x: A): OpPar[A]
+      def valid[A](x: A): FS[A]
 
-      def invalid(err: E): OpPar[Unit]
+      def invalid(err: E): FS[Unit]
 
-      def errors: OpPar[Errors]
+      def errors: FS[Errors]
 
-      def fromEither[A](x: Either[E, A]): OpPar[Either[E, A]]
+      def fromEither[A](x: Either[E, A]): FS[Either[E, A]]
 
-      def fromValidatedNel[A](x: ValidatedNel[E, A]): OpPar[ValidatedNel[E, A]]
+      def fromValidatedNel[A](x: ValidatedNel[E, A]): FS[ValidatedNel[E, A]]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/main/scala/effects/writer.scala
+++ b/freestyle-effects/shared/src/main/scala/effects/writer.scala
@@ -24,8 +24,8 @@ object writer {
   final class AccumulatorProvider[W] {
 
     @free sealed abstract class WriterM {
-      def writer[A](aw: (W, A)): OpPar[A]
-      def tell(w: W): OpPar[Unit]
+      def writer[A](aw: (W, A)): FS[A]
+      def tell(w: W): FS[Unit]
     }
 
     object implicits {

--- a/freestyle-effects/shared/src/test/scala/effects/EffectsTests.scala
+++ b/freestyle-effects/shared/src/test/scala/effects/EffectsTests.scala
@@ -550,22 +550,22 @@ object collision {
 
   @free
   trait B {
-    def x: OpSeq[Int]
+    def x: FS[Int]
   }
 
   @free
   trait C {
-    def x: OpSeq[Int]
+    def x: FS[Int]
   }
 
   @free
   trait D {
-    def x: OpSeq[Int]
+    def x: FS[Int]
   }
 
   @free
   trait E {
-    def x: OpSeq[Int]
+    def x: FS[Int]
   }
 
   @module

--- a/freestyle-fetch/shared/src/main/scala/fetch.scala
+++ b/freestyle-fetch/shared/src/main/scala/fetch.scala
@@ -21,12 +21,12 @@ import _root_.fetch._
 object fetch {
 
   @free sealed trait FetchM {
-    def runA[A](f: Fetch[A]): OpPar[A]
-    def runF[A](f: Fetch[A]): OpPar[(FetchEnv, A)]
-    def runE[A](f: Fetch[A]): OpPar[FetchEnv]
-    def runAWithCache[A](f: Fetch[A], cache: DataSourceCache): OpPar[A]
-    def runFWithCache[A](f: Fetch[A], cache: DataSourceCache): OpPar[(FetchEnv, A)]
-    def runEWithCache[A](f: Fetch[A], cache: DataSourceCache): OpPar[FetchEnv]
+    def runA[A](f: Fetch[A]): FS[A]
+    def runF[A](f: Fetch[A]): FS[(FetchEnv, A)]
+    def runE[A](f: Fetch[A]): FS[FetchEnv]
+    def runAWithCache[A](f: Fetch[A], cache: DataSourceCache): FS[A]
+    def runFWithCache[A](f: Fetch[A], cache: DataSourceCache): FS[(FetchEnv, A)]
+    def runEWithCache[A](f: Fetch[A], cache: DataSourceCache): FS[FetchEnv]
   }
 
   object implicits {

--- a/freestyle-fetch/shared/src/test/scala/FetchTests.scala
+++ b/freestyle-fetch/shared/src/test/scala/FetchTests.scala
@@ -92,7 +92,7 @@ class FetchTests extends AsyncWordSpec with Matchers {
 object algebras {
   @free
   trait NonFetch {
-    def x: OpSeq[Int]
+    def x: FS[Int]
   }
 
   implicit def nonFetchHandler: NonFetch.Handler[Future] =

--- a/freestyle-fs2/shared/src/main/scala/fs2.scala
+++ b/freestyle-fs2/shared/src/main/scala/fs2.scala
@@ -48,10 +48,10 @@ object fs2 {
   }
 
   @free sealed trait StreamM {
-    def run[A](s: Stream[Eff, A]): OpPar[Unit]
-    def runLog[A](s: Stream[Eff, A]): OpPar[Vector[A]]
-    def runFold[A, B](z: B, f: (B, A) => B)(s: Stream[Eff, A]): OpPar[B]
-    def runLast[A](s: Stream[Eff, A]): OpPar[Option[A]]
+    def run[A](s: Stream[Eff, A]): FS[Unit]
+    def runLog[A](s: Stream[Eff, A]): FS[Vector[A]]
+    def runFold[A, B](z: B, f: (B, A) => B)(s: Stream[Eff, A]): FS[B]
+    def runLast[A](s: Stream[Eff, A]): FS[Option[A]]
   }
 
   object implicits {

--- a/freestyle-fs2/shared/src/test/scala/Fs2Tests.scala
+++ b/freestyle-fs2/shared/src/test/scala/Fs2Tests.scala
@@ -125,7 +125,7 @@ class Fs2Tests extends AsyncWordSpec with Matchers {
 object algebras {
   @free
   trait NonStream {
-    def x: OpSeq[Int]
+    def x: FS[Int]
   }
 
   implicit def nonStreamHandler: NonStream.Handler[Future] =

--- a/freestyle-logging/shared/src/main/scala/logging.scala
+++ b/freestyle-logging/shared/src/main/scala/logging.scala
@@ -21,21 +21,21 @@ object logging {
   @free
   trait LoggingM {
 
-    def debug(msg: String): OpSeq[Unit]
+    def debug(msg: String): FS[Unit]
 
-    def debugWithCause(msg: String, cause: Throwable): OpSeq[Unit]
+    def debugWithCause(msg: String, cause: Throwable): FS[Unit]
 
-    def error(msg: String): OpSeq[Unit]
+    def error(msg: String): FS[Unit]
 
-    def errorWithCause(msg: String, cause: Throwable): OpSeq[Unit]
+    def errorWithCause(msg: String, cause: Throwable): FS[Unit]
 
-    def info(msg: String): OpSeq[Unit]
+    def info(msg: String): FS[Unit]
 
-    def infoWithCause(msg: String, cause: Throwable): OpSeq[Unit]
+    def infoWithCause(msg: String, cause: Throwable): FS[Unit]
 
-    def warn(msg: String): OpSeq[Unit]
+    def warn(msg: String): FS[Unit]
 
-    def warnWithCause(msg: String, cause: Throwable): OpSeq[Unit]
+    def warnWithCause(msg: String, cause: Throwable): FS[Unit]
   }
 
 }

--- a/freestyle-logging/shared/src/test/scala/algebras.scala
+++ b/freestyle-logging/shared/src/test/scala/algebras.scala
@@ -24,7 +24,7 @@ object algebras {
 
   @free
   trait NonLogging {
-    def x: OpSeq[Int]
+    def x: FS[Int]
   }
 
   implicit def nonLoggingHandler: NonLogging.Handler[Future] =

--- a/freestyle-slick/src/main/scala/slick.scala
+++ b/freestyle-slick/src/main/scala/slick.scala
@@ -28,7 +28,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 object slick {
 
   @free sealed trait SlickM {
-    def run[A](f: DBIO[A]): OpPar[A]
+    def run[A](f: DBIO[A]): FS[A]
   }
 
   object implicits {

--- a/freestyle-slick/src/test/scala/slick.scala
+++ b/freestyle-slick/src/test/scala/slick.scala
@@ -74,7 +74,7 @@ class SlickTests extends AsyncWordSpec with Matchers {
 object algebras {
   @free
   trait NonSlick {
-    def x: OpSeq[Int]
+    def x: FS[Int]
   }
 
   implicit def nonSlickHandler: NonSlick.Handler[Future] =

--- a/freestyle-twitter-util/src/test/scala/TwitterUtilTests.scala
+++ b/freestyle-twitter-util/src/test/scala/TwitterUtilTests.scala
@@ -97,9 +97,9 @@ object algebras {
 
   @free
   trait MixedFreeS {
-    def x: OpPar[Int]
-    def y: OpPar[Int]
-    def z: OpSeq[Int]
+    def x: FS[Int]
+    def y: FS[Int]
+    def z: FS[Int]
   }
 
 }

--- a/freestyle/jvm/src/test/scala/freestyle/parallel.scala
+++ b/freestyle/jvm/src/test/scala/freestyle/parallel.scala
@@ -123,8 +123,8 @@ class parallelTests extends WordSpec with Matchers {
 
       @free
       trait Validation {
-        def minSize(n: Int): OpPar[Boolean]
-        def hasNumber: OpPar[Boolean]
+        def minSize(n: Int): FS[Boolean]
+        def hasNumber: FS[Boolean]
       }
 
       implicit val interpreter = new Validation.Handler[ParValidator] {

--- a/freestyle/shared/src/main/scala/freestyle/free.scala
+++ b/freestyle/shared/src/main/scala/freestyle/free.scala
@@ -20,8 +20,10 @@ import scala.reflect.macros.blackbox.Context
 
 trait EffectLike[F[_]] {
   final type FS[A] = FreeS.Par[F, A]
-  final type OpSeq[A] = FreeS[F, A]
-  final type OpPar[A] = FreeS.Par[F, A]
+  final object FS {
+    final type Seq[A] = FreeS[F, A]
+    final type Par[A] = FreeS.Par[F, A]
+  }
 }
 
 object freeImpl {

--- a/freestyle/shared/src/main/scala/freestyle/package.scala
+++ b/freestyle/shared/src/main/scala/freestyle/package.scala
@@ -58,15 +58,14 @@ package object freestyle {
     def liftPar[F[_], A](freeap: FreeS.Par[F, A]): FreeS[F, A] =
       Free.liftF(freeap)
 
-    def inject[F[_], G[_]]: FreeSParInjectPartiallyApplied[F, G] =
+    def inject[F[_], G[_]](implicit I: Inject[F, G]): FreeSParInjectPartiallyApplied[F, G] =
       new FreeSParInjectPartiallyApplied
 
     /**
      * Pre-application of an injection to a `F[A]` value.
      */
-    final class FreeSParInjectPartiallyApplied[F[_], G[_]] {
-      def apply[A](fa: F[A])(implicit I: Inject[F, G]): FreeS.Par[G, A] =
-        FreeApplicative.lift(I.inj(fa))
+    final class FreeSParInjectPartiallyApplied[F[_], G[_]](implicit I: Inject[F, G]) {
+      def apply[A](fa: F[A]): FreeS.Par[G, A] = FreeApplicative.lift(I.inj(fa))
     }
 
     /**

--- a/freestyle/shared/src/main/scala/freestyle/package.scala
+++ b/freestyle/shared/src/main/scala/freestyle/package.scala
@@ -51,22 +51,17 @@ package object freestyle {
       Free.liftF(FreeApplicative.lift(fa))
 
     /** Lift a sequential `Free[F, A]` into `FreeS[F, A]` */
-    def liftSeq[F[_], A](free: Free[F, A]): FreeS[F, A] =
-      free.compile(λ[(F ~> FreeS.Par[F, ?])](fa => FreeApplicative.lift(fa)))
+    def liftSeq[F[_], A](free: Free[F, A]): FreeS[F, A] = {
+      val lifter = λ[(F ~> FreeS.Par[F, ?])](fa => FreeApplicative.lift(fa))
+      free.compile(lifter)
+    }
 
     /** Lift a parallel `FreeApplicative[F, A]` into `FreeS[F, A]` */
     def liftPar[F[_], A](freeap: FreeS.Par[F, A]): FreeS[F, A] =
       Free.liftF(freeap)
 
-    def inject[F[_], G[_]](implicit I: Inject[F, G]): FreeSParInjectPartiallyApplied[F, G] =
-      new FreeSParInjectPartiallyApplied
-
-    /**
-     * Pre-application of an injection to a `F[A]` value.
-     */
-    final class FreeSParInjectPartiallyApplied[F[_], G[_]](implicit I: Inject[F, G]) {
-      def apply[A](fa: F[A]): FreeS.Par[G, A] = FreeApplicative.lift(I.inj(fa))
-    }
+    def inject[F[_], G[_]](implicit I: Inject[F, G]): F ~> FreeS.Par[G, ?] =
+      λ[F ~> FreeS.Par[G, ?]](fa => FreeApplicative.lift(I.inj(fa) ) )
 
     /**
      * Lift a pure `A` value `FreeS[F, A]`.
@@ -110,8 +105,8 @@ package object freestyle {
      */
     def freeS: FreeS[F, A] = FreeS.liftPar(fa)
 
-    def exec[G[_]: Applicative](implicit interpreter: F ~> G): G[A] =
-      fa.foldMap(interpreter)
+    def exec[G[_]: Applicative](implicit handler: FSHandler[F,G]): G[A] =
+      fa.foldMap(handler)
   }
 
   /**

--- a/freestyle/shared/src/test/scala/freestyle/Utils.scala
+++ b/freestyle/shared/src/test/scala/freestyle/Utils.scala
@@ -20,43 +20,43 @@ import cats.arrow.FunctionK
 
 @free
 trait SCtors1 {
-  def x(a: Int): OpSeq[Int]
-  def y(a: Int): OpSeq[Int]
+  def x(a: Int): FS[Int]
+  def y(a: Int): FS[Int]
 }
 
 @free
 trait SCtors2 {
-  def i(a: Int): OpSeq[Int]
-  def j(a: Int): OpSeq[Int]
+  def i(a: Int): FS[Int]
+  def j(a: Int): FS[Int]
 }
 
 @free
 trait SCtors3 {
-  def o(a: Int): OpSeq[Int]
-  def p(a: Int): OpSeq[Int]
+  def o(a: Int): FS[Int]
+  def p(a: Int): FS[Int]
 }
 
 @free
 trait SCtors4 {
-  def k(a: Int): OpSeq[Int]
-  def m(a: Int): OpSeq[Int]
+  def k(a: Int): FS[Int]
+  def m(a: Int): FS[Int]
 }
 
 @free
 trait MixedFreeS {
-  def x: OpPar[Int]
-  def y: OpPar[Int]
-  def z: OpSeq[Int]
+  def x: FS[Int]
+  def y: FS[Int]
+  def z: FS[Int]
 }
 
 @free
 trait S1 {
-  def x(n: Int): OpSeq[Int]
+  def x(n: Int): FS[Int]
 }
 
 @free
 trait S2 {
-  def y(n: Int): OpSeq[Int]
+  def y(n: Int): FS[Int]
 }
 
 

--- a/freestyle/shared/src/test/scala/freestyle/free.scala
+++ b/freestyle/shared/src/test/scala/freestyle/free.scala
@@ -31,7 +31,7 @@ class freeTests extends WordSpec with Matchers {
     }
 
     "be rejected if applied to a trait with companion object" in {
-      """ @free trait Foo {def f: OpSeq[Int]} ; object Foo """ shouldNot compile
+      """ @free trait Foo {def f: FS[Int]} ; object Foo """ shouldNot compile
     }
 
     "create a companion with a `Op` type alias" in {
@@ -80,22 +80,22 @@ class freeTests extends WordSpec with Matchers {
     "allow multiple args in smart constructors" in {
       @free
       trait MultiArgs {
-        def x(a: Int, b: Int, c: Int): OpSeq[Int]
+        def x(a: Int, b: Int, c: Int): FS[Int]
       }
     }
 
     "allow smart constructors with no args" in {
       @free
       trait NoArgs {
-        def x: OpSeq[Int]
+        def x: FS[Int]
       }
     }
 
     "generate ADTs with friendly names and expose them as dependent types" in {
       @free
       trait FriendlyFreeS {
-        def sc1(a: Int, b: Int, c: Int): OpSeq[Int]
-        def sc2(a: Int, b: Int, c: Int): OpSeq[Int]
+        def sc1(a: Int, b: Int, c: Int): FS[Int]
+        def sc2(a: Int, b: Int, c: Int): FS[Int]
       }
       implicitly[FriendlyFreeS.Op[_] =:= FriendlyFreeS.Op[_]]
       implicitly[FriendlyFreeS.Sc1OP <:< FriendlyFreeS.Op[Int]]
@@ -106,9 +106,9 @@ class freeTests extends WordSpec with Matchers {
     "allow smart constructors with type arguments" in {
       @free
       trait KVStore {
-        def put[A](key: String, value: A): OpSeq[Unit]
-        def get[A](key: String): OpSeq[Option[A]]
-        def delete(key: String): OpSeq[Unit]
+        def put[A](key: String, value: A): FS[Unit]
+        def get[A](key: String): FS[Option[A]]
+        def delete(key: String): FS[Unit]
       }
       val interpreter = new KVStore.Handler[List] {
         def put[A](key: String, value: A): List[Unit] = Nil
@@ -120,9 +120,9 @@ class freeTests extends WordSpec with Matchers {
     "allow evaluation of abstract members that return FreeS.Pars" in {
       @free
       trait ApplicativesServ {
-        def x(key: String): OpPar[String]
-        def y(key: String): OpPar[String]
-        def z(key: String): OpPar[String]
+        def x(key: String): FS[String]
+        def y(key: String): FS[String]
+        def z(key: String): FS[String]
       }
       implicit val interpreter = new ApplicativesServ.Handler[Option] {
         override def x(key: String): Option[String] = Some(key)
@@ -138,9 +138,9 @@ class freeTests extends WordSpec with Matchers {
     "allow sequential evaluation of combined FreeS & FreeS.Par" in {
       @free
       trait MixedFreeS {
-        def x(key: String): OpPar[String]
-        def y(key: String): OpPar[String]
-        def z(key: String): OpSeq[String]
+        def x(key: String): FS[String]
+        def y(key: String): FS[String]
+        def z(key: String): FS[String]
       }
       implicit val interpreter = new MixedFreeS.Handler[Option] {
         override def x(key: String): Option[String] = Some(key)
@@ -159,7 +159,7 @@ class freeTests extends WordSpec with Matchers {
 
     "allow non-FreeS concrete definitions in the trait" in {
       @free trait WithExtra {
-        def x(a: Int): OpPar[String]
+        def x(a: Int): FS[String]
         def y: Int = 5
         val z: Int = 6
       }
@@ -175,8 +175,8 @@ class freeTests extends WordSpec with Matchers {
 
     "allow `FreeS` operations that use other abstractoperations" in {
       @free trait Combine {
-        def x(a: Int): OpSeq[Int]
-        def y(a: Int): OpSeq[Boolean] = x(a).map { _ >= 0 }
+        def x(a: Int): FS[Int]
+        def y(a: Int): FS[Boolean] = x(a).map { _ >= 0 }
       }
       val v = Combine[Combine.Op]
       implicit val interpreter = new Combine.Handler[Id]{

--- a/freestyle/shared/src/test/scala/freestyle/implicits.scala
+++ b/freestyle/shared/src/test/scala/freestyle/implicits.scala
@@ -41,7 +41,7 @@ class implicitsTests extends WordSpec with Matchers {
     "enable sequence" in {
       implicit val optionHandler = interps.optionHandler1
       val s = SCtors1[SCtors1.Op]
-      val program = List(s.x(1), s.x(2)).sequence[FreeS[SCtors1.Op, ?], Int]
+      val program = List(s.x(1), s.x(2)).sequence[FreeS.Par[SCtors1.Op, ?], Int]
       program.exec[Option] shouldBe (Some(List(1, 2)))
     }
 
@@ -53,7 +53,7 @@ class implicitsTests extends WordSpec with Matchers {
 
     "provide a custom implicit not found message for a missing Capture instance" in {
       shapeless.test.illTyped(
-        """SCtors1[SCtors1.Op].x(1).exec[scala.util.Try]""",
+        """SCtors1[SCtors1.Op].x(1).freeS.exec[scala.util.Try]""",
         ".*Handler not found to transform.*")
     }
 

--- a/freestyle/shared/src/test/scala/freestyle/implicits.scala
+++ b/freestyle/shared/src/test/scala/freestyle/implicits.scala
@@ -33,27 +33,27 @@ class implicitsTests extends WordSpec with Matchers {
 
     "enable traverseU" in {
       implicit val optionHandler = interps.optionHandler1
-      val s = SCtors1[SCtors1.Op]
-      val program = List(1, 2).traverseU(s.x)
+      val program = List(1, 2).traverseU(SCtors1[SCtors1.Op].x)
       program.exec[Option] shouldBe (Some(List(1, 2)))
     }
 
     "enable sequence" in {
       implicit val optionHandler = interps.optionHandler1
-      val s = SCtors1[SCtors1.Op]
-      val program = List(s.x(1), s.x(2)).sequence[FreeS.Par[SCtors1.Op, ?], Int]
-      program.exec[Option] shouldBe (Some(List(1, 2)))
+      def program[F[_]](implicit sc: SCtors1[F]) =
+        List(sc.x(1), sc.x(2)).sequence[sc.FS.Par, Int]
+
+      program[SCtors1.Op].exec[Option] shouldBe (Some(List(1, 2)))
     }
 
-    "provide a custom implicit not found message for a missing implicit Handler" in {
+    "provide a custom implicit not found message for a missing Capture instance" in {
       shapeless.test.illTyped(
         """Capture[Option]""",
         ".*No Capture instance found for Option.*")
     }
 
-    "provide a custom implicit not found message for a missing Capture instance" in {
+    "provide a custom implicit not found message for a missing implicit Handler" in {
       shapeless.test.illTyped(
-        """SCtors1[SCtors1.Op].x(1).freeS.exec[scala.util.Try]""",
+        """SCtors1[SCtors1.Op].x(1).exec[scala.util.Try]""",
         ".*Handler not found to transform.*")
     }
 

--- a/freestyle/shared/src/test/scala/nopackage.scala
+++ b/freestyle/shared/src/test/scala/nopackage.scala
@@ -19,13 +19,13 @@
 import freestyle._
 
 @free trait Logitech {
-  def eyes(s: String): OpPar[Boolean]
-  def skills(s: String): OpPar[Boolean]
+  def eyes(s: String): FS[Boolean]
+  def skills(s: String): FS[Boolean]
 }
 
 @free trait Asia {
-  def recycled(msg: String): OpSeq[Unit]
-  def rhino(prompt: String): OpSeq[String]
+  def recycled(msg: String): FS[Unit]
+  def rhino(prompt: String): FS[String]
 }
 
 @module trait Age[F[_]] {

--- a/http/akka/src/test/scala/freestyle/http/AkkaHttpTests.scala
+++ b/http/akka/src/test/scala/freestyle/http/AkkaHttpTests.scala
@@ -64,8 +64,8 @@ object userrepo {
 
   @free
   trait UserApp {
-    def get(id: Int): OpPar[User]
-    def list: OpSeq[List[User]]
+    def get(id: Int): FS[User]
+    def list: FS[List[User]]
   }
 
   implicit val handler: UserApp.Handler[Id] = new UserApp.Handler[Id] {

--- a/http/finch/src/test/scala/http/FinchTests.scala
+++ b/http/finch/src/test/scala/http/FinchTests.scala
@@ -109,7 +109,7 @@ class FinchTests extends AsyncWordSpec with Matchers {
 object algebra {
   @free
   trait Calc {
-    def sum(a: Int, b: Int): OpPar[Int]
+    def sum(a: Int, b: Int): FS[Int]
   }
 }
 

--- a/http/http4s/src/test/scala/http/Http4sTest.scala
+++ b/http/http4s/src/test/scala/http/Http4sTest.scala
@@ -80,8 +80,8 @@ object algebras {
 
   @free
   trait UserRepository {
-    def get(id: Long): OpPar[User]
-    def list: OpPar[List[User]]
+    def get(id: Long): FS[User]
+    def list: FS[List[User]]
   }
 
   @module

--- a/http/play/src/main/scala/play.scala
+++ b/http/play/src/main/scala/play.scala
@@ -19,19 +19,22 @@ package freestyle.http
 import freestyle._
 
 import cats.Monad
+import cats.arrow.FunctionK
 import cats.instances.future._
 
-import scala.concurrent._
+import scala.concurrent.{ExecutionContext, Future}
 
-import _root_.play.api.mvc._
-import _root_.play.api.http._
-
-object play {
+package play {
 
   object implicits {
 
-    implicit def freestylePlayFutureConversion[F[_], A](prog: FreeS[F, A])(
+    implicit def seqToFuture[F[_], A](prog: FreeS[F, A])(
         implicit I: ParInterpreter[F, Future],
+        EC: ExecutionContext
+    ): Future[A] = prog.exec[Future]
+
+    implicit def parToFuture[F[_], A](prog: FreeS.Par[F, A])(
+        implicit I: FunctionK[F, Future],
         EC: ExecutionContext
     ): Future[A] = prog.exec[Future]
 

--- a/http/play/src/test/scala/PlayTests.scala
+++ b/http/play/src/test/scala/PlayTests.scala
@@ -58,7 +58,7 @@ class PlayTests extends AsyncWordSpec with Matchers {
 
     "FreeS programs can interact with a given request and used as returned values in Play actions" in {
       Action.async { request =>
-        Noop[Noop.Op].noop.map(_ => Results.Ok(request.method))
+        Noop[Noop.Op].noop.map(_ => Results.Ok(request.method)).freeS
       } shouldBe an[Action[Result]]
     }
   }
@@ -67,7 +67,7 @@ class PlayTests extends AsyncWordSpec with Matchers {
 object algebras {
   @free
   trait Noop {
-    def noop: OpSeq[Unit]
+    def noop: FS[Unit]
   }
 }
 

--- a/tests/src/main/resources/pcplodtest.scala
+++ b/tests/src/main/resources/pcplodtest.scala
@@ -20,7 +20,7 @@ import cats.implicits._
 
 object pcplodtest {
   @free trait PcplodTestAlgebra {
-    def test(n: Int): OpPar[Int]
+    def test(n: Int): FS[Int]
   }
   implicit val impl = new PcplodTestAlgebra.H@handler@andler[Option] {
     override def test(n:Int): Option[Int] = Some(1)


### PR DESCRIPTION
This PR addresses issue #234. The goal of this issue is that, in the effect-algebra traits (those annotated with `@free`), there should be no separation between _parallel_ or _sequential_ operations. To achieve this, the changes in this PR modify the `@free` macro annotation as follows: 

* In the `EffectLike` trait we add a new type alias, `FS[A] = FreeS.Par[A]`. 
* We add a sanity check: in a `@free`-annotated trait, all abstract methods should have as return type `FS[_]`. 
* We keep the aliases `OpPar` and `OpSeq`, to be used for those methods in the trait that are declared and implemented, since this implementation is based on the monadic or applicative operations for `FreeS` and `FreeS.Par`. 
* (not directly related to the issue) we modify the `FreeS.inject` method, so that we build the _Injector_ object once, using the base `Inject` instance.


