### PR TITLE
Use nested coproduct list support from Iota 0.2.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,9 @@ lazy val freestyle = (crossProject in file("freestyle"))
   .settings(name := "freestyle")
   .jsSettings(sharedJsSettings: _*)
   .settings(libraryDependencies ++= Seq(%("scala-reflect", scalaVersion.value)))
-  .settings(libraryDependencies += "com.47deg" %%% "iota-core" % "0.2.0-SNAPSHOT")
   .crossDepSettings(
     commonDeps ++ Seq(
-      //%("iota-core"),
+      %("iota-core", "0.2.0-SNAPSHOT"),
       %("cats-free"),
       %("shapeless"),
       %("monix-eval") % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,10 @@ lazy val freestyle = (crossProject in file("freestyle"))
   .settings(name := "freestyle")
   .jsSettings(sharedJsSettings: _*)
   .settings(libraryDependencies ++= Seq(%("scala-reflect", scalaVersion.value)))
+  .settings(libraryDependencies += "com.47deg" %%% "iota-core" % "0.2.0-SNAPSHOT")
   .crossDepSettings(
     commonDeps ++ Seq(
-      %("iota-core"),
+      //%("iota-core"),
       %("cats-free"),
       %("shapeless"),
       %("monix-eval") % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val freestyle = (crossProject in file("freestyle"))
   .settings(libraryDependencies ++= Seq(%("scala-reflect", scalaVersion.value)))
   .crossDepSettings(
     commonDeps ++ Seq(
-      %("iota-core", "0.2.0-SNAPSHOT"),
+      %("iota-core"),
       %("cats-free"),
       %("shapeless"),
       %("monix-eval") % "test",

--- a/freestyle/shared/src/main/scala/freestyle/free.scala
+++ b/freestyle/shared/src/main/scala/freestyle/free.scala
@@ -147,6 +147,7 @@ object freeImpl {
       q"""
         object ${Eff.toTermName} {
 
+          type OpTypes = _root_.iota.KCons[Op, _root_.iota.KNil]
           sealed trait Op[$AA] extends scala.Product with java.io.Serializable {
             val $indexName : _root_.scala.Int
           }

--- a/freestyle/shared/src/main/scala/freestyle/module.scala
+++ b/freestyle/shared/src/main/scala/freestyle/module.scala
@@ -65,23 +65,9 @@ final class moduleImpl(val c: Context) {
       cls             <- decodeAnnotationTarget(annottees.toList)
       effectTuples     = gatherEffects(cls)
       classTree       <- makeClassTree(cls)
-      objectTree      <- makeModuleTree(cls, effectTuples)
+      coproductTree    = makeCoproductTree(effectTuples)
+      objectTree      <- makeModuleTree(cls, coproductTree, effectTuples)
     } yield q"$classTree; $objectTree")
-
-  def computeCoproductImpl: Tree =
-    foldAbort(for {
-      tpe             <- compassionateCompanionTypeOf(c.internal.enclosingOwner.owner)
-      fullEffectTypes =  expandEffectType(tpe)
-      fullEffectTrees <- fullEffectTypes.traverse(typeToTypeTree)
-      //coproductTree  = makeCatsCoproduct(fullEffectTrees) // TODO: make this configurable?
-      coproductTree    = makeIotaCoproduct(fullEffectTrees)
-    } yield q"""new { ..$coproductTree }""")
-
-  def compassionateCompanionTypeOf(sym: Symbol): ValidatedNel[String, Type] =
-    if (sym.companion.isType)
-      sym.companion.asType.toType.validNel
-    else
-      s"unable to find companion for $sym when expanding coproduct".invalidNel
 
   private[this] def decodeAnnotationTarget(annottees: List[c.Expr[Any]]) =
     annottees.map(_.tree) match {
@@ -100,66 +86,6 @@ final class moduleImpl(val c: Context) {
     cls.impl.body.collect {
       case valDef: ValDef if valDef.rhs.isEmpty => (valDef.name, valDef.tpt) }
 
-  private[this] def expandEffectType(tpe: Type): List[Type] = {
-    def isModuleFS(cs: ClassSymbol): Boolean =
-      cs.baseClasses.exists(_.name == TypeName("FreeModuleLike"))
-
-    def expandClass(cs: ClassSymbol): List[Type] =
-      cs.info.decls.toList
-        .collect { case met: MethodSymbol if met.isAbstract => met }
-        .flatMap(x => expandEffectType(x.returnType))
-
-    tpe.typeSymbol match {
-      case cs: ClassSymbol =>
-        if (isModuleFS(cs)) expandClass(cs) else List(tpe.typeConstructor)
-      case _ => Nil
-    }
-  }
-
-  private[this] def typeToTypeTree(tpe: Type): ValidatedNel[String, Tree] =
-    Validated.catchNonFatal(c.parse(tpe.toString)).leftMap(t =>
-      NonEmptyList.of(s"unable to convert type $tpe to tree"))
-
-  private[this] lazy val defaultf0: Tree =
-    q"type Op[$AA] = Nothing"
-  private[this] def defaultf1(tpt: Tree): Tree =
-    q"type Op[$AA] = $tpt.Op[$AA]"
-
-  private[this] def makeCatsCoproduct(
-    tpts: List[Tree]
-  ): Tree = tpts match {
-    case Nil                    => defaultf0
-    case tpt :: Nil             => defaultf1(tpt)
-    case head1 :: head2 :: tail =>
-
-      val max = tail.length
-      def Op(i: Int) = (max - i - 1) match {
-        case 0 => TypeName("Op")
-        case n => TypeName(s"Op$n")
-      }
-
-      tail.zipWithIndex.foldLeft(
-        q"type ${Op(-1)}[$AA] = $Coproduct[$head2.Op, $head1.Op, $AA]": Tree
-      ) { (prefix, tup) =>
-        val (tpt, i) = tup
-        q"""
-          ..$prefix
-          type ${Op(i)}[$AA] = $Coproduct[$tpt.Op, ${Op(i - 1)}, $AA]
-        """
-      }
-  }
-
-  private[this] def makeIotaCoproduct(
-    tpts: List[Tree]
-  ): Tree = tpts match {
-    case Nil        => defaultf0
-    case tpt :: Nil => defaultf1(tpt)
-    case _          =>
-      val klist = tpts.foldLeft(tq"$KNil": Tree)((tail, head) =>
-        tq"$KCons[$head.Op, $tail]")
-      q"type Op[$AA] = $CopK[$klist, $AA]"
-  }
-
   private[this] def makeClassTree(cls: ClassDef): ValidatedNel[String, ClassDef] = {
     val ClassDef(mods, name, tparams, Template(parents, self, body)) = cls
     val body0 = body.map {
@@ -171,8 +97,24 @@ final class moduleImpl(val c: Context) {
       Template(parentTrees, self, body0)).validNel
   }
 
+  private[this] def makeCoproductTree(effectTuples: List[(Name, Tree)]): Tree = {
+    val L = effectTuples.map(_._2).map(t => tq"$t.OpTypes": Tree) match {
+      case Nil         => tq"_root_.iota.KNil"
+      case tree :: Nil => tree
+      case trees       => trees.reduce((l, r) => tq"_root_.iota.KList.Op.Concat[$l, $r]")
+    }
+
+    println("parsing " + q"type OpTypes = $L".toString)
+    // (‡▼益▼)<!! would love to find a better solution for this line
+    val OpTypes = c.parse(q"type OpTypes = $L".toString)
+    q"""
+      $OpTypes
+      type Op[A]  = _root_.iota.CopK[OpTypes, A]"""
+  }
+
   private[this] def makeModuleTree(
     cls: ClassDef,
+    coproductTree: Tree,
     effects: List[(Name, Tree)]
   ): ValidatedNel[String, ModuleDef] = {
 
@@ -185,8 +127,7 @@ final class moduleImpl(val c: Context) {
 
     builtArgs.map(args => q"""
       object ${name.toTermName} {
-        val _computeOp = _root_.freestyle.moduleImpl.computeCoproduct
-        type Op[$AA] = _computeOp.Op[$AA]
+        ..$coproductTree
         def apply[$LL[_], ..$tparams](implicit ev: $name[$LL, ..$tparams]): $name[$LL, ..$tparams] = ev
         implicit def to[$LL[_], ..$tparams](implicit ..$args): To[$LL, ..$tparams] =
           new To[$LL, ..$tparams]()
@@ -198,10 +139,4 @@ final class moduleImpl(val c: Context) {
     v fold (
       errors => c.abort(c.enclosingPosition, errors.toList.mkString(", and\n")),
       a      => a)
-}
-
-object moduleImpl {
-  // a nested macro used to delay expansion of the coproduct types until
-  // after the free/module high level code is generated
-  def computeCoproduct: Any = macro moduleImpl.computeCoproductImpl
 }

--- a/freestyle/shared/src/test/scala/freestyle/InjKTests.scala
+++ b/freestyle/shared/src/test/scala/freestyle/InjKTests.scala
@@ -77,12 +77,12 @@ class InjKTests extends Properties("InjK") {
     implicit def left[F[_], G[_], A](implicit
       arbFA: Arbitrary[F[A]]
     ): Arbitrary[CopK[F ::: G ::: KNil, A]] =
-      Arbitrary(arbFA.arbitrary.map(v => CopK(0, v)))
+      Arbitrary(arbFA.arbitrary.map(v => CopK.unsafeApply(0, v)))
 
     implicit def right[F[_], G[_], A](implicit
       arbGA: Arbitrary[G[A]]
     ): Arbitrary[CopK[F ::: G ::: KNil, A]] =
-      Arbitrary(arbGA.arbitrary.map(v => CopK(1, v)))
+      Arbitrary(arbGA.arbitrary.map(v => CopK.unsafeApply(1, v)))
 
     implicit def both[F[_], G[_], A](implicit
       arbFA: Arbitrary[F[A]],

--- a/freestyle/shared/src/test/scala/freestyle/module.scala
+++ b/freestyle/shared/src/test/scala/freestyle/module.scala
@@ -163,7 +163,7 @@ class moduleTests extends WordSpec with Matchers {
       program.interpret[Option] shouldBe Option(2)
     }
 
-    "nested allow nested coproducts" ignore {
+    "allow nested coproducts" in {
 
       """
         |object repository {

--- a/freestyle/shared/src/test/scala/freestyle/module.scala
+++ b/freestyle/shared/src/test/scala/freestyle/module.scala
@@ -166,38 +166,16 @@ class moduleTests extends WordSpec with Matchers {
     "allow nested coproducts" in {
 
       """
-        |object repository {
-        |  final class RepositoryA[A] {
-        |    @free trait Ops {
-        |      def insert(input: A): FS[Option[A]]
-        |    }
+        |@free trait X {
+        |  def x: FS[Int]
+        |}
+        |object P {
+        |  @module trait Y {
+        |    val repo: X
         |  }
-        |  def apply[A] = new RepositoryA[A]
         |}
-        |
-        |object service {
-        |  final class ServiceA[A](name: String) {
-        |    val repositoryA: repository.RepositoryA[A] = repository[A]
-        |    @module
-        |    trait Ops {
-        |      val repo: repositoryA.Ops
-        |      def insert(input: A): FS.Seq[Option[A]] = repo.insert(input)
-        |    }
-        |  }
-        |  def apply[A](name: String) = new ServiceA[A](name)
-        |}
-        |
-        |object services {
-        |  case class C1(x: Int, y: String)
-        |  case class C2(a: String, b: Int)
-        |  val C1Service: service.ServiceA[C1] = service[C1]("c1")
-        |  val C2Service: service.ServiceA[C2] = service[C2]("c2")
-        |}
-        |
-        |@module
-        |trait ServicesModule {
-        |  val service1: services.C1Service.Ops
-        |  val service2: services.C2Service.Ops
+        |@module trait Z {
+        |  val a: P.Y
         |}""".stripMargin should compile
     }
   }


### PR DESCRIPTION
~This build will fail because the docs depend on the integration library which depends on the core macros for generating the free boilerplate. I've added a type to the `@free` generated code, so the integration library build is now outdated.~