### PR TITLE
Rename algebra operation suffix from `OP` to `Op`

### DIFF
--- a/freestyle-logging/js/src/main/scala/loggingJS.scala
+++ b/freestyle-logging/js/src/main/scala/loggingJS.scala
@@ -25,74 +25,62 @@ object loggingJS {
   trait Implicits {
     implicit def freeStyleLoggingHandler[M[_]](implicit M: Monad[M]): LoggingM.Handler[M] =
       new LoggingM.Handler[M] with LazyLogging {
+        import sourcecode.{File, Line}
 
         private[this] def formatMessage(
             msg: String,
             sourceAndLineInfo: Boolean,
-            line: sourcecode.Line,
-            file: sourcecode.File): String =
+            line: Line,
+            file: File): String =
           if (sourceAndLineInfo) s"$file:$line: $msg"
           else msg
 
-        def debug(
-            msg: String,
-            sourceAndLineInfo: Boolean,
-            line: sourcecode.Line,
-            file: sourcecode.File): M[Unit] =
-          M.pure(logger.debug(formatMessage(msg, sourceAndLineInfo, line, file)))
+        private def withLogger[A](f: Logger => A): M[A] =
+          M.pure(f(logger))
+
+        def debug(msg: String, sourceAndLineInfo: Boolean, line: Line, file: File): M[Unit] =
+          withLogger(_.debug(formatMessage(msg, sourceAndLineInfo, line, file)))
 
         def debugWithCause(
             msg: String,
             cause: Throwable,
             sourceAndLineInfo: Boolean,
-            line: sourcecode.Line,
-            file: sourcecode.File): M[Unit] =
-          M.pure(logger.debug(formatMessage(msg, sourceAndLineInfo, line, file), cause))
+            line: Line,
+            file: File): M[Unit] =
+          withLogger(_.debug(formatMessage(msg, sourceAndLineInfo, line, file), cause))
 
-        def error(
-            msg: String,
-            sourceAndLineInfo: Boolean,
-            line: sourcecode.Line,
-            file: sourcecode.File): M[Unit] =
-          M.pure(logger.error(formatMessage(msg, sourceAndLineInfo, line, file)))
+        def error(msg: String, sourceAndLineInfo: Boolean, line: Line, file: File): M[Unit] =
+          withLogger(_.error(formatMessage(msg, sourceAndLineInfo, line, file)))
 
         def errorWithCause(
             msg: String,
             cause: Throwable,
             sourceAndLineInfo: Boolean,
-            line: sourcecode.Line,
-            file: sourcecode.File): M[Unit] =
-          M.pure(logger.error(formatMessage(msg, sourceAndLineInfo, line, file), cause))
+            line: Line,
+            file: File): M[Unit] =
+          withLogger(_.error(formatMessage(msg, sourceAndLineInfo, line, file), cause))
 
-        def info(
-            msg: String,
-            sourceAndLineInfo: Boolean,
-            line: sourcecode.Line,
-            file: sourcecode.File): M[Unit] =
-          M.pure(logger.info(formatMessage(msg, sourceAndLineInfo, line, file)))
+        def info(msg: String, sourceAndLineInfo: Boolean, line: Line, file: File): M[Unit] =
+          withLogger(_.info(formatMessage(msg, sourceAndLineInfo, line, file)))
 
         def infoWithCause(
             msg: String,
             cause: Throwable,
             sourceAndLineInfo: Boolean,
-            line: sourcecode.Line,
-            file: sourcecode.File): M[Unit] =
-          M.pure(logger.info(formatMessage(msg, sourceAndLineInfo, line, file), cause))
+            line: Line,
+            file: File): M[Unit] =
+          withLogger(_.info(formatMessage(msg, sourceAndLineInfo, line, file), cause))
 
-        def warn(
-            msg: String,
-            sourceAndLineInfo: Boolean,
-            line: sourcecode.Line,
-            file: sourcecode.File): M[Unit] =
-          M.pure(logger.warn(formatMessage(msg, sourceAndLineInfo, line, file)))
+        def warn(msg: String, sourceAndLineInfo: Boolean, line: Line, file: File): M[Unit] =
+          withLogger(_.warn(formatMessage(msg, sourceAndLineInfo, line, file)))
 
         def warnWithCause(
             msg: String,
             cause: Throwable,
             sourceAndLineInfo: Boolean,
-            line: sourcecode.Line,
-            file: sourcecode.File): M[Unit] =
-          M.pure(logger.warn(formatMessage(msg, sourceAndLineInfo, line, file), cause))
+            line: Line,
+            file: File): M[Unit] =
+          withLogger(_.warn(formatMessage(msg, sourceAndLineInfo, line, file), cause))
       }
   }
 

--- a/freestyle/shared/src/main/scala/freestyle/internal/free.scala
+++ b/freestyle/shared/src/main/scala/freestyle/internal/free.scala
@@ -190,7 +190,7 @@ private[internal] class Request(reqDef: Decl.Def, indexValue: Int) {
 
   // Name of the Request ADT Class
   private[this] val reqName: String = reqDef.name.value
-  private[this] val req: Type.Name  = Type.Name(reqName.capitalize + "OP")
+  private[this] val req: Type.Name  = Type.Name(reqName.capitalize + "Op")
   private[this] val cboundPrefix = "__$cbound"
 
   private[this] val res: Type = reqDef.decltpe match {

--- a/freestyle/shared/src/test/scala/freestyle/free.scala
+++ b/freestyle/shared/src/test/scala/freestyle/free.scala
@@ -146,8 +146,8 @@ class freeTests extends WordSpec with Matchers {
           def sc2(a: Int, b: Int, c: Int): FS[Int]
         }
         implicitly[FriendlyFreeS.Op[_] =:= FriendlyFreeS.Op[_]]
-        implicitly[FriendlyFreeS.Sc1OP <:< FriendlyFreeS.Op[Int]]
-        implicitly[FriendlyFreeS.Sc2OP <:< FriendlyFreeS.Op[Int]]
+        implicitly[FriendlyFreeS.Sc1Op <:< FriendlyFreeS.Op[Int]]
+        implicitly[FriendlyFreeS.Sc2Op <:< FriendlyFreeS.Op[Int]]
       """ should compile
     }
 


### PR DESCRIPTION
Rename the `OP` algebra operation suffix to `Op` to be consistent with the `Op` type in `@module` (and `@free`) companion objects.

I refactored the loggingJVM handler to use the ideomatic method
freestyle handler instead of pattern matching on the algebra operations.

I suspect we only need to change the handler section of freestyle-docs afterwards.

Resolves #382.