### PR TITLE
Support for upper bounds in algebras type arg declarations

### DIFF
--- a/modules/core/shared/src/main/scala/freestyle/internal/free.scala
+++ b/modules/core/shared/src/main/scala/freestyle/internal/free.scala
@@ -109,7 +109,7 @@ private[internal] case class Algebra(
       requests.map {
         _.tparams
           .map(_.tbounds.hi)
-          .map(_.map(t => q"type ${Type.fresh()} <: $t"))
+          .map(_.map(t => q"type ${Type.fresh("PP$")} <: $t"))
       }
 
     val mm = Type.fresh("MM$")

--- a/modules/core/shared/src/main/scala/freestyle/internal/free.scala
+++ b/modules/core/shared/src/main/scala/freestyle/internal/free.scala
@@ -17,9 +17,11 @@
 package freestyle.internal
 
 import freestyle.FreeS
+
 import scala.collection.immutable.Seq
 import scala.meta._
 import scala.meta.Defn.{Class, Object, Trait}
+import scala.meta.Type.Param
 
 trait EffectLike[F[_]] {
   final type FS[A] = FreeS.Par[F, A]
@@ -102,6 +104,14 @@ private[internal] case class Algebra(
   val indexName: Term.Name = Term.fresh("FSAlgebraIndex")
 
   def handlerTrait: Trait = {
+
+    val requestParams: Seq[Seq[Option[Decl.Type]]] =
+      requests.map {
+        _.tparams
+          .map(_.tbounds.hi)
+          .map(_.map(t => q"type ${Type.fresh()} <: $t"))
+      }
+
     val mm = Type.fresh("MM$")
 
     val applyDef: Defn.Def = {
@@ -116,15 +126,20 @@ private[internal] case class Algebra(
       val fa = Term.fresh("fa$")
       val matchE: Term.Match = Term.Match(
         q"$fa.$indexName : @_root_.scala.annotation.switch",
-        requests.map(_.handlerCase(fa)) :+ errorCase
+        requests.zip(requestParams).map {
+          case (request, params) => request.handlerCase(fa, params)
+        } :+ errorCase
       )
 
       q"override def apply[${tyParam(aa)}]($fa: $OP[$aa]): $mm[$aa] = ($matchE).asInstanceOf[$mm[$aa]]"
     }
 
+    val highBoundTypeDecl: Seq[Decl.Type] = requestParams.flatMap(_.flatten)
+
     q"""
       trait Handler[${tyParamK(mm)}, ..$tparams] extends _root_.freestyle.FSHandler[$OP, $mm] {
         ..${requests.map(_.handlerDef(mm))}
+        ..$highBoundTypeDecl
         $applyDef
       }
     """
@@ -191,7 +206,7 @@ private[internal] class Request(reqDef: Decl.Def, indexValue: Int) {
   // Name of the Request ADT Class
   private[this] val reqName: String = reqDef.name.value
   private[this] val req: Type.Name  = Type.Name(reqName.capitalize + "Op")
-  private[this] val cboundPrefix = "__$cbound"
+  private[this] val cboundPrefix    = "__$cbound"
 
   private[this] val res: Type = reqDef.decltpe match {
     case Type.Apply(_, args) => args.last
@@ -201,14 +216,19 @@ private[internal] class Request(reqDef: Decl.Def, indexValue: Int) {
   private[this] val reqC    = Term.Name(req.value)
   private[this] val reqImpl = Term.Name(reqName)
 
-  val cbtparams = for {
-    tps <- reqDef.tparams.filter(_.cbounds.nonEmpty)
+  val cbtparams: Seq[Term.Param] = for {
+    tps    <- reqDef.tparams.filter(_.cbounds.nonEmpty)
     cbound <- tps.cbounds
-  } yield Term.Param(Nil, Term.fresh(cboundPrefix), Some(Type.Apply(cbound, Seq(Type.Name(tps.name.value)))), None)
+  } yield
+    Term.Param(
+      Nil,
+      Term.fresh(cboundPrefix),
+      Some(Type.Apply(cbound, Seq(Type.Name(tps.name.value)))),
+      None)
 
-  val tparams = reqDef.tparams.map {
+  val tparams: Seq[Param] = reqDef.tparams.map {
     case p if p.cbounds.nonEmpty => p.copy(cbounds = Nil)
-    case p => p
+    case p                       => p
   }
 
   val params: Seq[Term.Param] = reqDef.paramss.flatten.map {
@@ -228,7 +248,7 @@ private[internal] class Request(reqDef: Decl.Def, indexValue: Int) {
     """
   }
 
-  private[this] def nameOrImplicitly(param : Term.Param): Term.Name = param match {
+  private[this] def nameOrImplicitly(param: Term.Param): Term.Name = param match {
     case Term.Param(_, paramname, Some(atpeopt), _) if paramname.value.startsWith(cboundPrefix) =>
       val targ"${tpe: Type}" = atpeopt
       Term.Name(s"_root_.scala.Predef.implicitly[$tpe]")
@@ -246,7 +266,7 @@ private[internal] class Request(reqDef: Decl.Def, indexValue: Int) {
     addBody(reqDef, q"$inj($body)").copy(mods = Seq(Mod.Override()))
   }
 
-  def handlerCase(fa: Term.Name): Case = {
+  def handlerCase(fa: Term.Name, requestParams: Seq[Option[Decl.Type]]): Case = {
 
     val mexp: Term =
       if (params.isEmpty)
@@ -257,11 +277,9 @@ private[internal] class Request(reqDef: Decl.Def, indexValue: Int) {
           else {
             // Wildcard types are not working for function params like this f: (B, A) => B
             // val us: Type = Type.Placeholder(Type.Bounds(None, None) )
-            val typeParams = tparams.map { p =>
-              p.tbounds.hi match {
-                case Some(t) => t"_ <: $t"
-                case _       => t"_root_.scala.Any"
-              }
+            val typeParams = requestParams.map {
+              case Some(tName) => t"${tName.name}"
+              case None        => t"_root_.scala.Any"
             }
             Type.Apply(req, typeParams)
           }

--- a/modules/core/shared/src/test/scala/freestyle/free.scala
+++ b/modules/core/shared/src/test/scala/freestyle/free.scala
@@ -79,6 +79,17 @@ class freeTests extends WordSpec with Matchers {
       "@free trait X { def ix[A >: Int](a: A) : FS[A] }" should compile
     }
 
+    "a trait with different type parameters in the method" in {
+      "@free trait X { def ix[A <: Int, B, C >: Int](a: A, b: B, c: C) : FS[A] }" should compile
+    }
+
+    "a trait with high bounded type parameters and implicits in the method" in {
+      """
+        trait X[A]
+        @free trait Y { def ix[A <: Int : X](a: A) : FS[A] }
+      """ should compile
+    }
+
   }
 
   "the @free macro annotation should be rejected, and the compilation fail, if it is applied to" when {
@@ -381,6 +392,20 @@ class freeTests extends WordSpec with Matchers {
           override def x(a: Int): Int = 4
         }
       v.y(5).interpret[Id] shouldBe(true)
+    }
+
+    "generate interpreters or Handlers when mix higher bound params and implicits" in {
+      trait X[A]
+      @free trait Algebra {
+        def x[A <: String : X](a: A): FS[Int]
+      }
+      val v = Algebra[Algebra.Op]
+      implicit val interpreter: Algebra.Handler[Id] =
+        new Algebra.Handler[Id]{
+          override def x[A <: String](a: A, x: X[A]): Int = 4
+        }
+      implicit def x[A]: X[A] = new X[A] {}
+      v.x("").interpret[Id] shouldBe 4
     }
 
   }


### PR DESCRIPTION
This will fix the case where we'll have something like `[T <: SomeType: TypeTag]`, as @muradm requested in [this comment](https://github.com/frees-io/freestyle/pull/442#issuecomment-343752562).

It adds a `type` declaration in the *handler* body like this:

* `type A <: SomeType`

And make the casting in the pattern matching with `A` (instead of `_ <: SomeType`).

The problem with this code is that it's acting only when the param type is high bounded. We should add the `type` declaration for all params. Currently, the only issue is to convert a `Type Param` into a `Type` with scalameta.