### PR TITLE
Allows FS type aliases in @module traits

### DIFF
--- a/freestyle/shared/src/main/scala/freestyle/module.scala
+++ b/freestyle/shared/src/main/scala/freestyle/module.scala
@@ -166,8 +166,9 @@ final class moduleImpl(val c: Context) {
       case q"$mods val $name: $tpt[..$args]" => q"$mods val $name: $tpt[$FF, ..$args]"
       case x => x
     }
+    val parentTrees = parents ++ List(tq"_root_.freestyle.FreeModuleLike", tq"_root_.freestyle.EffectLike[$FF]")
     ClassDef(mods, name, FFtypeConstructor :: tparams,
-      Template(parents :+ tq"$FreeModuleLike", self, body0)).validNel
+      Template(parentTrees, self, body0)).validNel
   }
 
   private[this] def makeModuleTree(

--- a/freestyle/shared/src/test/scala/freestyle/Utils.scala
+++ b/freestyle/shared/src/test/scala/freestyle/Utils.scala
@@ -95,6 +95,20 @@ trait StateProp {
   val s2: S2
 }
 
+object comp {
+
+  @module
+  trait FSMod {
+
+    val sCtors1: SCtors1
+
+    def x(a: Int): FS.Seq[Int] = sCtors1.x(a)
+    def y(b: Int): FS.Seq[Int] = sCtors1.y(b)
+  }
+
+}
+
+
 object interps {
 
   implicit val optionHandler1: FSHandler[SCtors1.Op, Option] = new SCtors1.Handler[Option] {

--- a/freestyle/shared/src/test/scala/freestyle/module.scala
+++ b/freestyle/shared/src/test/scala/freestyle/module.scala
@@ -153,6 +153,15 @@ class moduleTests extends WordSpec with Matchers {
       o3.y shouldBe 2
     }
 
+    "allow modules be composed with algebras, having methods returning FS effects" in {
+      import comp._
+      val m1 = FSMod[FSMod.Op]
+      val program = for {
+        a <- m1.x(1)
+        b <- m1.y(1)
+      } yield a + b
+      program.interpret[Option] shouldBe Option(2)
+    }
   }
 
 }


### PR DESCRIPTION
Fixes https://github.com/frees-io/freestyle/issues/317

This PR makes that `modules` extends `EffectLike` in the macro expansion, hence, the `FS` type aliases can be used inside them.