### PR TITLE
Calculates coverage only for JVM, excluding JS tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ scala:
 - 2.11.11
 - 2.12.2
 
+env:
+- SCALAENV=jvm
+- SCALAENV=js
+
 jdk:
 - oraclejdk8
 
@@ -24,9 +28,13 @@ install:
   fi
 
 script:
-- sbt ++$TRAVIS_SCALA_VERSION test:fastOptJS
-- sbt ++$TRAVIS_SCALA_VERSION orgScriptCI
-- ./scripts/build.sh
+- if [ "$SCALAENV" = "jvm" ]; then
+    sbt ++$TRAVIS_SCALA_VERSION orgScriptCI;
+    ./scripts/build.sh;
+  fi
+- if [ "$SCALAENV" = "js" ]; then
+    sbt ++$TRAVIS_SCALA_VERSION test:fastOptJS validateJS;
+  fi
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -70,12 +70,10 @@ lazy val bench = (project in file("bench"))
   .settings(inConfig(Codegen)(Defaults.configSettings))
   .settings(classpathConfiguration in Codegen := Compile)
   .settings(noPublishSettings)
-  .settings(libraryDependencies ++= Seq(
-    %%("cats-free"),
-    %%("scalacheck")))
+  .settings(libraryDependencies ++= Seq(%%("cats-free"), %%("scalacheck")))
   .settings(inConfig(Compile)(
     sourceGenerators += Def.task {
-      val path = (sourceManaged in(Compile, compile)).value / "bench.scala"
+      val path = (sourceManaged in (Compile, compile)).value / "bench.scala"
       (runner in (Codegen, run)).value.run(
         "freestyle.bench.BenchBoiler",
         Attributed.data((fullClasspath in Codegen).value),
@@ -173,10 +171,6 @@ lazy val logging = (crossProject in file("freestyle-logging"))
 lazy val loggingJVM = logging.jvm
 lazy val loggingJS  = logging.js
 
-addCommandAlias("debug", "; clean ; test")
-
-addCommandAlias("validate", "; +clean ; +test; makeMicrosite")
-
 pgpPassphrase := Some(getEnvVar("PGP_PASSPHRASE").getOrElse("").toCharArray)
 pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
 pgpSecretRing := file(s"$gpgFolder/secring.gpg")
@@ -209,17 +203,8 @@ lazy val allModules: Seq[ProjectReference] = jvmModules ++ jsModules
 lazy val jvmFreestyleDeps: Seq[ClasspathDependency] =
   jvmModules.map(ClasspathDependency(_, None))
 
-coverageExcludedFiles in Global  := ".*<macro>"
-
-def toCompileTestList(sequence: Seq[ProjectReference]): List[String] = sequence.toList.map { p =>
-  val project: String = p.asInstanceOf[LocalProject].project
-  s"$project/test"
-}
-
 addCommandAlias("validateJVM", (toCompileTestList(jvmModules) ++ List("project root")).asCmd)
 addCommandAlias("validateJS", (toCompileTestList(jsModules) ++ List("project root")).asCmd)
 addCommandAlias(
   "validate",
   ";clean;compile;coverage;validateJVM;coverageReport;coverageAggregate;coverageOff")
-
-orgScriptTaskListSetting := List("validate".asRunnableItemFull)

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbtorgpolicies.runnable.syntax._
+
 lazy val root = (project in file("."))
   .settings(moduleName := "root")
   .settings(name := "freestyle")
@@ -206,3 +208,18 @@ lazy val allModules: Seq[ProjectReference] = jvmModules ++ jsModules
 
 lazy val jvmFreestyleDeps: Seq[ClasspathDependency] =
   jvmModules.map(ClasspathDependency(_, None))
+
+coverageExcludedFiles in Global  := ".*<macro>"
+
+def toCompileTestList(sequence: Seq[ProjectReference]): List[String] = sequence.toList.map { p =>
+  val project: String = p.asInstanceOf[LocalProject].project
+  s"$project/test"
+}
+
+addCommandAlias("validateJVM", (toCompileTestList(jvmModules) ++ List("project root")).asCmd)
+addCommandAlias("validateJS", (toCompileTestList(jsModules) ++ List("project root")).asCmd)
+addCommandAlias(
+  "validate",
+  ";clean;compile;coverage;validateJVM;coverageReport;coverageAggregate;coverageOff")
+
+orgScriptTaskListSetting := List("validate".asRunnableItemFull)

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,0 +1,28 @@
+import freestyle.FreestylePlugin
+import sbt._
+import sbtorgpolicies.OrgPoliciesPlugin.autoImport.orgScriptTaskListSetting
+import sbtorgpolicies.runnable.syntax._
+import scoverage.ScoverageKeys.coverageExcludedFiles
+
+object ProjectPlugin extends AutoPlugin {
+
+  override def requires: Plugins = FreestylePlugin
+
+  override def trigger: PluginTrigger = allRequirements
+
+  object autoImport {
+
+    def toCompileTestList(sequence: Seq[ProjectReference]): List[String] = sequence.toList.map {
+      p =>
+        val project: String = p.asInstanceOf[LocalProject].project
+        s"$project/test"
+    }
+
+  }
+
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    coverageExcludedFiles in Global := ".*<macro>",
+    orgScriptTaskListSetting := List("validate".asRunnableItemFull)
+  )
+
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,21 +22,24 @@ clone_repo () {
   return 0
 }
 
+EXIT_STATUS=0
+
 DOCS_REPO="https://github.com/frees-io/freestyle-docs.git"
 INTEGRATIONS_REPO="https://github.com/frees-io/freestyle-integrations.git"
 
 VERSION="$(grep -F -m 1 'version in ThisBuild :=' version.sbt)"; VERSION="${VERSION#*\"}"; VERSION="${VERSION%\"*}"
 
-sbt ++$TRAVIS_SCALA_VERSION publishLocal
+(sbt ++$TRAVIS_SCALA_VERSION publishLocal) || EXIT_STATUS=$?
 echo "Checking projects $DOCS_REPO and $INTEGRATIONS_REPO for freestyle version $VERSION"
 
 # Checking freestyle-integrations
-clone_repo $INTEGRATIONS_REPO
-cd freestyle-integrations && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION "clean" "compile" "test" "publishLocal" && cd ..
+(clone_repo $INTEGRATIONS_REPO) || EXIT_STATUS=$?
+(cd freestyle-integrations && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION "clean" "compile" "test" "publishLocal" && cd ..) || EXIT_STATUS=$?
 
 # Checking freestyle-docs
 if [ "$TRAVIS_SCALA_VERSION" = "2.12.2" ]; then
-  clone_repo $DOCS_REPO
-  cd freestyle-docs && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION "clean" "tut"  && cd ..
+  (clone_repo $DOCS_REPO) || EXIT_STATUS=$?
+  (cd freestyle-docs && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION "clean" "tut"  && cd ..) || EXIT_STATUS=$?
 fi
 
+exit $EXIT_STATUS


### PR DESCRIPTION
Fixes #347

Also:
* Avoids running ScalaJS tests twice
* Bring matrix expansions to separate ScalaJVM/ScalaJS Travis builds
* `build.sh` now accumulates errors in the exit code