### PR TITLE
Disables tests in deploy stage

### DIFF
--- a/docs/src/main/tut/docs/rpc/README.md
+++ b/docs/src/main/tut/docs/rpc/README.md
@@ -54,7 +54,7 @@ Add the following dependency to your project's build file.
 For Scala `2.11.x` and `2.12.x`:
 
 ```scala
-libraryDependencies += "io.frees" %% "frees-rpc" % "0.1.2"
+libraryDependencies += "io.frees" %% "frees-rpc" % "0.2.0"
 ```
 
 ## About gRPC


### PR DESCRIPTION
Given the current Travis pipeline, all the tests are being executed before the deploy stage. Hence it doesn't make sense to run again as a part of the release process.

It also upgrades the frees-rpc version.