### PR TITLE
Fixes the packageDoc issue with Scalameta macros

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -24,7 +24,14 @@ object ProjectPlugin extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     coverageExcludedFiles in Global := ".*<macro>",
     orgScriptTaskListSetting := List("validate".asRunnableItemFull),
-    publishArtifact in (Compile, packageDoc) := false
+    packageDoc in Compile := {
+      val sourceFile = (baseDirectory in LocalRootProject).value / "README.md"
+      val targetFile = crossTarget.value / s"${name.value}-javadoc.jar"
+
+      IO.copy(Seq(sourceFile -> targetFile), overwrite = true).toSeq
+
+      targetFile
+    }
   )
 
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,9 +1,7 @@
 import freestyle.FreestylePlugin
 import sbt._
-import sbt.Keys._
 import sbtorgpolicies.OrgPoliciesPlugin.autoImport.orgScriptTaskListSetting
 import sbtorgpolicies.runnable.syntax._
-import scoverage.ScoverageKeys.coverageExcludedFiles
 
 object ProjectPlugin extends AutoPlugin {
 
@@ -11,27 +9,10 @@ object ProjectPlugin extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
 
-  object autoImport {
-
-    def toCompileTestList(sequence: Seq[ProjectReference]): List[String] = sequence.toList.map {
-      p =>
-        val project: String = p.asInstanceOf[LocalProject].project
-        s"$project/test"
-    }
-
-  }
+  object autoImport
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    coverageExcludedFiles in Global := ".*<macro>",
-    orgScriptTaskListSetting := List("validate".asRunnableItemFull),
-    packageDoc in Compile := {
-      val sourceFile = (baseDirectory in LocalRootProject).value / "README.md"
-      val targetFile = crossTarget.value / s"${name.value}-javadoc.jar"
-
-      IO.copy(Seq(sourceFile -> targetFile), overwrite = true).toSeq
-
-      targetFile
-    }
+    orgScriptTaskListSetting := List("validate".asRunnableItemFull)
   )
 
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,7 +40,7 @@ echo "Checking projects $DOCS_REPO and $INTEGRATIONS_REPO for freestyle version 
 # Checking freestyle-docs
 if [ "$TRAVIS_SCALA_VERSION" = "2.12.2" ]; then
   (clone_repo $DOCS_REPO) || EXIT_STATUS=$?
-  (cd freestyle-docs && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION "clean" "tut"  && cd ..) || EXIT_STATUS=$?
+  (cd freestyle-docs && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION "tut"  && cd ..) || EXIT_STATUS=$?
 fi
 
 exit $EXIT_STATUS


### PR DESCRIPTION
This PR comes to fix the scalameta macros expansion issue when docs are being generated.

`publishArtifact in (Compile, packageDoc) := false` is not valid since Sonatype requires the Javadoc jar as a requirement: http://central.sonatype.org/pages/requirements.html#supply-javadoc-and-sources

Hence, these changes override the standard behavior to establish as `javadoc.jar` file the `README.md` file of this project.