### PR TITLE
Bumps sbt-freestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: precise
 
 scala:
 - 2.11.11
-- 2.12.2
+- 2.12.3
 
 env:
 - SCALAENV=jvm
@@ -17,7 +17,7 @@ matrix:
   - scala: 2.11.11
     env: FREESBUILD=docs
   # Excluding docs check for now
-  #- scala: 2.12.2
+  #- scala: 2.12.3
   #  env: FREESBUILD=docs
 
 jdk:
@@ -33,14 +33,14 @@ script:
 - ./scripts/build.sh
 
 after_success:
-- if [ "$TRAVIS_SCALA_VERSION" = "2.12.2" -a "$SCALAENV" = "jvm" ]; then
+- if [ "$TRAVIS_SCALA_VERSION" = "2.12.3" -a "$SCALAENV" = "jvm" ]; then
     bash <(curl -s https://codecov.io/bash);
   fi
 - sbt ++$TRAVIS_SCALA_VERSION orgAfterCISuccess
 
 cache:
   directories:
-  - $HOME/.sbt/0.13
+  - $HOME/.sbt/1.0
   - $HOME/.sbt/boot/scala*
   - $HOME/.sbt/cache
   - $HOME/.sbt/launchers

--- a/modules/config/src/main/scala/config.scala
+++ b/modules/config/src/main/scala/config.scala
@@ -27,8 +27,7 @@ import scala.concurrent.duration._
 
 object config {
 
-  case class ConfigError(msg: String, underlying: Option[Throwable] = None)
-      extends Throwable(msg) {
+  case class ConfigError(msg: String, underlying: Option[Throwable] = None) extends Throwable(msg) {
     underlying foreach initCause
   }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("io.frees"        % "sbt-freestyle"   % "0.2.1")
+addSbtPlugin("io.frees"        % "sbt-freestyle"   % "0.2.2")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("io.frees"        % "sbt-freestyle"   % "0.1.1")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.0.3")
+resolvers += Resolver.sonatypeRepo("releases")
+addSbtPlugin("io.frees"        % "sbt-freestyle"   % "0.2.1")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.0")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC1")


### PR DESCRIPTION
This PR bumps the version of `sbt-freestyle`, which transitively means:

* Upgrade to sbt `1.0.1`.
* Upgrade all the project dependencies including `cats`, `scalameta`, `monix`, etc.
* Upgrade plugins, including `sbt-microsites`, `sbt-dependencies`, etc.
* Disables scalafmt auto-format until this issue is complete: https://github.com/47deg/sbt-org-policies/issues/511 .
* Disables sbt-coursier by default until next stable version.
* Others.