### PR TITLE
@debug StaticAnnotation

### DIFF
--- a/freestyle/shared/src/main/scala/freestyle/internal/ScalametaUtil.scala
+++ b/freestyle/shared/src/main/scala/freestyle/internal/ScalametaUtil.scala
@@ -17,21 +17,20 @@
 package freestyle.internal
 
 import scala.collection.immutable.Seq
+import scala.meta.Defn.{Class, Object}
 import scala.meta._
-import scala.meta.Defn.{ Class, Trait, Object }
 
 /* Utilities for scalameta independents of freestyle*/
 object ScalametaUtil {
 
   def isAbstract(cls: Class): Boolean = cls.mods.exists {
     case Mod.Abstract() => true
-    case _ => false
+    case _              => false
   }
 
-
-  def toVar(name: Term.Name) = Pat.Var.Term(name)
+  def toVar(name: Term.Name)             = Pat.Var.Term(name)
   def toName(par: Term.Param): Term.Name = Term.Name(par.name.value)
-  def toType(par: Type.Param): Type = Type.Name(par.name.value)
+  def toType(par: Type.Param): Type      = Type.Name(par.name.value)
 
   def tyParam(ty: Type.Name): Type.Param =
     q"type X[Y]".tparams.head.copy(name = ty) // take Y, replace Y name with tyn
@@ -43,9 +42,8 @@ object ScalametaUtil {
 
   def tyAddArg(tyApp: Type, tyArg: Type): Type.Apply = tyApp match {
     case Type.Apply(tyFun, tyArgs) => Type.Apply(tyFun, tyArg +: tyArgs)
-    case ty => Type.Apply( ty, Seq(tyArg) )
+    case ty                        => Type.Apply(ty, Seq(tyArg))
   }
-
 
   /* Given a Decl.Def, that represents an abstract method, make a concrete method Defn.Def
    *   by giving it a Term that serves as its body */
@@ -53,11 +51,11 @@ object ScalametaUtil {
     Defn.Def(decl.mods, decl.name, decl.tparams, decl.paramss, Some(decl.decltpe), body)
 
   def mkObject(
-    mods: Seq[Mod] = Nil,
-    name: Term.Name,
-    early: Seq[Stat] = Nil,
-    parents: Seq[Ctor.Call] = Nil,
-    self: Term.Param = Term.Param(Nil, Name.Anonymous(), None, None),
-    stats: Seq[Stat]) = Object( mods, name, Template(early, parents, self, if (stats.isEmpty) Some(stats) else None))
+      mods: Seq[Mod] = Nil,
+      name: Term.Name,
+      early: Seq[Stat] = Nil,
+      parents: Seq[Ctor.Call] = Nil,
+      self: Term.Param = Term.Param(Nil, Name.Anonymous(), None, None),
+      stats: Seq[Stat]) =
+    Object(mods, name, Template(early, parents, self, if (stats.isEmpty) Some(stats) else None))
 }
-

--- a/freestyle/shared/src/main/scala/freestyle/internal/free.scala
+++ b/freestyle/shared/src/main/scala/freestyle/internal/free.scala
@@ -33,14 +33,20 @@ trait EffectLike[F[_]] {
 object freeImpl {
 
   import errors._
+  import syntax._
 
   def free(defn: Any): Stat = defn match {
 
     case cls: Trait =>
-      freeAlg(Algebra(cls.mods, cls.name, cls.tparams, cls.ctor, cls.templ), true)
-
+      freeAlg(
+        Algebra(cls.mods.filtered, cls.name, cls.tparams, cls.ctor, cls.templ),
+        isTrait = true)
+        .`debug?`(cls.mods)
     case cls: Class if ScalametaUtil.isAbstract(cls) =>
-      freeAlg(Algebra(cls.mods, cls.name, cls.tparams, cls.ctor, cls.templ), false)
+      freeAlg(
+        Algebra(cls.mods.filtered, cls.name, cls.tparams, cls.ctor, cls.templ),
+        isTrait = false)
+        .`debug?`(cls.mods)
 
     case c: Class /* ! isAbstract */   => abort(s"$invalid in ${c.name}. $abstractOnly")
     case Term.Block(Seq(_, c: Object)) => abort(s"$invalid in ${c.name}. $noCompanion")
@@ -92,8 +98,8 @@ private[internal] case class Algebra(
     case (dd, ix) => new Request(dd, ix)
   }
 
-  val OP        = Type.Name("Op") // Root trait of the Effect ADT
-  val indexName = Term.fresh("FSAlgebraIndex")
+  val OP: Type.Name        = Type.Name("Op") // Root trait of the Effect ADT
+  val indexName: Term.Name = Term.fresh("FSAlgebraIndex")
 
   def handlerTrait: Trait = {
     val mm = Type.fresh("MM$")

--- a/freestyle/shared/src/main/scala/freestyle/internal/module.scala
+++ b/freestyle/shared/src/main/scala/freestyle/internal/module.scala
@@ -25,14 +25,21 @@ import scala.meta.Defn.{Class, Object, Trait}
 object moduleImpl {
 
   import ModuleUtil._
+  import syntax._
 
   def module(defn: Any): Term.Block = defn match {
     case cls: Trait =>
-      val fsmod = FreeSModule(cls.mods, cls.name, cls.tparams, cls.ctor, cls.templ, true)
-      Term.Block(Seq(fsmod.makeClass, fsmod.makeObject))
+      val fsmod =
+        FreeSModule(cls.mods.filtered, cls.name, cls.tparams, cls.ctor, cls.templ, isTrait = true)
+      Term
+        .Block(Seq(fsmod.makeClass, fsmod.makeObject))
+        .`debug?`(cls.mods)
     case cls: Class if ScalametaUtil.isAbstract(cls) =>
-      val fsmod = FreeSModule(cls.mods, cls.name, cls.tparams, cls.ctor, cls.templ, false)
-      Term.Block(Seq(fsmod.makeClass, fsmod.makeObject))
+      val fsmod =
+        FreeSModule(cls.mods.filtered, cls.name, cls.tparams, cls.ctor, cls.templ, isTrait = false)
+      Term
+        .Block(Seq(fsmod.makeClass, fsmod.makeObject))
+        .`debug?`(cls.mods)
     case c: Class /* ! isAbstract */ =>
       abort(abstractOnly)
     case Term.Block(Seq(_, c: Object)) =>

--- a/freestyle/shared/src/main/scala/freestyle/internal/syntax.scala
+++ b/freestyle/shared/src/main/scala/freestyle/internal/syntax.scala
@@ -14,23 +14,34 @@
  * limitations under the License.
  */
 
-package freestyle
+package freestyle.internal
 
-import scala.annotation.{compileTimeOnly, StaticAnnotation}
-import freestyle.internal.{ freeImpl, moduleImpl }
+import scala.collection.immutable.Seq
+import scala.meta._
 
-@compileTimeOnly("enable macro paradise to expand @free macro annotations")
-class free extends StaticAnnotation {
-  import scala.meta._
+object syntax {
 
-  inline def apply(defn: Any): Any = meta { freeImpl.free(defn) }
+  implicit def debugSyntax(block: Term.Block): DebugOps = new DebugOps(block)
+
+  implicit def filterModifiers(mods: Seq[Mod]): ModOps = new ModOps(mods)
+
+  final class DebugOps(block: Term.Block) {
+
+    def `debug?`(mods: Seq[Mod]): Term.Block = {
+      mods foreach {
+        case mod"@debug" => println(block)
+        case _           =>
+      }
+      block
+    }
+  }
+
+  final class ModOps(mods: Seq[Mod]) {
+
+    def filtered: Seq[Mod] = mods.filter {
+      case mod"@debug" => false
+      case _           => true
+    }
+  }
+
 }
-
-@compileTimeOnly("enable macro paradise to expand @module macro annotations")
-class module extends StaticAnnotation {
-  import scala.meta._
-
-  inline def apply(defn: Any): Any = meta { moduleImpl.module(defn) }
-}
-
-class debug extends StaticAnnotation

--- a/freestyle/shared/src/test/scala/freestyle/free.scala
+++ b/freestyle/shared/src/test/scala/freestyle/free.scala
@@ -168,6 +168,22 @@ class freeTests extends WordSpec with Matchers {
 
   }
 
+  "the @free macro annotation works together with @debug annotation" when {
+
+    "a trait without @free macro annotation is ignored" ignore {
+      "@debug trait X { def f(a: Char) : FS[Int] }" should compile
+    }
+
+    "a trait with at least one request" in {
+      "@free @debug trait Y { def bar(x:Int): FS[Int] }" should compile
+    }
+
+    "an abstract class with at least one request" in {
+      "@debug @free abstract class Z { def bar(x:Int): FS[Int] }" should compile
+    }
+
+  }
+
   "The @free annotation should generate interpreters or Handlers that" should {
 
     "allow `FreeS` operations that use other abstract operations" in {

--- a/freestyle/shared/src/test/scala/freestyle/module.scala
+++ b/freestyle/shared/src/test/scala/freestyle/module.scala
@@ -35,7 +35,6 @@ class moduleTests extends WordSpec with Matchers {
       """@module trait  Foo[F[_]] { val x: Int} ; object Foo """ shouldNot compile
     }
 
-
     "[simple] create a companion with a `T` type alias" in {
       type T[A] = M1.Op[A]
     }
@@ -178,5 +177,24 @@ class moduleTests extends WordSpec with Matchers {
         |  val a: P.Y
         |}""".stripMargin should compile
     }
+  }
+
+  "@module @free and @debug annotations work together" when {
+
+    "a trait with @module and @debug macro annotations work as expected, printing the generated code" in {
+      """
+        |@free @debug trait X {
+        |  def x: FS[Int]
+        |}
+        |object P {
+        |  @module trait Y {
+        |    val repo: X
+        |  }
+        |}
+        |@module @debug trait Z {
+        |  val a: P.Y
+        |}""".stripMargin should compile
+    }
+
   }
 }


### PR DESCRIPTION
This PR ships a new `@debug` annotation that can be used with `@free` and `@module` macro annotations, providing the ability to show the generated code in compilation time.

For example:

```scala
@free @debug trait X {
  def x: FS[Int]
}
object P {
  @module trait Y {
    val repo: X
  }
}
@module @debug trait Z {
  val a: P.Y
}
```

will show in the output something like this:

```scala
{
  trait X[FF$343[_]] extends _root_.freestyle.internal.EffectLike[FF$343] { def x: FS[Int] }
  object X {
    sealed trait Op[_] extends scala.Product with java.io.Serializable { val FSAlgebraIndex342: _root_.scala.Int }
    case class XOP() extends AnyRef with Op[Int] { override val FSAlgebraIndex342: _root_.scala.Int = 0 }
    type OpTypes = _root_.iota.KCons[Op, _root_.iota.KNil]
    trait Handler[MM$349[_]] extends _root_.freestyle.FSHandler[Op, MM$349] {
      protected[this] def x: MM$349[Int]
      override def apply[AA$350](fa$351: Op[AA$350]): MM$349[AA$350] = ((fa$351.FSAlgebraIndex342: @_root_.scala.annotation.switch) match {
        case 0 =>
          x
        case i =>
          throw new _root_.java.lang.Exception(s"freestyle internal error: index " + i + " out of bounds for " + this)
      }).asInstanceOf[MM$349[AA$350]]
    }
    class To[LL$345[_]](implicit ii$346: _root_.freestyle.InjK[Op, LL$345]) extends X[LL$345] {
      private[this] val toInj347 = _root_.freestyle.FreeS.inject[Op, LL$345](ii$346)
      override def x: FS[Int] = toInj347(XOP())
    }
    implicit def to[LL$345[_]](implicit ii$346: _root_.freestyle.InjK[Op, LL$345]): To[LL$345] = new To[LL$345]
    def apply[LL$345[_]](implicit ev$348: X[LL$345]): X[LL$345] = ev$348
  }
}
{
  trait Z[FF$352[_]] extends _root_.freestyle.internal.EffectLike[FF$352] { val a: P.Y[FF$352] }
  object Z {
    type OpTypes = P.Y.OpTypes
    type Op[AA$354] = _root_.iota.CopK[OpTypes, AA$354]
    class To[GG$353[_]](implicit val a: P.Y[GG$353]) extends Z[GG$353] {}
    implicit def to[GG$353[_]](implicit a: P.Y[GG$353]): To[GG$353] = new To[GG$353]()
    def apply[GG$353[_]](implicit ev: Z[GG$353]): Z[GG$353] = ev
  }
}
```

As you can see, only the pieces that you want to debug will be shown.

If this makes sense, I'll add a new tiny docs section explaining how to use it.