### PR TITLE
Provides async instances to stdlib Future

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,9 @@ lazy val effectsJS  = effects.js
 lazy val async = module("async", subFolder = Some("async"))
   .dependsOn(core)
   .jsSettings(sharedJsSettings: _*)
-  .crossDepSettings(commonDeps: _*)
+  .crossDepSettings(commonDeps ++ Seq(
+    %("cats-effect") % Test
+  ): _*)
 
 lazy val asyncJVM = async.jvm
 lazy val asyncJS  = async.js

--- a/modules/async/async/shared/src/main/scala/async.scala
+++ b/modules/async/async/shared/src/main/scala/async.scala
@@ -16,8 +16,8 @@
 
 package freestyle
 
+import cats.syntax.either._
 import scala.concurrent._
-import scala.util.{Failure, Left, Right, Success}
 
 object async {
 
@@ -39,10 +39,7 @@ object async {
     override def apply[A](future: Future[A]): F[A] =
       AC.runAsync { cb =>
         E.execute(new Runnable {
-          def run(): Unit = future.onComplete {
-            case Failure(e) => cb(Left(e))
-            case Success(r) => cb(Right(r))
-          }
+          def run(): Unit = future.onComplete(_.toEither)
         })
       }
   }

--- a/modules/async/async/shared/src/main/scala/async.scala
+++ b/modules/async/async/shared/src/main/scala/async.scala
@@ -16,8 +16,8 @@
 
 package freestyle
 
-import cats.syntax.either._
 import scala.concurrent._
+import scala.util._
 
 object async {
 
@@ -39,7 +39,10 @@ object async {
     override def apply[A](future: Future[A]): F[A] =
       AC.runAsync { cb =>
         E.execute(new Runnable {
-          def run(): Unit = future.onComplete(_.toEither)
+          def run(): Unit = future.onComplete {
+            case Failure(e) => cb(Left(e))
+            case Success(r) => cb(Right(r))
+          }
         })
       }
   }

--- a/modules/async/async/shared/src/test/scala/Future2AsyncMTests.scala
+++ b/modules/async/async/shared/src/test/scala/Future2AsyncMTests.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle
+
+import freestyle.async.implicits._
+import freestyle.async.Future2AsyncM
+import org.scalatest._
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class Future2AsyncMTests extends WordSpec with Matchers {
+
+  val exception: Throwable = new RuntimeException("Future2AsyncMTest exception")
+
+  def failedFuture[T]: Future[T] = Future.failed(exception)
+
+  def successfulFuture[T](value: T): Future[T] = Future.successful(value)
+
+  val F2F: Future2AsyncM[Future] = new Future2AsyncM[Future]
+
+  val foo = "bar"
+
+  "Future2Async Handler" should {
+
+    "transform Future to Future successfully" in {
+      Await.result(F2F.apply(successfulFuture(foo)), 5.seconds) shouldBe foo
+    }
+
+    "recover from failed Futures and throw them accordingly" in {
+      an[Throwable] shouldBe thrownBy(Await.result(F2F.apply(failedFuture[String]), 5.seconds))
+    }
+
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.4-SNAPSHOT"
+version in ThisBuild := "0.4.4"


### PR DESCRIPTION
This PR provides async instances to go from `scala.concurrent.Future` to any `F`.