### PR TITLE
Adds an implicit conversion for ListenableFuture[Void]

### DIFF
--- a/modules/async/async-guava/src/main/scala/asyncGuava/async.scala
+++ b/modules/async/async-guava/src/main/scala/asyncGuava/async.scala
@@ -49,4 +49,17 @@ object implicits {
       E: ExecutionContext): ListenableFuture ~> F =
     new ListenableFuture2AsyncM[F]
 
+  implicit def listenableVoidToListenableUnit(future: ListenableFuture[Void])(
+      implicit E: ExecutionContext): ListenableFuture[Unit] =
+    Futures.transformAsync(
+      future,
+      new AsyncFunction[Void, Unit] {
+        override def apply(input: Void): ListenableFuture[Unit] =
+          Futures.immediateFuture((): Unit)
+      },
+      new JavaExecutor {
+        override def execute(command: Runnable): Unit = E.execute(command)
+      }
+    )
+
 }


### PR DESCRIPTION
Working with the Cassandra Datastax library I've dealt with methods that return a [`CloseFuture`](https://docs.datastax.com/en/drivers/java/2.0/com/datastax/driver/core/CloseFuture.html). This `CloseFuture` is an instance of `ListenableFuture[Void]`.

This PR adds an implicit conversion for transforming a `ListenableFuture[Void]` to `ListenableFuture[Unit]`