### PR TITLE
Support for explicit [F[_]] carrier types in `@module`, `@free` & `@tagless`

### DIFF
--- a/modules/core/shared/src/main/scala/freestyle/internal/module.scala
+++ b/modules/core/shared/src/main/scala/freestyle/internal/module.scala
@@ -82,8 +82,6 @@ private[internal] case class FreeSModule(
 
   /* The effects are Val Declarations (no value definition) */
   def makeClass: Defn = {
-  //  val ff: Type.Name = Type.fresh("FF$")
-//    val pat           = q"trait Foo[${tyParamK(ff)}] extends _root_.freestyle.internal.EffectLike[$ff]"
 
     val (ff, pat)           = tparams.toList match {
       case List(f @ tparam"..$mods $name[$tparam]") =>

--- a/modules/core/shared/src/main/scala/freestyle/internal/module.scala
+++ b/modules/core/shared/src/main/scala/freestyle/internal/module.scala
@@ -61,21 +61,37 @@ private[internal] case class FreeSModule(
   import ModuleUtil._
   import ScalametaUtil._
 
+  val cleanedTParams: Seq[Type.Param] = tparams.toList match {
+    case List(f@tparam"..$mods $name[$tparam]") => Nil
+    case _ => tparams
+  }
+
   val effects: Seq[ModEffect] =
     templ.stats.getOrElse(Nil).collect {
+      case vdec @ Decl.Val(_, Seq(Pat.Var.Term(_)), Type.Apply(tname @ _, Seq(Type.Name(_)))) => ModEffect(vdec)
       case vdec @ Decl.Val(_, Seq(Pat.Var.Term(_)), _) => ModEffect(vdec)
     }
 
   def enrichStat(tt: Type.Name, st: Stat): Stat = st match {
-    case vdec @ Decl.Val(mods, Seq(Pat.Var.Term(tname)), ty) =>
+    case vdec @ Decl.Val(_, Seq(Pat.Var.Term(tname)), Type.Apply(_, Seq(_))) =>
+      vdec
+    case vdec @ Decl.Val(_, Seq(Pat.Var.Term(tname)), ty) =>
       vdec.copy(decltpe = Type.Apply(ty, Seq(tt)))
     case x => x
   }
 
   /* The effects are Val Declarations (no value definition) */
   def makeClass: Defn = {
-    val ff: Type.Name = Type.fresh("FF$")
-    val pat           = q"trait Foo[${tyParamK(ff)}] extends _root_.freestyle.internal.EffectLike[$ff]"
+  //  val ff: Type.Name = Type.fresh("FF$")
+//    val pat           = q"trait Foo[${tyParamK(ff)}] extends _root_.freestyle.internal.EffectLike[$ff]"
+
+    val (ff, pat)           = tparams.toList match {
+      case List(f @ tparam"..$mods $name[$tparam]") =>
+        (Type.Name(f.name.value), q"trait Foo[$f] extends _root_.freestyle.internal.EffectLike[${toType(f)}]")
+      case _ =>
+        val ff: Type.Name = Type.fresh("FF$")
+        (ff, q"trait Foo[${tyParamK(ff)}] extends _root_.freestyle.internal.EffectLike[$ff]")
+    }
 
     val nstats = templ.stats.map(_.map(stat => enrichStat(ff, stat)))
     val ntempl = templ.copy(parents = pat.templ.parents, stats = nstats)
@@ -91,8 +107,8 @@ private[internal] case class FreeSModule(
 
   def lifterStats: (Class, Defn.Def, Defn.Def) = {
     val gg: Type.Name              = Type.fresh("GG$")
-    val toTParams: Seq[Type.Param] = tyParamK(gg) +: tparams
-    val toTArgs: Seq[Type]         = gg +: tparams.map(toType)
+    val toTParams: Seq[Type.Param] = tyParamK(gg) +: cleanedTParams
+    val toTArgs: Seq[Type]         = gg +: cleanedTParams.map(toType)
 
     val sup: Term.ApplyType = Term.ApplyType(Ctor.Ref.Name(name.value), toTArgs)
     val toClass: Class = {
@@ -141,7 +157,10 @@ private[internal] case class ModEffect(effVal: Decl.Val) {
   def buildDefParam(gg: Type.Name): Term.Param =
     q"def foo(implicit x: Int)".paramss.head.head.copy(
       name = effVal.pats.head.name,
-      decltpe = Some(Type.Apply(effVal.decltpe, Seq(gg)))
+      decltpe = Some(effVal.decltpe match {
+        case Type.Apply(t @ _, _) => Type.Apply(t, Seq(gg))
+        case _ => Type.Apply(effVal.decltpe, Seq(gg))
+      })
     )
 
   // buildParam(x, t) = q"class Foo(implicit val $x: $t[$gg])"
@@ -149,7 +168,10 @@ private[internal] case class ModEffect(effVal: Decl.Val) {
     q"def foo(implicit x: Int)".paramss.head.head.copy(
       mods = Seq(Mod.Implicit(), Mod.ValParam()),
       name = effVal.pats.head.name,
-      decltpe = Some(Type.Apply(effVal.decltpe, Seq(gg)))
+      decltpe = Some(effVal.decltpe match {
+        case Type.Apply(t @ _, _) => Type.Apply(t, Seq(gg))
+        case _ => Type.Apply(effVal.decltpe, Seq(gg))
+      })
     )
 
   // x => q"x.OpTypes"
@@ -159,7 +181,8 @@ private[internal] case class ModEffect(effVal: Decl.Val) {
   def typeToObject(ty: Type): Term.Ref = ty match {
     case Type.Name(n)                 => Term.Name(n)
     case Type.Select(q, Type.Name(n)) => Term.Select(q, Term.Name(n))
-    case _                            => abort("What is the case here")
+    case Type.Apply(t, Seq(_)) => typeToObject(t)
+    case _                            => abort(s"found: $ty unmatched. What is the case here")
   }
 
 }

--- a/modules/core/shared/src/main/scala/freestyle/internal/module.scala
+++ b/modules/core/shared/src/main/scala/freestyle/internal/module.scala
@@ -179,7 +179,7 @@ private[internal] case class ModEffect(effVal: Decl.Val) {
   def typeToObject(ty: Type): Term.Ref = ty match {
     case Type.Name(n)                 => Term.Name(n)
     case Type.Select(q, Type.Name(n)) => Term.Select(q, Term.Name(n))
-    case Type.Apply(t, Seq(_)) => typeToObject(t)
+    case Type.Apply(t, Seq(_))        => typeToObject(t)
     case _                            => abort(s"found: $ty unmatched. What is the case here")
   }
 

--- a/modules/core/shared/src/test/scala/freestyle/free.scala
+++ b/modules/core/shared/src/test/scala/freestyle/free.scala
@@ -31,6 +31,10 @@ class freeTests extends WordSpec with Matchers {
       "@free trait X { def bar(x:Int): FS[Int] }" should compile
     }
 
+    "a trait with an F[_] bound type param" in {
+      "@free @debug trait FBound[F[_]] { def bar(x:Int): FS[Int] }" should compile
+    }
+
     "an abstract class with at least one request" in {
       "@free abstract class X { def bar(x:Int): FS[Int] }" should compile
     }

--- a/modules/core/shared/src/test/scala/freestyle/module.scala
+++ b/modules/core/shared/src/test/scala/freestyle/module.scala
@@ -203,4 +203,53 @@ class moduleTests extends WordSpec with Matchers {
     }
 
   }
+
+  "@module @free and @debug work together when explicitly defining carrier F[_]" when {
+
+    "a trait with @module allows carrier F[_] in itself" in {
+      """
+        |@free @debug trait X {
+        |  def x: FS[Int]
+        |}
+        |object P {
+        |  @module @debug trait Y {
+        |    val repo: X
+        |  }
+        |}
+        |@module @debug trait FBoundModule1[F[_]] {
+        |  val a: P.Y
+        |}""".stripMargin should compile
+    }
+
+    "a trait with @module allows carrier F[_] in its aggregated algebras" in {
+      """
+        |@free @debug trait X[F[_]] {
+        |  def x: FS[Int]
+        |}
+        |object P {
+        |  @module @debug trait Y[F[_]] {
+        |    val repo: X
+        |  }
+        |}
+        |@module @debug trait FBoundModule2[F[_]] {
+        |  val a: P.Y
+        |}""".stripMargin should compile
+    }
+
+    "a trait with @module allows carrier F[_] in its aggregated algebras val decls" in {
+      """
+        |@free @debug trait X[F[_]] {
+        |  def x: FS[Int]
+        |}
+        |object P {
+        |  @module @debug trait Y[F[_]] {
+        |    val repo: X[F]
+        |  }
+        |}
+        |@module @debug trait FBoundModule3[F[_]] {
+        |  val a: P.Y[F]
+        |}""".stripMargin should compile
+    }
+
+  }
 }


### PR DESCRIPTION
Fixes #345 

This PR allows users to add the `F[_]` carrier type and enables better syntax highlighting in IDEA for those that choose to do so.