### PR TITLE
Freestyle Build Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,13 @@ scala:
 env:
 - SCALAENV=jvm
 - SCALAENV=js
+- FREESBUILD=docs
+- FREESBUILD=integrations
+
+matrix:
+  exclude:
+  - scala: 2.11.11
+    env: FREESBUILD=docs
 
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,22 +26,8 @@ before_install:
   fi
 - export PATH=${PATH}:./vendor/bundle
 
-install:
-- if [ "$TRAVIS_SCALA_VERSION" = "2.12.2" ]; then
-      rvm use 2.2.3 --install --fuzzy ;
-      gem update --system ;
-      gem install sass ;
-      gem install jekyll -v 3.2.1 ;
-  fi
-
 script:
-- if [ "$SCALAENV" = "jvm" ]; then
-    sbt ++$TRAVIS_SCALA_VERSION orgScriptCI;
-    ./scripts/build.sh;
-  fi
-- if [ "$SCALAENV" = "js" ]; then
-    sbt ++$TRAVIS_SCALA_VERSION test:fastOptJS validateJS;
-  fi
+- ./scripts/build.sh
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,10 @@ script:
 - ./scripts/build.sh
 
 after_success:
-- bash <(curl -s https://codecov.io/bash)
-- sbt ++$TRAVIS_SCALA_VERSION orgAfterCISuccess
+- if [ "$TRAVIS_SCALA_VERSION" = "2.12.2" -a "$SCALAENV" = "jvm" ]; then
+    bash <(curl -s https://codecov.io/bash);
+    sbt ++$TRAVIS_SCALA_VERSION orgAfterCISuccess;
+  fi
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
   exclude:
   - scala: 2.11.11
     env: FREESBUILD=docs
+  # Excluding docs check for now
+  - scala: 2.12.2
+    env: FREESBUILD=docs
 
 jdk:
 - oraclejdk8

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -24,7 +24,14 @@ object ProjectPlugin extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     coverageExcludedFiles in Global := ".*<macro>",
     orgScriptTaskListSetting := List("validate".asRunnableItemFull),
-    publishArtifact in (Compile, packageDoc) := false
+    packageDoc in Compile := {
+      val sourceFile = (baseDirectory in LocalRootProject).value / "README.md"
+      val targetFile = crossTarget.value / s"${name.value}-javadoc.jar"
+
+      IO.copy(Seq(sourceFile -> targetFile), overwrite = true).toSeq
+
+      targetFile
+    }
   )
 
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,9 +1,7 @@
 import freestyle.FreestylePlugin
 import sbt._
-import sbt.Keys._
 import sbtorgpolicies.OrgPoliciesPlugin.autoImport.orgScriptTaskListSetting
 import sbtorgpolicies.runnable.syntax._
-import scoverage.ScoverageKeys.coverageExcludedFiles
 
 object ProjectPlugin extends AutoPlugin {
 
@@ -11,27 +9,10 @@ object ProjectPlugin extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
 
-  object autoImport {
-
-    def toCompileTestList(sequence: Seq[ProjectReference]): List[String] = sequence.toList.map {
-      p =>
-        val project: String = p.asInstanceOf[LocalProject].project
-        s"$project/test"
-    }
-
-  }
+  object autoImport
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    coverageExcludedFiles in Global := ".*<macro>",
-    orgScriptTaskListSetting := List("validate".asRunnableItemFull),
-    packageDoc in Compile := {
-      val sourceFile = (baseDirectory in LocalRootProject).value / "README.md"
-      val targetFile = crossTarget.value / s"${name.value}-javadoc.jar"
-
-      IO.copy(Seq(sourceFile -> targetFile), overwrite = true).toSeq
-
-      targetFile
-    }
+    orgScriptTaskListSetting := List("validate".asRunnableItemFull)
   )
 
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,7 +40,7 @@ echo "Checking projects $DOCS_REPO and $INTEGRATIONS_REPO for freestyle version 
 # Checking freestyle-docs
 if [ "$TRAVIS_SCALA_VERSION" = "2.12.2" ]; then
   (clone_repo $DOCS_REPO) || EXIT_STATUS=$?
-  (cd freestyle-docs && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION "clean" "tut"  && cd ..) || EXIT_STATUS=$?
+  (cd freestyle-docs && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION "tut"  && cd ..) || EXIT_STATUS=$?
 fi
 
 exit $EXIT_STATUS

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,18 +29,35 @@ INTEGRATIONS_REPO="https://github.com/frees-io/freestyle-integrations.git"
 
 VERSION="$(grep -F -m 1 'version in ThisBuild :=' version.sbt)"; VERSION="${VERSION#*\"}"; VERSION="${VERSION%\"*}"
 
-(sbt ++$TRAVIS_SCALA_VERSION publishLocal) || EXIT_STATUS=$?
-echo "Checking projects $DOCS_REPO and $INTEGRATIONS_REPO for freestyle version $VERSION"
+SCALA_JS_SCRIPT="sbt ++$TRAVIS_SCALA_VERSION test:fastOptJS validateJS"
+SCALA_JVM_SCRIPT="sbt ++$TRAVIS_SCALA_VERSION orgScriptCI"
 
-# Checking freestyle-integrations
-(clone_repo $INTEGRATIONS_REPO) || EXIT_STATUS=$?
-(cd freestyle-integrations && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION "clean" "compile" "test") || EXIT_STATUS=$?
-(sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION "publishLocal" && cd ..) || EXIT_STATUS=$?
+PUBLISH_PROJECT="sbt ++$TRAVIS_SCALA_VERSION publishLocal"
 
-# Checking freestyle-docs
-if [ "$TRAVIS_SCALA_VERSION" = "2.12.2" ]; then
-  (clone_repo $DOCS_REPO) || EXIT_STATUS=$?
-  (cd freestyle-docs && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION "tut"  && cd ..) || EXIT_STATUS=$?
+CLONE_INTEGRATIONS_REPO="clone_repo $INTEGRATIONS_REPO"
+CLONE_DOCS_REPO="clone_repo $DOCS_REPO"
+
+INTEGRATIONS_SCRIPT="cd freestyle-integrations && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION 'clean' 'compile' 'test' 'publishLocal' && cd .."
+DOCS_SCRIPT="cd freestyle-docs && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION 'tut' && cd .."
+
+if [ "$SCALAENV" = "jvm" ]; then
+  eval $SCALA_JVM_SCRIPT || EXIT_STATUS=$?
+fi
+
+if [ "$SCALAENV" = "js" ]; then
+  eval $SCALA_JS_SCRIPT || EXIT_STATUS=$?
+fi
+
+if [ "$FREESBUILD" = "integrations" ]; then
+  eval $PUBLISH_PROJECT || EXIT_STATUS=$?
+  eval $CLONE_INTEGRATIONS_REPO || EXIT_STATUS=$?
+  eval $INTEGRATIONS_SCRIPT || EXIT_STATUS=$?
+fi
+
+if [ "$FREESBUILD" = "docs" ]; then
+  eval $PUBLISH_PROJECT || EXIT_STATUS=$?
+  eval $CLONE_DOCS_REPO || EXIT_STATUS=$?
+  eval $DOCS_SCRIPT || EXIT_STATUS=$?
 fi
 
 exit $EXIT_STATUS

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,7 +37,7 @@ PUBLISH_PROJECT="sbt ++$TRAVIS_SCALA_VERSION publishLocal"
 CLONE_INTEGRATIONS_REPO="clone_repo $INTEGRATIONS_REPO"
 CLONE_DOCS_REPO="clone_repo $DOCS_REPO"
 
-INTEGRATIONS_SCRIPT="cd freestyle-integrations && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION 'clean' 'compile' 'test' 'publishLocal' && cd .."
+INTEGRATIONS_SCRIPT="cd freestyle-integrations && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION 'clean' 'compile' 'test' && cd .."
 DOCS_SCRIPT="cd freestyle-docs && sbt ++$TRAVIS_SCALA_VERSION -Dfrees.version=$VERSION 'tut' && cd .."
 
 if [ "$SCALAENV" = "jvm" ]; then


### PR DESCRIPTION
This PR brings a new Travis build matrix to run independently all the processes we want to check as a part of the Freestyle pipeline:

* Cross Scala Version (currently, 2.11/2.12)
* Cross ScalaJS builds
* Check [freestyle-integrations](https://github.com/frees-io/freestyle-integrations) project, to be sure we are not breaking it with the changes introduced in the Freestyle's core.
* Check [freestyle-docs](https://github.com/frees-io/freestyle-docs) project, to be sure we are not breaking the documentation.

However, for the last check (docs), we have some unknown issues related to the `tut` task, where it seems we have some collisions in the classpath.

It's not working here:
https://travis-ci.org/frees-io/freestyle/jobs/242480609#L1998

Nevertheless, the same code and versions are working in its own repo:
https://travis-ci.org/frees-io/freestyle-docs/builds/242444127#L2856

I'll submit a new issue to address it apart from this PR.