### PR TITLE
Adds a custom deploy job stage for releasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ matrix:
   exclude:
   - scala: 2.11.11
     env: FREESBUILD=docs
-  - scala: 2.11.11
-    env: SCALAENV=all
+  - env: SCALAENV=all
 
 jdk:
 - oraclejdk8
@@ -56,28 +55,13 @@ script:
     sbt ++$TRAVIS_SCALA_VERSION validateJS;
   elif [ "$FREESBUILD" = "docs" ]; then
     sbt ++$TRAVIS_SCALA_VERSION docs/tut;
-  elif [ "$SCALAENV" = "all" ]; then
-    sbt ++$TRAVIS_SCALA_VERSION validate;
   else
     echo "You might not be invited to the party";
   fi
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)
-- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
-    if grep -q "SNAPSHOT" version.sbt; then
-      sbt ++$TRAVIS_SCALA_VERSION publish;
-    else
-      if [ "$SCALAENV" = "all" ]; then
-        sbt orgUpdateDocFiles;
-        git reset --hard HEAD;
-        git clean -f;
-        git checkout master;
-        git pull origin master;
-        sbt release;
-      fi
-    fi
-  fi
+
 notifications:
   webhooks:
     urls:
@@ -87,3 +71,24 @@ notifications:
     on_start: always
     on_failure: always
     on_success: always
+
+jobs:
+  include:
+    - stage: deploy
+      script:
+        - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
+            if grep -q "SNAPSHOT" version.sbt; then
+              sbt ++$TRAVIS_SCALA_VERSION publish;
+            else
+              if [ "$SCALAENV" = "all" ]; then
+                sbt orgUpdateDocFiles;
+                git reset --hard HEAD;
+                git clean -f;
+                git checkout master;
+                git pull origin master;
+                sbt release;
+              fi
+            fi
+          fi
+      scala: 2.12.3
+      env: SCALAENV=all


### PR DESCRIPTION
This PR uses a new feature (still **beta**) to define job stages in Travis.

https://docs.travis-ci.com/user/build-stages/matrix-expansion/

It would be good to include it in our current pipeline to make faster and better our CI builds, more importantly when we are releasing new `Freestyle` versions.

![screenshot 2017-10-24 11 02 08](https://user-images.githubusercontent.com/4879373/31933907-cf01561e-b8aa-11e7-95a6-7d7f3e7696e2.png)

The `Deploy` stage would depend on the `Test` stage.