### PR TITLE
FS-238 Remove F from Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ import freestyle._
   def get(id: UserId): FS[User]
 }
 
-@module trait Persistence[F[_]] {
-  val database: Database[F]
-  val cache: Cache[F]
+@module trait Persistence {
+  val database: Database
+  val cache: Cache
 }
 ```
 

--- a/docs/src/main/tut/README.md
+++ b/docs/src/main/tut/README.md
@@ -23,9 +23,9 @@ import freestyle._
   def get(id: UserId): FS[User]
 }
 
-@module trait Persistence[F[_]] {
-  val database: Database[F]
-  val cache: Cache[F]
+@module trait Persistence {
+  val database: Database
+  val cache: Cache
 }
 ```
 </div>

--- a/docs/src/main/tut/docs/README.md
+++ b/docs/src/main/tut/docs/README.md
@@ -65,9 +65,9 @@ Freestyle algebras can be combined into `@module` definitions which provide aggr
 parametrization of Free programs.
 
 ```tut:book
-@module trait Application[F[_]] {
-  val validation: Validation[F]
-  val interaction: Interaction[F]
+@module trait Application {
+  val validation: Validation
+  val interaction: Interaction
 }
 ```
 

--- a/docs/src/main/tut/docs/core/interpreters/README.md
+++ b/docs/src/main/tut/docs/core/interpreters/README.md
@@ -105,9 +105,9 @@ implicit def logHandler: Log.Handler[KVStoreState] =
 Before we create a program combining all operations, let’s consider both `KVStore` and `Log` as part of a module in our application:
 
 ```tut:book
-@module trait Backend[F[_]] {
-  val store: KVStore[F]
-  val log: Log[F]
+@module trait Backend {
+  val store: KVStore
+  val log: Log
 }
 ```
 

--- a/docs/src/main/tut/docs/core/modules/README.md
+++ b/docs/src/main/tut/docs/core/modules/README.md
@@ -39,17 +39,17 @@ Modules can be further nested so they become part of the tree that conforms an a
 import algebras._
 
 object modules {
-    @module trait Persistence[F[_]] {
-      val database: Database[F]
-      val cache: Cache[F]
+    @module trait Persistence {
+      val database: Database
+      val cache: Cache
     }
-    @module trait Display[F[_]] {
-      val presenter: Presenter[F]
-      val validator: IdValidation[F]
+    @module trait Display {
+      val presenter: Presenter
+      val validator: IdValidation
     }
-    @module trait App[F[_]] {
-      val persistence: Persistence[F]
-      val display: Display[F]
+    @module trait App {
+      val persistence: Persistence
+      val display: Display
     }
 }
 ```

--- a/docs/src/main/tut/docs/integrations/doobie/README.md
+++ b/docs/src/main/tut/docs/integrations/doobie/README.md
@@ -76,9 +76,9 @@ Only using `DoobieM` is not exactly useful however, as it just adds an extra lev
   def subtract(a: Int, b: Int): FS[Int]
 }
 
-@module trait Example[F[_]] {
-  val doobieM: DoobieM[F]
-  val calc: Calc[F]
+@module trait Example {
+  val doobieM: DoobieM
+  val calc: Calc
 }
 ```
 

--- a/docs/src/main/tut/docs/integrations/fetch/README.md
+++ b/docs/src/main/tut/docs/integrations/fetch/README.md
@@ -45,9 +45,9 @@ Then, make sure to include the Fetch algebra `FetchM` in your application:
 import freestyle.fetch._
 import freestyle.fetch.implicits._
 
-@module trait App[F[_]] {
-  val interact: Interact[F]
-  val fetches: FetchM[F]
+@module trait App {
+  val interact: Interact
+  val fetches: FetchM
 }
 ```
 

--- a/docs/src/main/tut/docs/integrations/fs2/README.md
+++ b/docs/src/main/tut/docs/integrations/fs2/README.md
@@ -28,9 +28,9 @@ import freestyle.implicits._
 import freestyle.fs2._
 import freestyle.fs2.implicits._
 
-@module trait App[F[_]] {
-  val interact: Interact[F]
-  val streams: StreamM[F]
+@module trait App {
+  val interact: Interact
+  val streams: StreamM
 }
 ```
 

--- a/docs/src/main/tut/docs/integrations/slick/README.md
+++ b/docs/src/main/tut/docs/integrations/slick/README.md
@@ -79,9 +79,9 @@ Only using `SlickM` is not exactly useful in this case as it just adds an extra 
   def subtract(a: Int, b: Int): FS[Int]
 }
 
-@module trait Example[F[_]] {
-  val slickM: SlickM[F]
-  val calc: Calc[F]
+@module trait Example {
+  val slickM: SlickM
+  val calc: Calc
 }
 ```
 

--- a/docs/src/main/tut/docs/patterns/config/README.md
+++ b/docs/src/main/tut/docs/patterns/config/README.md
@@ -85,9 +85,9 @@ derived from using different algebras:
 import freestyle.config._
 import freestyle.config.implicits._
 
-@module trait App[F[_]] {
-  val issuesService: IssuesService[F]
-  val config: ConfigM[F]
+@module trait App {
+  val issuesService: IssuesService
+  val config: ConfigM
 }
 ```
 

--- a/docs/src/main/tut/docs/patterns/logging/README.md
+++ b/docs/src/main/tut/docs/patterns/logging/README.md
@@ -75,9 +75,9 @@ derived from using different algebras:
 import freestyle.logging._
 import freestyle.loggingJVM.implicits._
 
-@module trait App[F[_]] {
-  val customerService: CustomerService[F]
-  val log: LoggingM[F]
+@module trait App {
+  val customerService: CustomerService
+  val log: LoggingM
 }
 ```
 

--- a/docs/src/main/tut/docs/stack/README.md
+++ b/docs/src/main/tut/docs/stack/README.md
@@ -57,17 +57,17 @@ object modules {
   val rd = reader[Config]
   val cacheP = new KeyValueProvider[CustomerId, Customer]
 
-  @module trait Persistence[F[_]] {
-    val customer: algebras.CustomerPersistence[F]
-    val stock: algebras.StockPersistence[F]
+  @module trait Persistence {
+    val customer: algebras.CustomerPersistence
+    val stock: algebras.StockPersistence
   }
 
-  @module trait App[F[_]] {
-    val persistence: Persistence[F]
+  @module trait App {
+    val persistence: Persistence
 
-    val errorM: ErrorM[F]
-    val cacheM: cacheP.CacheM[F]
-    val readerM: rd.ReaderM[F]
+    val errorM: ErrorM
+    val cacheM: cacheP.CacheM
+    val readerM: rd.ReaderM
   }
 }
 ```

--- a/freestyle-config/src/test/scala/config.scala
+++ b/freestyle-config/src/test/scala/config.scala
@@ -68,9 +68,9 @@ object algebras {
     }
 
   @module
-  trait App[F[_]] {
-    val nonConfig: NonConfig[F]
-    val configM: ConfigM[F]
+  trait App {
+    val nonConfig: NonConfig
+    val configM: ConfigM
   }
 
   val app = App[App.Op]

--- a/freestyle-doobie/src/test/scala/doobie.scala
+++ b/freestyle-doobie/src/test/scala/doobie.scala
@@ -83,9 +83,9 @@ object algebras {
     }
 
   @module
-  trait App[F[_]] {
-    val nonDoobie: NonDoobie[F]
-    val doobieM: DoobieM[F]
+  trait App {
+    val nonDoobie: NonDoobie
+    val doobieM: DoobieM
   }
 
   val app = App[App.Op]

--- a/freestyle-effects/shared/src/test/scala/effects/EffectsTests.scala
+++ b/freestyle-effects/shared/src/test/scala/effects/EffectsTests.scala
@@ -543,9 +543,9 @@ object collision {
   val rd = reader[Config]
 
   @module
-  trait AppX[F[_]] {
-    val stateM: st.StateM[F]
-    val readerM: rd.ReaderM[F]
+  trait AppX {
+    val stateM: st.StateM
+    val readerM: rd.ReaderM
   }
 
   @free
@@ -569,21 +569,21 @@ object collision {
   }
 
   @module
-  trait X[F[_]] {
-    val a: B[F]
-    val b: C[F]
+  trait X {
+    val a: B
+    val b: C
   }
 
   @module
-  trait Y[F[_]] {
-    val c: C[F]
-    val d: D[F]
+  trait Y {
+    val c: C
+    val d: D
   }
 
   @module
-  trait Z[F[_]] {
-    val x: X[F]
-    val y: Y[F]
+  trait Z {
+    val x: X
+    val y: Y
   }
 
 }

--- a/freestyle-fetch/shared/src/test/scala/FetchTests.scala
+++ b/freestyle-fetch/shared/src/test/scala/FetchTests.scala
@@ -101,9 +101,9 @@ object algebras {
     }
 
   @module
-  trait App[F[_]] {
-    val nonFetch: NonFetch[F]
-    val fetchM: FetchM[F]
+  trait App {
+    val nonFetch: NonFetch
+    val fetchM: FetchM
   }
 
   val app = App[App.Op]

--- a/freestyle-fs2/shared/src/test/scala/Fs2Tests.scala
+++ b/freestyle-fs2/shared/src/test/scala/Fs2Tests.scala
@@ -134,9 +134,9 @@ object algebras {
     }
 
   @module
-  trait App[F[_]] {
-    val nonStream: NonStream[F]
-    val streamM: StreamM[F]
+  trait App {
+    val nonStream: NonStream
+    val streamM: StreamM
   }
 
   val app = App[App.Op]

--- a/freestyle-logging/shared/src/test/scala/algebras.scala
+++ b/freestyle-logging/shared/src/test/scala/algebras.scala
@@ -33,9 +33,9 @@ object algebras {
     }
 
   @module
-  trait App[F[_]] {
-    val nonLogging: NonLogging[F]
-    val loggingM: LoggingM[F]
+  trait App {
+    val nonLogging: NonLogging
+    val loggingM: LoggingM
   }
 
   val app = App[App.Op]

--- a/freestyle-slick/src/test/scala/slick.scala
+++ b/freestyle-slick/src/test/scala/slick.scala
@@ -83,9 +83,9 @@ object algebras {
     }
 
   @module
-  trait App[F[_]] {
-    val nonSlick: NonSlick[F]
-    val slickM: SlickM[F]
+  trait App {
+    val nonSlick: NonSlick
+    val slickM: SlickM
   }
 
   val app = App[App.Op]

--- a/freestyle/shared/src/main/scala/freestyle/module.scala
+++ b/freestyle/shared/src/main/scala/freestyle/module.scala
@@ -32,27 +32,20 @@ object openUnion {
 
     def fail(msg: String) = c.abort(c.enclosingPosition, msg)
 
-    /* The findAlgebras method takes as input the `ClassSymbol` for the `@module`-annotated `trait`,
-     * and it computes the list of _algebras_ (`@free`-annotated `trait`s) that are included in the module.
+    /* This method takes as input the `ClassSymbol` of the `@module`-annotated `trait` and computes the list
+     *  of _algebras_ (`@free`-annotated `trait`s) used, directly or transitively, by the `@module`.
      *
-     * Now, a `@module` M can directly include a `@free` algebra A, but it can also include another `@module` N.
-     * In this case, we also need to collect recursively all the `@free` algebras included in N.
-     *
-     * To recognise if the type of a variable refers to a `@module`, the generated companion object for any
-     * `@module` inherits from the `FreeModuleLike` trait.
+     * To recognise if a `val` type is itself  a `@module`, the `@module` macro adds `FreeModuleLike`
+     * trait as a super-class of the `@module`-annotated trait.
      */
     def findAlgebras(s: ClassSymbol): List[Type] = {
 
-      // cs: the trait annotated as `@module`
       def methodsOf(cs: ClassSymbol): List[MethodSymbol] =
         cs.info.decls.toList.collect { case met: MethodSymbol if met.isAbstract => met }
 
-      // cs is a `@module` is the _class_ of the `object` extends from `FreeModuleLike`
-      // Note that a trait's companion object has a _real_ class, unknown, to rule its behaviour.
       def isModuleFS(cs: ClassSymbol): Boolean =
         cs.baseClasses.exists( _.name == TypeName("FreeModuleLike") )
 
-      // cs: the trait annotated as `@module`
       def fromClass(cs: ClassSymbol): List[Type] =
         methodsOf(cs).flatMap(x => fromMethod(x.returnType))
 
@@ -75,8 +68,8 @@ object openUnion {
         case alg :: Nil => q"type Op[$AA] = $alg.Op[$AA]" :: Nil
 
         case alg0 :: alg1 :: algs =>
-          /* We create several type aliases, where the type names are generated fresh names, 
-           * C0, C1, ..., C{n-1}, where n is the length of algebras. We then generate aliases: 
+          /* We create several type aliases, where the type names are generated fresh names,
+           * C0, C1, ..., C{n-1}, where n is the length of algebras. We then generate aliases:
            *
            * type C1 = A1 |+| A0
            * type C2 = A2 |+| C1
@@ -84,8 +77,7 @@ object openUnion {
            * type C{n-1} = A{n-1} |+| C{n-2
            * type Op{n-1}= C{n-1}
            */
-          val num = algebras.length
-          val ccs: List[TypeName] = List.range(0, num).map( i => freshTypeName("CC$") )
+          val ccs: List[TypeName] = algebras.map( _ => freshTypeName("CC$") )
           val tyDef1 = q"type ${ccs(1)}[$AA] = Coproduct[$alg1.Op, $alg0.Op, $AA]"
           val tyDefs = algebras.zipWithIndex.drop(2).map { case (alg, pos) =>
             q"type ${ccs(pos)}[$AA] = Coproduct[$alg.Op, ${ccs(pos-1)}, $AA]"
@@ -141,16 +133,13 @@ object moduleImpl {
 
     def mkModuleObject(userTrait: ClassDef): ModuleDef = {
       val mod = userTrait.name
-      val effVals: List[ValDef] = filterEffectVals(userTrait.impl)
-
       val tts = userTrait.tparams
       val tns = tts.map(_.name)
-
       val AA = freshTypeName("AA$")
       val ev = freshTermName("ev$")
       val xx = freshTermName("xx$")
 
-      val effArgs: List[ValDef] = effVals.map( v => toImplArg(v) )
+      val effArgs: List[ValDef] = filterEffectVals(userTrait.impl).map( v => toImplArg(v) )
 
       q"""
         object ${mod.toTermName} {

--- a/freestyle/shared/src/test/scala/freestyle/Utils.scala
+++ b/freestyle/shared/src/test/scala/freestyle/Utils.scala
@@ -61,40 +61,40 @@ trait S2 {
 
 
 @module
-trait M1[F[_]] {
-  val sctors1: SCtors1[F]
-  val sctors2: SCtors2[F]
+trait M1 {
+  val sctors1: SCtors1
+  val sctors2: SCtors2
 }
 
 @module
-trait M2[G[_]] {
-  val sctors3: SCtors3[G]
-  val sctors4: SCtors4[G]
+trait M2 {
+  val sctors3: SCtors3
+  val sctors4: SCtors4
 }
 
 @module
-trait O1[H[_]] {
-  val m1: M1[H]
-  val m2: M2[H]
+trait O1 {
+  val m1: M1
+  val m2: M2
 }
 
 @module
-trait O2[F[_]] {
-  val o1: O1[F]
+trait O2 {
+  val o1: O1
   val x = 1
   def y = 2
 }
 
 @module
-trait O3[F[_]] {
+trait O3 {
   def x = 1
   def y = 2
 }
 
 @module
-trait StateProp[F[_]] {
-  val s1: S1[F]
-  val s2: S2[F]
+trait StateProp {
+  val s1: S1
+  val s2: S2
 }
 
 object interps {

--- a/freestyle/shared/src/test/scala/nopackage.scala
+++ b/freestyle/shared/src/test/scala/nopackage.scala
@@ -28,7 +28,7 @@ import freestyle._
   def rhino(prompt: String): FS[String]
 }
 
-@module trait Age[F[_]] {
-  val logitech: Logitech[F]
-  val asia: Asia[F]
+@module trait Age {
+  val logitech: Logitech
+  val asia: Asia
 }

--- a/http/http4s/src/test/scala/http/Http4sTest.scala
+++ b/http/http4s/src/test/scala/http/Http4sTest.scala
@@ -85,8 +85,8 @@ object algebras {
   }
 
   @module
-  trait App[F[_]] {
-    val userRepo: UserRepository[F]
+  trait App {
+    val userRepo: UserRepository
   }
 }
 


### PR DESCRIPTION
This PR fulfills ticket #238. 

We refactor the `@module` macro so as to avoid the use of the `F[_]` parameter, which is now a fresh type name,  added by the macro to the trait and vals.

As a smaller pass-by optimisations, we change the inheritance of the market trait `ModuleLike` out of the object companion and add it to the trait, so as to make the recursive test simpler.