### PR TITLE
Allows higher typed params in algrebra methods

### DIFF
--- a/modules/core/shared/src/main/scala/freestyle/internal/free.scala
+++ b/modules/core/shared/src/main/scala/freestyle/internal/free.scala
@@ -257,7 +257,13 @@ private[internal] class Request(reqDef: Decl.Def, indexValue: Int) {
           else {
             // Wildcard types are not working for function params like this f: (B, A) => B
             // val us: Type = Type.Placeholder(Type.Bounds(None, None) )
-            Type.Apply(req, tparams.map(_ => t"_root_.scala.Any"))
+            val typeParams = tparams.map { p =>
+              p.tbounds.hi match {
+                case Some(t) => t"_ <: $t"
+                case _       => t"_root_.scala.Any"
+              }
+            }
+            Type.Apply(req, typeParams)
           }
 
         val alias = Term.fresh()

--- a/modules/core/shared/src/test/scala/freestyle/free.scala
+++ b/modules/core/shared/src/test/scala/freestyle/free.scala
@@ -67,6 +67,18 @@ class freeTests extends WordSpec with Matchers {
       "@free trait X { def f: FS[Int] }" should compile
     }
 
+    "a trait with type parameters in the method" in {
+      "@free trait X { def ix[A](a: A) : FS[A] }" should compile
+    }
+
+    "a trait with high bounded type parameters in the method" in {
+      "@free trait X { def ix[A <: Int](a: A) : FS[A] }" should compile
+    }
+
+    "a trait with lower bounded type parameters in the method" in {
+      "@free trait X { def ix[A >: Int](a: A) : FS[A] }" should compile
+    }
+
   }
 
   "the @free macro annotation should be rejected, and the compilation fail, if it is applied to" when {
@@ -126,7 +138,7 @@ class freeTests extends WordSpec with Matchers {
     }
 
     "allow implicit summoning" in {
-      "implicitly[SCtors1[SCtors1.Op]]" should compile 
+      "implicitly[SCtors1[SCtors1.Op]]" should compile
     }
 
     "provide automatic implementations for smart constructors" in {


### PR DESCRIPTION
Fixes #431 by applying an existential type only when the param type is high bounded.

Thoughts?