### PR TITLE
Catch exceptions in freestyle-config

### DIFF
--- a/freestyle-config/src/test/scala/config.scala
+++ b/freestyle-config/src/test/scala/config.scala
@@ -23,6 +23,7 @@ import freestyle.config._
 import freestyle.config.implicits._
 import scala.concurrent.{ExecutionContext, Future}
 import cats.instances.future._
+import cats.syntax.either._
 
 class ConfigTests extends AsyncWordSpec with Matchers {
 

--- a/freestyle-config/src/test/scala/config.scala
+++ b/freestyle-config/src/test/scala/config.scala
@@ -45,11 +45,11 @@ class ConfigTests extends AsyncWordSpec with Matchers {
         a   <- app.nonConfig.x
         cfg <- app.configM.parseString("{n = 1}")
       } yield cfg.int("n").map(_ + a)
-      program.exec[Future] map { _ shouldBe Some(1 + 1) }
+      program.exec[Future] map { _ shouldBe Right(1 + 1) }
     }
 
     "allow configuration to load classpath files" in {
-      app.configM.load.exec[Future] map { _.int("s") shouldBe Some(3) }
+      app.configM.load.exec[Future] map { _.int("s") shouldBe Right(3) }
     }
 
   }


### PR DESCRIPTION
This changes the return type of all the methods on `Config` to `Either[ConfigException, A]` (aliased as `Config.Result`) and catches `ConfigException`s using Cats' `Either.catchOnly`.

Fixes #260.