### PR TITLE
Rearrange interdependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val freestyleJVM = freestyle.jvm
 lazy val freestyleJS  = freestyle.js
 
 lazy val tagless = (crossProject in file("freestyle-tagless"))
-  .dependsOn(freestyle)
+  .dependsOn(freestyle % "test -> compile")
   .settings(name := "freestyle-tagless")
   .jsSettings(sharedJsSettings: _*)
   .crossDepSettings(commonDeps: _*)
@@ -32,6 +32,11 @@ lazy val tagless = (crossProject in file("freestyle-tagless"))
   .settings(
     libraryDependencies += "com.kailuowang" %%% "mainecoon-core" % "0.0.5"
   )
+  .crossDepSettings( commonDeps ++ Seq(
+    "com.kailuowang" %%% "mainecoon-core" % "0.0.5",
+    %("cats-core"),
+    %("cats-free")
+  ))
 
 lazy val taglessJVM = tagless.jvm
 lazy val taglessJS  = tagless.js


### PR DESCRIPTION
The dependency between tagless and freestyle-core is made only for
tests. We have to add the cats libraries to dependencies.