### PR TITLE
FS-165 Module looks from Root

### DIFF
--- a/docs/src/main/scala/docs.scala
+++ b/docs/src/main/scala/docs.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.docs
+
+import freestyle._
+
+@free
+trait Validation {
+  def minSize(s: String, n: Int): FS[Boolean]
+  def hasNumber(s: String): FS[Boolean]
+}
+
+@free
+trait Interaction {
+  def tell(msg: String): FS[Unit]
+  def ask(prompt: String): FS[String]
+}

--- a/docs/src/main/scala/integrations.scala
+++ b/docs/src/main/scala/integrations.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.docs.integrations
+
+import freestyle._
+
+@free
+trait Calc {
+  def subtract(a: Int, b: Int): FS[Int]
+}
+
+@free
+trait Interact {
+  def tell(msg: String): FS[Unit]
+}

--- a/docs/src/main/scala/interpreters.scala
+++ b/docs/src/main/scala/interpreters.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.docs.core.interpreters
+
+import cats.syntax.applicative._
+import freestyle._
+
+@free
+trait KVStore {
+  def put[A](key: String, value: A): FS[Unit]
+  def get[A](key: String): FS[Option[A]]
+  def delete(key: String): FS[Unit]
+  def update[A](key: String, f: A => A): FS.Seq[Unit] =
+    get[A](key).freeS flatMap {
+      case Some(a) => put[A](key, f(a)).freeS
+      case None    => ().pure[FS.Seq]
+    }
+}
+
+@free
+trait Log {
+  def info(msg: String): FS[Unit]
+  def warn(msg: String): FS[Unit]
+}

--- a/docs/src/main/scala/modules.scala
+++ b/docs/src/main/scala/modules.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.docs.core.modules
+
+import freestyle._
+
+@free
+trait Cache {
+  def get(id: Int): FS[Option[Int]]
+}
+@free
+trait Database {
+  def get(id: Int): FS[Int]
+}
+@free
+trait IdValidation {
+  def validate(id: Option[Int]): FS[Int]
+}
+@free
+trait Presenter {
+  def show(id: Int): FS[Int]
+}
+
+@module
+trait Persistence[F[_]] {
+  val database: Database[F]
+  val cache: Cache[F]
+}
+@module
+trait Display[F[_]] {
+  val presenter: Presenter[F]
+  val validator: IdValidation[F]
+}

--- a/docs/src/main/scala/patterns.scala
+++ b/docs/src/main/scala/patterns.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.docs.patterns
+
+import freestyle._
+
+@free
+trait CustomerService {
+  def customers: FS[List[String]]
+}
+
+@free
+trait IssuesService {
+  def states: FS[List[String]]
+}

--- a/docs/src/main/scala/stack.scala
+++ b/docs/src/main/scala/stack.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.docs.stack
+
+import freestyle._
+
+object types {
+  type CustomerId = java.util.UUID
+}
+
+import types._
+
+case class Customer(id: CustomerId, name: String)
+case class Order(crates: Int, variety: String, customerId: CustomerId)
+case class Config(varieties: Set[String])
+
+@free
+trait CustomerPersistence {
+  def getCustomer(id: CustomerId): FS[Option[Customer]]
+}
+
+@free
+trait StockPersistence {
+  def checkQuantityAvailable(variety: String): FS[Int]
+  def registerOrder(order: Order): FS[Unit]
+}
+
+@module
+trait Persistence[F[_]] {
+  val customer: CustomerPersistence[F]
+  val stock: StockPersistence[F]
+}

--- a/docs/src/main/tut/docs/README.md
+++ b/docs/src/main/tut/docs/README.md
@@ -40,7 +40,6 @@ In the example below we will define two algebras with intermixed sequential and 
 
 ```tut:book
 import freestyle._
-import freestyle.implicits._
 
 @free trait Validation {
   def minSize(s: String, n: Int): FS[Boolean]
@@ -60,6 +59,10 @@ Learn more about [algebras](./core/algebras) in the extended documentation.
 Freestyle algebras can be combined into `@module` definitions which provide aggregation and unification over the
 parametrization of Free programs.
 
+```tut:reset:silent
+import freestyle._
+import freestyle.docs._
+```
 ```tut:book
 @module trait Application[F[_]] {
   val validation: Validation[F]
@@ -80,9 +83,11 @@ Abstract definitions it's all it takes to start building programs that support s
 The example below combines both algebras to produce a more complex program
 
 ```tut:book
+import cats.syntax.cartesian._
+import freestyle.implicits._
+
 def program[F[_]](implicit A: Application[F]) = {
   import A._
-  import cats.implicits._
 
   for {
     userInput <- interaction.ask("Give me something with at least 3 chars and a number on it")
@@ -119,7 +124,7 @@ The mere fact that you provide implicit evidences for the individual steps enabl
 At this point we can run our pure programs at the edge of the world.
 
 ```tut:book
-import cats.implicits._
+import cats.instances.future._
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await
 

--- a/docs/src/main/tut/docs/core/interpreters/README.md
+++ b/docs/src/main/tut/docs/core/interpreters/README.md
@@ -36,6 +36,10 @@ import cats.implicits._
 ```
 
 To define a runtime interpreter for this, we simply extend `KVStore.Handler[M[_]]` and implement its abstract members:
+```tut:reset:invisible
+import freestyle._
+import freestyle.docs.core.interpreters._
+```
 
 ```tut:book
 import cats.data.State
@@ -81,9 +85,10 @@ implicit def manualKvStoreHandler: KVStore.Op ~> KVStoreState =
 
 Freestyle performs automatic composition of interpreters by providing the implicit machinery necessary to derive a Module interpreter
 by the evidence of it's algebras' interpreters.
-To illustrate interpreter composition, let's define a new algebra `Log` which we will compose with our `KVStore` operations:
+To illustrate interpreter composition, we define a new algebra `Log`, which we will compose with our `KVStore` operations. 
+The code for `Log` is available [here](../../../../scala/interpreters.scala).
 
-```tut:book
+```scala
 @free trait Log {
   def info(msg: String): FS[Unit]
   def warn(msg: String): FS[Unit]
@@ -94,6 +99,7 @@ Once our algebra is defined we can easily write an interpreter for it:
 
 ```tut:book
 import cats.implicits._
+import freestyle.docs.core.interpreters
 
 implicit def logHandler: Log.Handler[KVStoreState] = 
   new Log.Handler[KVStoreState] {

--- a/docs/src/main/tut/docs/integrations/doobie/README.md
+++ b/docs/src/main/tut/docs/integrations/doobie/README.md
@@ -71,10 +71,13 @@ task.unsafeRunSync.toOption
 Only using `DoobieM` is not exactly useful however, as it just adds an extra level of indirection on top of `ConnectionIO` in this case. As a more realistic example, we will use `DoobieM` in a module together with another algebra:
 
 
-```tut:book
+```scala
 @free trait Calc {
   def subtract(a: Int, b: Int): FS[Int]
 }
+```
+```tut:book
+import freestyle.docs.integrations.Calc
 
 @module trait Example[F[_]] {
   val doobieM: DoobieM[F]

--- a/docs/src/main/tut/docs/integrations/fetch/README.md
+++ b/docs/src/main/tut/docs/integrations/fetch/README.md
@@ -30,10 +30,7 @@ def fetchOne(x: Int): Fetch[Int] = Fetch(x)(OneSource)
 
 Let's start by creating a simple algebra for our application for printing messages on the screen:
 
-```tut:book
-import freestyle._
-import freestyle.implicits._
-
+```scala
 @free trait Interact {
   def tell(msg: String): FS[Unit]
 }
@@ -42,8 +39,10 @@ import freestyle.implicits._
 Then, make sure to include the Fetch algebra `FetchM` in your application:
 
 ```tut:book
+import freestyle._
 import freestyle.fetch._
 import freestyle.fetch.implicits._
+import freestyle.docs.integrations.Interact
 
 @module trait App[F[_]] {
   val interact: Interact[F]
@@ -54,9 +53,8 @@ import freestyle.fetch.implicits._
 Now that we've got our `Interact` algebra and `FetchM` in our app, we're ready to write the first program:
 
 ```tut:book
-def program[F[_]](
-  implicit app: App[F]
-): FreeS[F, Int] =  for {
+def program[F[_]]( implicit app: App[F] ): FreeS[F, Int] =  
+  for {
     _ <- app.interact.tell("Hello")
     x <- app.fetches.runA(fetchOne(1))
     _ <- app.interact.tell(s"Result: ${x}")
@@ -81,7 +79,9 @@ implicit def interactInterp[F[_]](
 Now we can run the program to a `Future`. Check how the result from the fetch is printed to the console:
 
 ```tut:book
-import scala.concurrent._
+import freestyle.implicits._
+
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/docs/src/main/tut/docs/integrations/fs2/README.md
+++ b/docs/src/main/tut/docs/integrations/fs2/README.md
@@ -12,9 +12,7 @@ Familiarity with fs2 is assumed, take a look at the [fs2 documentation](https://
 
 We'll start by creating a simple algebra for our application for printing messages on the screen:
 
-```tut:book
-import freestyle._
-
+```scala
 @free trait Interact {
   def tell(msg: String): FS[Unit]
 }
@@ -23,6 +21,7 @@ import freestyle._
 Then, make sure to include the streams algebra `StreamM` in your application:
 
 ```tut:book
+import freestyle.docs.integrations.Interact
 import freestyle._
 import freestyle.implicits._
 import freestyle.fs2._
@@ -51,7 +50,7 @@ def program[F[_]](
 To run it, we need to create an implicit interpreter for our `Interact` algebra:
 
 ```tut:book
-import cats._
+import cats.MonadError
 
 implicit def interactInterp[F[_]](
   implicit ME: MonadError[F, Throwable]
@@ -68,8 +67,8 @@ And now we can run the program to a `Future`. Check how the stream's value is pr
 ```tut:book
 import cats.instances.future._
 
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 
 Await.result(program[App.Op].exec[Future], Duration.Inf)

--- a/docs/src/main/tut/docs/integrations/slick/README.md
+++ b/docs/src/main/tut/docs/integrations/slick/README.md
@@ -74,10 +74,14 @@ Await.result(future, Duration.Inf)
 Only using `SlickM` is not exactly useful in this case as it just adds an extra level of indirection on top of `DBIO`. As a more realistic example, we will use `SlickM` in a module together with another algebra:
 
 
-```tut:book
+```scala
 @free trait Calc {
   def subtract(a: Int, b: Int): FS[Int]
 }
+```
+
+```tut:book
+import freestyle.docs.integrations.Calc
 
 @module trait Example[F[_]] {
   val slickM: SlickM[F]

--- a/freestyle/shared/src/main/scala/freestyle/module.scala
+++ b/freestyle/shared/src/main/scala/freestyle/module.scala
@@ -73,13 +73,13 @@ object openUnion {
     val AA = freshTypeName("AA$")
 
     def mkCoproduct(algebras: List[Type]): List[TypeDef] =
-      algebras.map(x => TermName(x.toString) ) match {
+      algebras.map(x => TermName(s"_root_.${x.toString}" )) match {
         case Nil => q"type Op[$AA] = Nothing" :: Nil
 
         case alg :: Nil => q"type Op[$AA] = $alg.Op[$AA]" :: Nil
 
         case alg0 :: alg1 :: algs =>
-          /* We create several type aliases, where the type names are generated fresh names, 
+          /* We create several type aliases, where the type names are generated fresh names,
            * C0, C1, ..., C{n-1}, where n is the length of algebras. We then generate aliases: 
            *
            * type C1 = A1 |+| A0
@@ -88,8 +88,7 @@ object openUnion {
            * type C{n-1} = A{n-1} |+| C{n-2
            * type Op{n-1}= C{n-1}
            */
-          val num = algebras.length
-          val ccs: List[TypeName] = List.range(0, num).map( i => freshTypeName("CC$") )
+          val ccs: List[TypeName] = algebras.map( _ => freshTypeName("CC$") )
           val tyDef1 = q"type ${ccs(1)}[$AA] = Coproduct[$alg1.Op, $alg0.Op, $AA]"
           val tyDefs = algebras.zipWithIndex.drop(2).map { case (alg, pos) =>
             q"type ${ccs(pos)}[$AA] = Coproduct[$alg.Op, ${ccs(pos-1)}, $AA]"
@@ -139,11 +138,11 @@ object moduleImpl {
       val effArgs: List[ValDef] = effVals.map( v => toImplArg(v) )
 
       q"""
-        object ${mod.toTermName} extends FreeModuleLike {
+        object ${mod.toTermName} extends _root_.freestyle.FreeModuleLike {
 
           import _root_.cats.data.Coproduct
 
-          val $xx = openUnion.apply(this)
+          val $xx = _root_.freestyle.openUnion.apply(this)
 
           type Op[$AA] = $xx.Op[$AA]
 

--- a/freestyle/shared/src/test/scala/freestyle/issues/Issue165.scala
+++ b/freestyle/shared/src/test/scala/freestyle/issues/Issue165.scala
@@ -14,22 +14,23 @@
  * limitations under the License.
  */
 
-// The purpose of this test is to see if freestyle still compiles classes in _root_ package. 
+/** This tests reproduces the bug in https://github.com/47deg/freestyle/issues/165
+  *
+  * The problem was that the "@module" macro was not using _root_ to start the type 
+  * references, which causes some collisions. This is a problem of macro hygiene.
+  */
+
+package issue165
 
 import freestyle._
 
+// The root of this package is freestyle.issue165.issue165
+object issue165
+
 @free trait India {
-  def kolkata(msg: String): FS[Unit]
-}
-
-package country {
-
-  @free trait China {
-    def beijing(msg: String): FS[Unit]
-  }
-
+  def kolkata: FS[Int]
 }
 
 @module trait Asia[F[_]] {
-  val china: country.China[F]
+  val india: India[F]
 }


### PR DESCRIPTION
This PR addresses ticket #165. It modifies the `@module` macro, so that now it looks for the `Op` types of the algebra using the `_root_ prefix. 

One side effect of this changes is that it restricts the  `@module` macro to use `@free` or `@module` traits with a defined `package`, which excludes those defined in a Scala console session, or (for extension) in a [tut](https://github.com/tpolecat/tut) book. For instance, pasting this to the console: 
```scala
import freestyle._
@free trait Foo { def x: FS[Int] }
@module trait Bar[F] {val y: Foo[F] }
```
would no longer work. For this reason we have to adapt the many `tut:book` items in the `docs`, adding a few Scala files.