### PR TITLE
Fix compiler errors Finch Todo example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -268,11 +268,13 @@ lazy val todolistExample = (project in file("freestyle-examples/todolist"))
   .dependsOn(httpFinch)
   .dependsOn(fs2JVM)
   .settings(name := "freestyle-examples-todolist")
+  .settings(noPublishSettings)
   .settings(
     libraryDependencies ++= Seq(
       %%("circe-generic"),
       %%("doobie-h2-cats"),
-      "com.github.finagle" %% "finch-circe" % "0.14.0"
+      "com.github.finagle" %% "finch-circe" % "0.14.0",
+      "com.twitter" %% "twitter-server" % "1.29.0"
     ) ++ commonDeps
   )
 


### PR DESCRIPTION
To use the finch integration that makes it possible to use a `FreeS` or `FreeS.Par` in somthing like `get(int) {  ... }`, there needs to be a `FooHandler[Id]` or a `FooHandler[Future]` in scope.

There is also nothing in Freestyle which automatically composes implicitly available natural transformations, so I called `andThen` explicitly in `todo.runtime.implicits`.