### PR TITLE
Releases Freestyle 0.4.1

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.1-SNAPSHOT"
+version in ThisBuild := "0.4.1"


### PR DESCRIPTION
Releases Freestyle `0.4.1`.

It just integrates all the repositories all-in-one. As a result, we're releasing `frees-http-client`, which is not available in `0.4.0`.