### PR TITLE
Move Monix tests to tests module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,6 @@ lazy val freestyle = (crossProject in file("freestyle"))
       %("iota-core"),
       %("cats-free"),
       %("shapeless"),
-      %("monix-eval") % "test",
-      %("monix-cats") % "test",
       %("cats-laws")  % "test",
       %("discipline") % "test"
     ): _*
@@ -45,12 +43,14 @@ lazy val taglessJVM = tagless.jvm
 lazy val taglessJS  = tagless.js
 
 lazy val tests = (project in file("tests"))
-  .dependsOn(freestyleJVM)
+  .dependsOn(freestyleJVM % "compile->compile;test->test")
   .settings(noPublishSettings: _*)
   .settings(
     libraryDependencies ++= commonDeps ++ Seq(
       %("scala-reflect", scalaVersion.value),
-      %%("pcplod") % "test"
+      %%("pcplod") % "test",
+      %%("monix-eval") % "test",
+      %%("monix-cats") % "test"
     ),
     fork in Test := true,
     javaOptions in Test ++= {
@@ -201,6 +201,7 @@ lazy val jvmModules: Seq[ProjectReference] = Seq(
   cacheJVM,
   config,
   loggingJVM
+  // ,tests
 )
 
 lazy val jsModules: Seq[ProjectReference] = Seq(

--- a/tests/src/test/scala/MonixParallelTests.scala
+++ b/tests/src/test/scala/MonixParallelTests.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.tests
+
+import freestyle.implicits._
+import monix.eval.Task
+import monix.cats._
+import monix.eval.Task.nondeterminism
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{Matchers, WordSpec}
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class MonixParallelTests extends WordSpec with Matchers {
+  "Applicative Parallel Support" should {
+    "allow non deterministic execution when interpreting to monix.eval.Task" in {
+
+      val test = new freestyle.NonDeterminismTestShared
+      import test._
+
+      implicit val interpreter = new freestyle.MixedFreeS.Handler[Task] {
+        override def x: Task[Int] = Task(blocker(1, 1000L))
+        override def y: Task[Int] = Task(blocker(2, 0L))
+        override def z: Task[Int] = Task(blocker(3, 2000L))
+      }
+
+      Await.result(program.interpret[Task].runAsync, Duration.Inf) shouldBe List(3, 1, 2, 3)
+      buf.toArray shouldBe Array(3, 2, 1, 3)
+    }
+  }
+}

--- a/tests/src/test/scala/Tests.scala
+++ b/tests/src/test/scala/Tests.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package freestyle
+package freestyle.tests
 
 import org.scalatest.{Matchers, WordSpec}
 import cats.implicits._


### PR DESCRIPTION
This means we don't have a test dependency on monix in freestyle itself anymore.

This means we can publish a `freestyle` milestone without having to wait on a monix release supporting Cats 1.0.0-MF by just using a tagged monix version as a dependency in `tests`.