### PR TITLE
Removes sudo: required from Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: scala
 
 dist: precise
 
-sudo: required
-
 scala:
 - 2.11.11
 - 2.12.2


### PR DESCRIPTION
Ubuntu Precise 12.04 LTS End of Life: 
* https://blog.travis-ci.com/2017-04-17-precise-EOL
* https://blog.travis-ci.com/2017-05-04-precise-image-updates