### PR TITLE
Removes -Xlint from tutScalacOptions and scalacOptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,9 @@ lazy val docs = (project in file("docs"))
       %("h2") % "test"
     )
   )
+  .settings(
+    tutScalacOptions ~= (_ filterNot Set("-Ywarn-unused-import", "-Xlint").contains)
+  )
   .enablePlugins(MicrositesPlugin)
 
 lazy val monix = (crossProject in file("freestyle-monix"))

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -74,7 +74,7 @@ object ProjectPlugin extends AutoPlugin {
         (tut in ProjectRef(file("."), "docs")).asRunnableItem),
       resolvers += Resolver.sonatypeRepo("snapshots"),
       scalacOptions ++= scalacAdvancedOptions,
-      scalacOptions ~= (_ filterNot (_ == "-Yliteral-types")),
+      scalacOptions ~= (_ filterNot Set("-Yliteral-types", "-Xlint").contains),
       parallelExecution in Test := false,
       compileOrder in Compile := CompileOrder.JavaThenScala,
       coverageFailOnMinimum := false


### PR DESCRIPTION
This PR removes the `"warning: Unused import"` messages from tut files.

Please @raulraja could you review? Thanks