### PR TITLE
failing testcase for comprehension with one generator and an assignment

### DIFF
--- a/freestyle/shared/src/test/scala/freestyle/module.scala
+++ b/freestyle/shared/src/test/scala/freestyle/module.scala
@@ -177,6 +177,23 @@ class moduleTests extends WordSpec with Matchers {
         |  val a: P.Y
         |}""".stripMargin should compile
     }
+
+    "allow single generator for comprehensions" in {
+      """
+        @free trait Foo {
+          def foo: FS[Int]
+        }
+        @module trait Bar {
+          val foo: Foo
+
+          def bar: FS[Double] = for {
+            f <- foo.foo
+            bar = f.toDouble
+          } yield bar
+        }
+      """ should compile
+
+    }
   }
 
   "@module @free and @debug annotations work together" when {


### PR DESCRIPTION
failing testcase for #369

@xeno-by this looks like a `scala.meta` bug... can scala.meta parse something like this?

```scala
          def bar: Option[Double] = for {
            f <- getOptionInt
            bar = f.toDouble
          } yield bar
```