### PR TITLE
Simplify Exec

### DIFF
--- a/docs/src/main/tut/docs/core/algebras/README.md
+++ b/docs/src/main/tut/docs/core/algebras/README.md
@@ -63,7 +63,7 @@ object UserRepository {
 
   def apply[L[_]](implicit c: UserRepository[L]): UserRepository[L] = c
 
-  trait Handler[M[_]] extends FunctionK[Op, M] {
+  trait Handler[M[_]] extends FSHandler[Op, M] {
 
     protected[this] def get(id: Long): M[User]
     protected[this] def save(user: User): M[User]

--- a/freestyle-cache/shared/src/test/scala/TestContext.scala
+++ b/freestyle-cache/shared/src/test/scala/TestContext.scala
@@ -30,12 +30,12 @@ trait CacheTestContext extends BeforeAndAfterEach { self: Suite =>
   private[this] implicit val rawMap: KeyValueMap[Id, String, Int] =
     new ConcurrentHashMapWrapper[Id, String, Int]
 
-  private[this] implicit val idInt: FSHandler[Id, Id] = FunctionK.id[Id]
+  private[this] implicit val idHandler: FSHandler[Id, Id] = FunctionK.id[Id]
 
   protected[this] final val provider = new KeyValueProvider[String, Int]
 
   protected[this] implicit val interpret: provider.CacheM.Handler[Id] =
-    provider.implicits.cacheHandler(rawMap, idInt)
+    provider.implicits.cacheHandler(rawMap, idHandler)
 
   override def beforeEach = rawMap.clear
 

--- a/freestyle-cache/shared/src/test/scala/TestContext.scala
+++ b/freestyle-cache/shared/src/test/scala/TestContext.scala
@@ -18,6 +18,7 @@ package freestyle.cache
 
 import cats.arrow.FunctionK
 import cats.{~>, Applicative, Id}
+import freestyle.FSHandler
 import freestyle.cache.hashmap._
 import org.scalatest.{BeforeAndAfterEach, Suite}
 
@@ -29,7 +30,7 @@ trait CacheTestContext extends BeforeAndAfterEach { self: Suite =>
   private[this] implicit val rawMap: KeyValueMap[Id, String, Int] =
     new ConcurrentHashMapWrapper[Id, String, Int]
 
-  private[this] implicit val idInt: Id ~> Id = FunctionK.id[Id]
+  private[this] implicit val idInt: FSHandler[Id, Id] = FunctionK.id[Id]
 
   protected[this] final val provider = new KeyValueProvider[String, Int]
 

--- a/freestyle-doobie/src/main/scala/doobie.scala
+++ b/freestyle-doobie/src/main/scala/doobie.scala
@@ -16,7 +16,7 @@
 
 package freestyle
 
-import cats.{~>, Foldable}
+import cats.Foldable
 import _root_.doobie.imports._
 import fs2.util.{Catchable, Suspendable}
 

--- a/freestyle-doobie/src/main/scala/doobie.scala
+++ b/freestyle-doobie/src/main/scala/doobie.scala
@@ -16,7 +16,6 @@
 
 package freestyle
 
-import cats.Foldable
 import _root_.doobie.imports._
 import fs2.util.{Catchable, Suspendable}
 

--- a/freestyle/shared/src/main/scala/freestyle/Implicits.scala
+++ b/freestyle/shared/src/main/scala/freestyle/Implicits.scala
@@ -17,11 +17,9 @@
 package freestyle
 
 import cats.{ Applicative, Monad }
-import cats.arrow.FunctionK
 import cats.data.Coproduct
 import cats.free.{Free, FreeApplicative, Inject}
 import shapeless.Lazy
-
 
 trait Interpreters {
 
@@ -29,10 +27,6 @@ trait Interpreters {
       implicit fm: FSHandler[F, M],
       gm: Lazy[FSHandler[G, M]]): FSHandler[Coproduct[F, G, ?], M] =
     fm or gm.value
-
-  implicit def interpretAp[F[_], M[_]: Monad](
-      implicit fInterpreter: FSHandler[F, M]): FSHandler[FreeApplicative[F, ?], M] =
-    λ[FunctionK[FreeApplicative[F, ?], M]](_.foldMap(fInterpreter))
 
   // workaround for https://github.com/typelevel/cats/issues/1505
   implicit def catsFreeRightInjectInstanceLazy[F[_], G[_], H[_]](

--- a/freestyle/shared/src/main/scala/freestyle/free.scala
+++ b/freestyle/shared/src/main/scala/freestyle/free.scala
@@ -139,14 +139,13 @@ object freeImpl {
       q"""
         object ${Eff.toTermName} {
 
-          import _root_.cats.arrow.FunctionK
           import _root_.cats.free.Inject
-          import _root_.freestyle.FreeS
+          import _root_.freestyle.{ FreeS, FSHandler}
 
           sealed trait $OP[$AA] extends scala.Product with java.io.Serializable
           ..${requests.map( _.mkRequestClass(TTs))}
 
-          trait Handler[$MM[_], ..$TTs] extends FunctionK[$OP, $MM] {
+          trait Handler[$MM[_], ..$TTs] extends FSHandler[$OP, $MM] {
             ..${requests.map( _.handlerDef )}
 
             override def apply[$AA]($fa: $OP[$AA]): $MM[$AA] = $fa match {

--- a/freestyle/shared/src/main/scala/freestyle/package.scala
+++ b/freestyle/shared/src/main/scala/freestyle/package.scala
@@ -104,8 +104,17 @@ package object freestyle {
      * Runs a seq/par program by converting each parallel fragment in `f` into an `H`
      * `H` should probably be an `IO`/`Task` like `Monad` also providing parallel execution.
      */
-    def exec[H[_]: Monad](implicit interpreter: ParInterpreter[F, H]): H[A] =
+    def parExec[H[_]: Monad](implicit interpreter: ParInterpreter[F, H]): H[A] =
       fa.foldMap(interpreter)
+
+    /**
+     * Runs a seq/par program by converting each parallel fragment in `f` into an `H`
+     * `H` should probably be an `IO`/`Task` like `Monad` also providing parallel execution.
+     */
+    def exec[H[_]: Monad](implicit handler: FSHandler[F, H]): H[A] = {
+      val parInterpreter = λ[FSHandler[FreeApplicative[F, ?], H]](_.foldMap(handler))
+      fa.foldMap(parInterpreter)
+    }
   }
 
   /**

--- a/freestyle/shared/src/test/scala/freestyle/Utils.scala
+++ b/freestyle/shared/src/test/scala/freestyle/Utils.scala
@@ -16,8 +16,6 @@
 
 package freestyle
 
-import cats.arrow.FunctionK
-
 @free
 trait SCtors1 {
   def x(a: Int): FS[Int]
@@ -99,42 +97,42 @@ trait StateProp {
 
 object interps {
 
-  implicit val optionHandler1: FunctionK[SCtors1.Op, Option] = new SCtors1.Handler[Option] {
+  implicit val optionHandler1: FSHandler[SCtors1.Op, Option] = new SCtors1.Handler[Option] {
     def x(a: Int): Option[Int] = Some(a)
     def y(a: Int): Option[Int] = Some(a)
   }
 
-  implicit val listHandler1: FunctionK[SCtors1.Op, List] = new SCtors1.Handler[List] {
+  implicit val listHandler1: FSHandler[SCtors1.Op, List] = new SCtors1.Handler[List] {
     def x(a: Int): List[Int] = List(a)
     def y(a: Int): List[Int] = List(a)
   }
 
-  implicit val optionHandler2: FunctionK[SCtors2.Op, Option] = new SCtors2.Handler[Option] {
+  implicit val optionHandler2: FSHandler[SCtors2.Op, Option] = new SCtors2.Handler[Option] {
     def i(a: Int): Option[Int] = Some(a)
     def j(a: Int): Option[Int] = Some(a)
   }
 
-  implicit val listHandler2: FunctionK[SCtors2.Op, List] = new SCtors2.Handler[List] {
+  implicit val listHandler2: FSHandler[SCtors2.Op, List] = new SCtors2.Handler[List] {
     def i(a: Int): List[Int] = List(a)
     def j(a: Int): List[Int] = List(a)
   }
 
-  implicit val optionHandler3: FunctionK[SCtors3.Op, Option] = new SCtors3.Handler[Option] {
+  implicit val optionHandler3: FSHandler[SCtors3.Op, Option] = new SCtors3.Handler[Option] {
     def o(a: Int): Option[Int] = Some(a)
     def p(a: Int): Option[Int] = Some(a)
   }
 
-  implicit val listHandler3: FunctionK[SCtors3.Op, List] = new SCtors3.Handler[List] {
+  implicit val listHandler3: FSHandler[SCtors3.Op, List] = new SCtors3.Handler[List] {
     def o(a: Int): List[Int] = List(a)
     def p(a: Int): List[Int] = List(a)
   }
 
-  implicit val optionHandler4: FunctionK[SCtors4.Op, Option] = new SCtors4.Handler[Option] {
+  implicit val optionHandler4: FSHandler[SCtors4.Op, Option] = new SCtors4.Handler[Option] {
     def k(a: Int): Option[Int] = Some(a)
     def m(a: Int): Option[Int] = Some(a)
   }
 
-  implicit val listHandler4: FunctionK[SCtors4.Op, List] = new SCtors4.Handler[List] {
+  implicit val listHandler4: FSHandler[SCtors4.Op, List] = new SCtors4.Handler[List] {
     def k(a: Int): List[Int] = List(a)
     def m(a: Int): List[Int] = List(a)
   }

--- a/freestyle/shared/src/test/scala/freestyle/module.scala
+++ b/freestyle/shared/src/test/scala/freestyle/module.scala
@@ -104,9 +104,11 @@ class moduleTests extends WordSpec with Matchers {
       import freestyle.implicits._
       import interps.{optionHandler1, optionHandler2}
       "implicitly[FunctionK[M1.Op, Option]]" should compile
+      "implicitly[FSHandler[M1.Op, Option]]" should compile
     }
 
     "[onion] find a FunctionK[Module.Op, ?] providing there is existing ones for it's smart constructors" in {
+      "implicitly[FSHandler[O1.Op, Option]]" should compile
       "implicitly[FunctionK[O1.Op, Option]]" should compile
     }
 

--- a/http/http4s/src/main/scala/http/http4s.scala
+++ b/http/http4s/src/main/scala/http/http4s.scala
@@ -17,17 +17,20 @@
 package freestyle
 package http
 
-import cats.{~>, Monad}
+import cats.{Applicative, Monad}
 import org.http4s.EntityEncoder
-
-import freestyle.implicits._
 
 object http4s {
 
   implicit def freeSEntityEncoder[F[_], G[_], A](
-      implicit NT: F ~> G,
+      implicit NT: FSHandler[F, G],
       G: Monad[G],
       EE: EntityEncoder[G[A]]): EntityEncoder[FreeS[F, A]] =
     EE.contramap((f: FreeS[F, A]) => f.exec[G])
 
+  implicit def freeSParEntityEncoder[F[_], G[_], A](
+      implicit NT: FSHandler[F, G],
+      G: Applicative[G],
+      EE: EntityEncoder[G[A]]): EntityEncoder[FreeS.Par[F, A]] =
+    EE.contramap((f: FreeS.Par[F, A]) => f.exec[G])
 }

--- a/http/play/src/main/scala/play.scala
+++ b/http/play/src/main/scala/play.scala
@@ -16,8 +16,8 @@
 
 package freestyle.http
 
-import freestyle._
 import cats.instances.future._
+import freestyle._
 import scala.concurrent.{ExecutionContext, Future}
 
 package play {
@@ -25,6 +25,11 @@ package play {
   object implicits {
 
     implicit def seqToFuture[F[_], A](prog: FreeS[F, A])(
+        implicit I: ParInterpreter[F, Future],
+        EC: ExecutionContext
+    ): Future[A] = prog.parExec[Future]
+
+    implicit def parSeqToFuture[F[_], A](prog: FreeS[F, A])(
         implicit I: FSHandler[F, Future],
         EC: ExecutionContext
     ): Future[A] = prog.exec[Future]

--- a/http/play/src/main/scala/play.scala
+++ b/http/play/src/main/scala/play.scala
@@ -17,11 +17,7 @@
 package freestyle.http
 
 import freestyle._
-
-import cats.Monad
-import cats.arrow.FunctionK
 import cats.instances.future._
-
 import scala.concurrent.{ExecutionContext, Future}
 
 package play {
@@ -29,12 +25,12 @@ package play {
   object implicits {
 
     implicit def seqToFuture[F[_], A](prog: FreeS[F, A])(
-        implicit I: ParInterpreter[F, Future],
+        implicit I: FSHandler[F, Future],
         EC: ExecutionContext
     ): Future[A] = prog.exec[Future]
 
     implicit def parToFuture[F[_], A](prog: FreeS.Par[F, A])(
-        implicit I: FunctionK[F, Future],
+        implicit I: FSHandler[F, Future],
         EC: ExecutionContext
     ): Future[A] = prog.exec[Future]
 


### PR DESCRIPTION
We unify the `exec` syntactic methods for `FreeS` and `FreeS.Par`, so that now all `exec` methods take an `FSHandler`. We also replace in a few places the use of `FunctionK` or `~>` with `FSHandler.