### PR TITLE
Fixed problem with a test application.conf file being included on the freestyle deployed jars…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -177,7 +177,7 @@ lazy val config = (project in file("freestyle-config"))
     name := "freestyle-config",
     fixResources := {
       val testConf   = (resourceDirectory in Test).value / "application.conf"
-      val targetFile = (classDirectory in (freestyleJVM, Compile)).value / "application.conf"
+      val targetFile = (classDirectory in (freestyleJVM, Test)).value / "application.conf"
       if (testConf.exists) {
         IO.copyFile(
           testConf,


### PR DESCRIPTION
… due to a small error on the sbt configuration for freestyle-config. This caused issues with duplicated (and different) application.conf files when trying to package projects that depend on freestyle using tools like sbt-assembly.