### PR TITLE
Adding support for case classy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,9 @@ lazy val config = (project in file("freestyle-config"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      %("config", "1.2.1")
+      %("config", "1.2.1"),
+      %%("classy-config-typesafe"),
+      %%("classy-core")
     ) ++ commonDeps
   )
 

--- a/freestyle-config/src/main/scala/config.scala
+++ b/freestyle-config/src/main/scala/config.scala
@@ -16,12 +16,14 @@
 
 package freestyle
 
-import scala.collection.JavaConverters._
-import scala.concurrent.duration._
-
 import cats.MonadError
 import cats.syntax.either._
+import classy._
+import classy.config._
 import com.typesafe.config.{ConfigException, ConfigFactory}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 
 object config {
 
@@ -44,6 +46,8 @@ object config {
     def load: FS[Config]
     def empty: FS[Config]
     def parseString(s: String): FS[Config]
+    def loadAs[T](implicit dec: ConfigDecoder[T]): FS[Either[DecodeError, T]]
+    def parseStringAs[T](s: String)(implicit dec: ConfigDecoder[T]): FS[Either[DecodeError, T]]
   }
 
   object implicits {
@@ -74,6 +78,10 @@ object config {
         def empty: M[Config] = ME.pure(loadConfig(ConfigFactory.empty()))
         def parseString(s: String): M[Config] =
           ME.catchNonFatal(loadConfig(ConfigFactory.parseString(s)))
+        def loadAs[T](decoder: ConfigDecoder[T]): M[Either[DecodeError, T]] =
+          ME.pure(decoder.load())
+        def parseStringAs[T](s: String, decoder: ConfigDecoder[T]): M[Either[DecodeError, T]] =
+          ME.pure(decoder.fromString(s))
       }
   }
 

--- a/freestyle-config/src/test/scala/ConfigTests.scala
+++ b/freestyle-config/src/test/scala/ConfigTests.scala
@@ -27,6 +27,8 @@ import cats.instances.either._
 import cats.instances.future._
 import cats.syntax.cartesian._
 import cats.syntax.either._
+import classy.config._
+import com.typesafe.config.{Config => TypesafeConfig}
 
 class ConfigTests extends AsyncWordSpec with Matchers {
 
@@ -72,6 +74,26 @@ class ConfigTests extends AsyncWordSpec with Matchers {
       }
     }
 
+    "allow configuration to load classpath files and convert into case class" in {
+      case class MyConfig(s: Int)
+      implicit val decoder = readConfig[Int]("s") map MyConfig.apply
+      app.configM.loadAs[MyConfig].interpret[Future] map { _ shouldBe Right(MyConfig(3)) }
+    }
+
+    "allow configuration to parse strings and convert into case class" in {
+      case class MyConfig(n: Int, s: String, b: Boolean)
+      implicit val decoder = for {
+        n <- readConfig[Int]("n")
+        s <- readConfig[String]("s")
+        b <- readConfig[Boolean]("b")
+      } yield MyConfig(n, s, b)
+
+      val config = """{n = 1, s = "foo", b = true}"""
+
+      app.configM.parseStringAs[MyConfig](config).interpret[Future] map {
+        _ shouldBe Right(MyConfig(1, "foo", true))
+      }
+    }
   }
 
 }

--- a/freestyle-config/src/test/scala/ConfigTests.scala
+++ b/freestyle-config/src/test/scala/ConfigTests.scala
@@ -77,7 +77,7 @@ class ConfigTests extends AsyncWordSpec with Matchers {
     "allow configuration to load classpath files and convert into case class" in {
       case class MyConfig(s: Int)
       implicit val decoder = readConfig[Int]("s") map MyConfig.apply
-      app.configM.loadAs[MyConfig].interpret[Future] map { _ shouldBe Right(MyConfig(3)) }
+      app.configM.loadAs[MyConfig].interpret[Future] map { _ shouldBe MyConfig(3) }
     }
 
     "allow configuration to parse strings and convert into case class" in {
@@ -91,7 +91,7 @@ class ConfigTests extends AsyncWordSpec with Matchers {
       val config = """{n = 1, s = "foo", b = true}"""
 
       app.configM.parseStringAs[MyConfig](config).interpret[Future] map {
-        _ shouldBe Right(MyConfig(1, "foo", true))
+        _ shouldBe MyConfig(1, "foo", true)
       }
     }
   }


### PR DESCRIPTION
This pull request adds two new methods in config algebra called `loadAs[T]` and `parseStringAs[T]` that will allow us to decode the content of the config file into a case class of type `T`.