### PR TITLE
Tries to fix random test failures at http Play module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import sbtorgpolicies.model._
-
 lazy val root = (project in file("."))
   .settings(moduleName := "root")
   .settings(name := "freestyle")
@@ -268,7 +266,7 @@ lazy val httpPlay = (project in file("http/play"))
   .dependsOn(freestyleJVM)
   .settings(name := "freestyle-http-play")
   .settings(
-    parallelExecution in Test := false,
+    concurrentRestrictions in Global := Seq(Tags.limitAll(1)),
     libraryDependencies ++= Seq(
       %%("play")      % "test",
       %%("play-test") % "test"

--- a/http/play/src/test/scala/PlayTests.scala
+++ b/http/play/src/test/scala/PlayTests.scala
@@ -16,22 +16,18 @@
 
 package freestyle.http
 
-import org.scalatest.{AsyncWordSpec, Matchers}
+import org.scalatest.{Matchers, WordSpec}
 
 import scala.concurrent.ExecutionContext
-
 import cats.Monad
-
 import freestyle._
 import freestyle.implicits._
-
 import freestyle.http.play.implicits._
-
 import _root_.play.api.mvc.{Action, Codec, Request, Result, Results}
 import _root_.play.api.http.{ContentTypeOf, Writeable}
+import ExecutionContext.Implicits.global
 
-class PlayTests extends AsyncWordSpec with Matchers {
-  implicit override def executionContext = ExecutionContext.Implicits.global
+class PlayTests extends WordSpec with Matchers {
 
   implicit def unitWr(implicit C: Codec): Writeable[Unit] =
     Writeable(data => C.encode(data.toString))


### PR DESCRIPTION
This PR tries to fix the random test failures we have now at http Play sbt module. Basically, it adds a new restriction on concurrent task execution, where we'd be limiting the maximum number of concurrently executing tasks to 1. It also, replaces `AsyncWordSpec` by `WordSpec`.