### PR TITLE
Add debug import to print macro generated trees

### DIFF
--- a/freestyle/shared/src/main/scala/freestyle/debug/package.scala
+++ b/freestyle/shared/src/main/scala/freestyle/debug/package.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle
+
+/** Implicit options to configure/control Freestyle's macros
+  */
+package object debug {
+  object optionTypes {
+    sealed trait ShowTrees
+  }
+  import optionTypes._
+
+  object options {
+
+    /** Import this value to have Freestyle print the macro generated code
+      * to the console during compilation
+      */
+    implicit val ShowTrees: ShowTrees = null.asInstanceOf[ShowTrees]
+  }
+}

--- a/freestyle/shared/src/main/scala/freestyle/free.scala
+++ b/freestyle/shared/src/main/scala/freestyle/free.scala
@@ -39,6 +39,10 @@ object freeImpl {
     val AA = freshTypeName("AA$") // AA is the parameter inside type applications
     val inj = freshTermName("toInj")
 
+    // debug option to show generated trees before returning
+    lazy val showTrees =
+      !c.inferImplicitValue(typeOf[debug.optionTypes.ShowTrees], true).isEmpty
+
     def fail(msg: String) = c.abort(c.enclosingPosition, msg)
 
     // Messages of error
@@ -167,6 +171,9 @@ object freeImpl {
       """
     }
 
-    gen()
+    val res = gen()
+    if (showTrees)
+      c.echo(c.enclosingPosition, s"generated tree:\n${showCode(res)}")
+    res
   }
 }


### PR DESCRIPTION
This adds a debug implicit that can be imported to configure the macros to print the generated trees to the console. This pattern can be used to add additional debug options.

This was ported over from Iota, which has several debug flags: https://github.com/47deg/iota/blob/v0.0.1/modules/core/src/main/scala/iota/debug/package.scala

The show trees output behaves roughly like this (demo output from Iota):
```
import iota.debug.options.ShowTrees
// import iota.debug.options.ShowTrees

CopK.FunctionK.of[Algebra, Future](evalOrderOp, evalPriceOp, evalUserOp)
// <console>:30: generated tree:
// {
//   final class $anon extends _root_.iota.CopKFunctionK[Algebra, Future] {
//     private[this] val arr0 = evalUserOp.asInstanceOf[_root_.cats.arrow.FunctionK[Any, Future]];
//     private[this] val arr1 = evalOrderOp.asInstanceOf[_root_.cats.arrow.FunctionK[Any, Future]];
//     private[this] val arr2 = evalPriceOp.asInstanceOf[_root_.cats.arrow.FunctionK[Any, Future]];
//     override def apply[A](ca: Algebra[A]): Future[A] = (ca.index: @_root_.scala.annotation.switch) match {
//       case 0 => arr0(ca.value)
//       case 1 => arr1(ca.value)
//       case 2 => arr2(ca.value)
//       case (i @ _) => throw new _root_.java.lang.Exception(StringContext("iota internal error: index ").s().+(i).+(" out of bounds for ").+(this))
//     };
//     override def toString: String = "CopKFunctio...
// res28: iota.CopKFunctionK[Algebra,scala.concurrent.Future] = CopKFunctionK[Algebra, Future]<<generated>>
```

Freestyle Usage:

```
import debug.options.ShowTrees
@free Foo { /* ... */ }
```

Note: If you're using this in test code, the implicit doesn't seem to be picked up correctly if it's nested all the way in the test.

This does not work:
```
"allow smart constructors with no args" in {
  import debug.options.ShowTrees
  @free
  trait NoArgs {
    def x: FS[Int]
  }
}
```

But this does:
```
import debug.options.ShowTrees
"allow smart constructors with no args" in {
  @free
  trait NoArgs {
    def x: FS[Int]
  }
}
```