### PR TITLE
Make Algebras and Modules concrete with `.instance`

### DIFF
--- a/modules/core/shared/src/test/scala/freestyle/free.scala
+++ b/modules/core/shared/src/test/scala/freestyle/free.scala
@@ -359,7 +359,7 @@ class freeTests extends WordSpec with Matchers {
         def y: Int = 5
         val z: Int = 6
       }
-      val v = WithExtra[WithExtra.Op]
+      val v = WithExtra.instance
       v.y shouldBe 5
       v.z shouldBe 6
 

--- a/modules/core/shared/src/test/scala/freestyle/module.scala
+++ b/modules/core/shared/src/test/scala/freestyle/module.scala
@@ -124,8 +124,8 @@ class moduleTests extends WordSpec with Matchers {
       program.interpret[List] shouldBe List(4)
     }
 
-    "[onion] reuse program interpretation in diferent runtimes" in {
-      val o1 = O1[O1.Op]
+    "[onion] reuse program interpretation in different runtimes" in {
+      val o1 = O1.instance
       val program = for {
         a <- o1.m1.sctors1.x(1)
         b <- o1.m1.sctors1.y(1)


### PR DESCRIPTION
This PR allows additional syntax in `@free` and `@module` companions that allows obtaining an already concrete instance to the `Op` of the container to be used at the edge of applications. 
Currently uers are forced to use `App[App.Op]` to materialize the `@module trait App` Coproduct. this PR allows them to obtain the same result by simply doing `App.instance` which then they can use to run their effects at the edge of the application.