### PR TITLE
Releases Freestyle 0.1.0.

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -61,7 +61,7 @@ object ProjectPlugin extends AutoPlugin {
         GitHubIssuesBadge.apply,
         ScalaJSBadge.apply
       ),
-      orgSupportedScalaJSVersion := Some("0.6.15"),
+      orgSupportedScalaJSVersion := Some("0.6.16"),
       orgScriptTaskListSetting := List(
         orgValidateFiles.asRunnableItem,
         (clean in Global).asRunnableItemFull,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("com.47deg"       % "sbt-org-policies" % "0.4.19")
-addSbtPlugin("io.get-coursier" % "sbt-coursier"     % "1.0.0-RC1")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.21")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0-SNAPSHOT"
+version in ThisBuild := "0.1.0"


### PR DESCRIPTION
It also: 

* Fixes the microsite images.
* Removes the explicit Coursier dependency since it's being provided transitively by `sbt-org-policies` plugin.