### PR TITLE
Prevents OOM Issues in Releasing Process

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,9 +1,9 @@
 # Cats jvmopts see https://weblogs.java.net/blog/kcpeppe/archive/2013/12/11/case-study-jvm-hotspot-flags
 -Dfile.encoding=UTF8
--Xms2G
--Xmx2G
--XX:MaxMetaspaceSize=512M
--XX:ReservedCodeCacheSize=128M
+-Xms1G
+-Xmx6G
+-XX:MaxMetaspaceSize=1024M
+-XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit
 # effectively adds GC to Perm space


### PR DESCRIPTION
It has been tested with long running sbt processes, and this new parameters seem to be working fine.

Branch where I've been playing with https://github.com/47deg/freestyle/tree/oom-tests

Issue detected when releasing `0.1.0` version: https://travis-ci.org/47deg/freestyle/jobs/228042151#L5230