### PR TITLE
Nested Coproduct Test (as ignored)

### DIFF
--- a/freestyle/shared/src/main/scala/freestyle/module.scala
+++ b/freestyle/shared/src/main/scala/freestyle/module.scala
@@ -166,8 +166,9 @@ final class moduleImpl(val c: Context) {
       case q"$mods val $name: $tpt[..$args]" => q"$mods val $name: $tpt[$FF, ..$args]"
       case x => x
     }
+    val parentTrees = parents ++ List(tq"$FreeModuleLike", tq"freestyle.EffectLike[$FF]")
     ClassDef(mods, name, FFtypeConstructor :: tparams,
-      Template(parents :+ tq"$FreeModuleLike", self, body0)).validNel
+      Template(parentTrees, self, body0)).validNel
   }
 
   private[this] def makeModuleTree(

--- a/freestyle/shared/src/test/scala/freestyle/Utils.scala
+++ b/freestyle/shared/src/test/scala/freestyle/Utils.scala
@@ -95,6 +95,20 @@ trait StateProp {
   val s2: S2
 }
 
+object comp {
+
+  @module
+  trait FSMod {
+
+    val sCtors1: SCtors1
+
+    def x(a: Int): FS.Seq[Int] = sCtors1.x(a)
+    def y(b: Int): FS.Seq[Int] = sCtors1.y(b)
+  }
+
+}
+
+
 object interps {
 
   implicit val optionHandler1: FSHandler[SCtors1.Op, Option] = new SCtors1.Handler[Option] {

--- a/freestyle/shared/src/test/scala/freestyle/module.scala
+++ b/freestyle/shared/src/test/scala/freestyle/module.scala
@@ -153,6 +153,15 @@ class moduleTests extends WordSpec with Matchers {
       o3.y shouldBe 2
     }
 
+    "allow modules be composed with algebras, having methods returning FS effects" in {
+      import comp._
+      val m1 = FSMod[FSMod.Op]
+      val program = for {
+        a <- m1.x(1)
+        b <- m1.y(1)
+      } yield a + b
+      program.interpret[Option] shouldBe Option(2)
+    }
   }
 
 }

--- a/freestyle/shared/src/test/scala/freestyle/module.scala
+++ b/freestyle/shared/src/test/scala/freestyle/module.scala
@@ -162,6 +162,43 @@ class moduleTests extends WordSpec with Matchers {
       } yield a + b
       program.interpret[Option] shouldBe Option(2)
     }
-  }
 
+    "nested allow nested coproducts" ignore {
+
+      """
+        |object repository {
+        |  final class RepositoryA[A] {
+        |    @free trait Ops {
+        |      def insert(input: A): FS[Option[A]]
+        |    }
+        |  }
+        |  def apply[A] = new RepositoryA[A]
+        |}
+        |
+        |object service {
+        |  final class ServiceA[A](name: String) {
+        |    val repositoryA: repository.RepositoryA[A] = repository[A]
+        |    @module
+        |    trait Ops {
+        |      val repo: repositoryA.Ops
+        |      def insert(input: A): FS.Seq[Option[A]] = repo.insert(input)
+        |    }
+        |  }
+        |  def apply[A](name: String) = new ServiceA[A](name)
+        |}
+        |
+        |object services {
+        |  case class C1(x: Int, y: String)
+        |  case class C2(a: String, b: Int)
+        |  val C1Service: service.ServiceA[C1] = service[C1]("c1")
+        |  val C2Service: service.ServiceA[C2] = service[C2]("c2")
+        |}
+        |
+        |@module
+        |trait ServicesModule {
+        |  val service1: services.C1Service.Ops
+        |  val service2: services.C2Service.Ops
+        |}""".stripMargin should compile
+    }
+  }
 }


### PR DESCRIPTION
This PR shows how nested coproducts are not working in Freestyle. Nor `iota` nor the `cats` coproduct are making it as a working valid test case.

Depends on https://github.com/frees-io/freestyle/pull/318

Currently, this new test is tagged as `ignore`.