### PR TITLE
Git Docs: branch and swallow clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,14 @@ before_install:
   fi
 - export PATH=${PATH}:./vendor/bundle
 - if [ "$TRAVIS_SCALA_VERSION" = "2.12.2" ]; then
-    git clone https://github.com/frees-io/freestyle-docs.git ;
+    set -x;
+    DOCS_REPO="https://github.com/frees-io/freestyle-docs.git" ;
+    if [ $(git ls-remote $DOCS_REPO | grep "refs/heads/$TRAVIS_BRANCH" | wc -l) = 1 ] ; then
+        git clone --branch $TRAVIS_BRANCH --depth=1 $DOCS_REPO  ;
+    else
+        git clone --branch master --depth=1 $DOCS_REPO  ;
+    fi ;
+    set +x;
   fi
 
 install:


### PR DESCRIPTION
We change the doc building part: we add a check such that, if
there is a branch in the docs repo with the same name as the current
branch buing built, then we check out that branch.
We also add an option to check out no history from the docs repo.