### PR TITLE
Remove MonadError requirement for logging algebra

### DIFF
--- a/freestyle-logging/js/src/main/scala/loggingJS.scala
+++ b/freestyle-logging/js/src/main/scala/loggingJS.scala
@@ -16,38 +16,37 @@
 
 package freestyle
 
-import cats.MonadError
+import cats.Monad
 import freestyle.logging._
 import slogging._
 
 object loggingJS {
 
   trait Implicits {
-    implicit def freeStyleLoggingHandler[M[_]](
-        implicit ME: MonadError[M, Throwable]): LoggingM.Handler[M] =
+    implicit def freeStyleLoggingHandler[M[_]](implicit M: Monad[M]): LoggingM.Handler[M] =
       new LoggingM.Handler[M] with LazyLogging {
 
         LoggerConfig.factory = PrintLoggerFactory()
 
-        def debug(msg: String): M[Unit] = ME.catchNonFatal(logger.debug(msg))
+        def debug(msg: String): M[Unit] = M.pure(logger.debug(msg))
 
         def debugWithCause(msg: String, cause: Throwable): M[Unit] =
-          ME.catchNonFatal(logger.debug(msg, cause))
+          M.pure(logger.debug(msg, cause))
 
-        def error(msg: String): M[Unit] = ME.catchNonFatal(logger.error(msg))
+        def error(msg: String): M[Unit] = M.pure(logger.error(msg))
 
         def errorWithCause(msg: String, cause: Throwable): M[Unit] =
-          ME.catchNonFatal(logger.error(msg, cause))
+          M.pure(logger.error(msg, cause))
 
-        def info(msg: String): M[Unit] = ME.catchNonFatal(logger.info(msg))
+        def info(msg: String): M[Unit] = M.pure(logger.info(msg))
 
         def infoWithCause(msg: String, cause: Throwable): M[Unit] =
-          ME.catchNonFatal(logger.info(msg, cause))
+          M.pure(logger.info(msg, cause))
 
-        def warn(msg: String): M[Unit] = ME.catchNonFatal(logger.warn(msg))
+        def warn(msg: String): M[Unit] = M.pure(logger.warn(msg))
 
         def warnWithCause(msg: String, cause: Throwable): M[Unit] =
-          ME.catchNonFatal(logger.warn(msg, cause))
+          M.pure(logger.warn(msg, cause))
       }
   }
 

--- a/freestyle-logging/jvm/src/main/scala/loggingJVM.scala
+++ b/freestyle-logging/jvm/src/main/scala/loggingJVM.scala
@@ -16,7 +16,7 @@
 
 package freestyle
 
-import cats.MonadError
+import cats.Monad
 import freestyle.logging._
 import journal._
 
@@ -24,30 +24,30 @@ object loggingJVM {
 
   trait Implicits {
     implicit def freeStyleLoggingHandler[M[_], C: Manifest](
-        implicit ME: MonadError[M, Throwable]): LoggingM.Handler[M] =
+        implicit M: Monad[M]): LoggingM.Handler[M] =
       new LoggingM.Handler[M] {
 
         val logger = Logger[C]
 
-        def debug(msg: String): M[Unit] = ME.catchNonFatal(logger.debug(msg))
+        def debug(msg: String): M[Unit] = M.pure(logger.debug(msg))
 
         def debugWithCause(msg: String, cause: Throwable): M[Unit] =
-          ME.catchNonFatal(logger.debug(msg, cause))
+          M.pure(logger.debug(msg, cause))
 
-        def error(msg: String): M[Unit] = ME.catchNonFatal(logger.error(msg))
+        def error(msg: String): M[Unit] = M.pure(logger.error(msg))
 
         def errorWithCause(msg: String, cause: Throwable): M[Unit] =
-          ME.catchNonFatal(logger.error(msg, cause))
+          M.pure(logger.error(msg, cause))
 
-        def info(msg: String): M[Unit] = ME.catchNonFatal(logger.info(msg))
+        def info(msg: String): M[Unit] = M.pure(logger.info(msg))
 
         def infoWithCause(msg: String, cause: Throwable): M[Unit] =
-          ME.catchNonFatal(logger.info(msg, cause))
+          M.pure(logger.info(msg, cause))
 
-        def warn(msg: String): M[Unit] = ME.catchNonFatal(logger.warn(msg))
+        def warn(msg: String): M[Unit] = M.pure(logger.warn(msg))
 
         def warnWithCause(msg: String, cause: Throwable): M[Unit] =
-          ME.catchNonFatal(logger.warn(msg, cause))
+          M.pure(logger.warn(msg, cause))
       }
   }
 

--- a/freestyle-logging/jvm/src/test/scala/LoggingTests.scala
+++ b/freestyle-logging/jvm/src/test/scala/LoggingTests.scala
@@ -32,9 +32,9 @@ class LoggingTests extends AsyncWordSpec with Matchers {
 
   "Logging Freestyle integration" should {
 
-    "allow a log message to be interleaved inside a program monadic flow" in {
-      case object Cause extends Exception("kaboom") with NoStackTrace
+    case object Cause extends Exception("kaboom") with NoStackTrace
 
+    "allow a log message to be interleaved inside a program monadic flow" in {
       val program = for {
         a <- app.nonLogging.x
         _ <- app.loggingM.debug("Debug Message")
@@ -50,5 +50,14 @@ class LoggingTests extends AsyncWordSpec with Matchers {
       program.interpret[Future] map { _ shouldBe 2 }
     }
 
+    "not depend on MonadError, thus allowing use of Monads without MonadError, like Id, for test algebras" in {
+      val program = for {
+        a <- app.nonLogging.x
+        _ <- app.loggingM.info("Info Message")
+        _ <- app.loggingM.infoWithCause("Info Message", Cause)
+        b <- FreeS.pure(1)
+      } yield a + b
+      program.interpret[TestAlgebra].run("configHere") shouldBe 2
+    }
   }
 }

--- a/freestyle-logging/shared/src/test/scala/algebras.scala
+++ b/freestyle-logging/shared/src/test/scala/algebras.scala
@@ -16,6 +16,8 @@
 
 package freestyle
 
+import cats.Id
+import cats.data.Kleisli
 import freestyle.logging.LoggingM
 
 import scala.concurrent.Future
@@ -27,9 +29,16 @@ object algebras {
     def x: FS[Int]
   }
 
-  implicit def nonLoggingHandler: NonLogging.Handler[Future] =
+  implicit def nonLoggingFutureHandler: NonLogging.Handler[Future] =
     new NonLogging.Handler[Future] {
       def x: Future[Int] = Future.successful(1)
+    }
+
+  type TestAlgebra[A] = Kleisli[Id, String, A]
+
+  implicit def nonLoggingTestAlgebraHandler: NonLogging.Handler[TestAlgebra] =
+    new NonLogging.Handler[TestAlgebra] {
+      def x: TestAlgebra[Int] = Kleisli.pure(1)
     }
 
   @module


### PR DESCRIPTION
Restricting logging algebra to require MonadError evidence caused issues when using common Monads like Id in testing, as that monad lacks a MonadError instance.

This fix replaces the MonadError evidence by a simple Monad evidence and expects the effect capturing monad at the end of the stack to handle any exceptions raised during Logging.