### PR TITLE
FS-462 Explain FS.Seq and FS.Par type alias.

### DIFF
--- a/docs/src/main/tut/docs/core/algebras/README.md
+++ b/docs/src/main/tut/docs/core/algebras/README.md
@@ -10,52 +10,38 @@ Algebraic Data Types are the foundation used to define `Free` based applications
 
 When you build an algebra with Freestyle, you only need to concentrate on the API that you want to be exposed as abstract smart constructors, without worrying how they will be implemented.
 
-A trait or abstract class annotated with `@free` or `@tagless` is all you need to create your first algebra with Freestyle:
+In Freestyle, an **algebra** is a trait or abstract class annotated with `@free` or `@tagless`:
 
 ```tut:book
 import freestyle.free._
 
 case class User(id: Long, name: String)
 
-@free trait UserRepository {
+@free trait Users {
   def get(id: Long): FS[User]
   def save(user: User): FS[User]
   def list: FS[List[User]]
 }
 ```
 
- or 
+The `Users` trait declares three smart constructors, named `get`, `save`, and `list`, which generate the basic operations in the algebra. A **smart constructor** is an abstract method declaration with a return type of the form `FS[Ret]`, where `Ret` is the type of the data computed by the operation, and `FS[_]`  marks the method as an operation of the algebra. Intuitively, `FS` means that the method gives a computation within some (generic) context or effect `FS`. 
+For example, the `save` smart constructor has a return type `FS[User]`. Intuitively, this declares `save` as a computation in a context (or effect) `FS`, whose result will be a `User` object. 
 
-```tut:book
-import freestyle.tagless._
+The `@free` is a Scala [macro annotation](https://www.scala-lang.org/blog/2017/10/09/scalamacros.html), that replaces the annotated trait `Users` by a modified trait, and generates a companion object, as in the code below: 
 
-@tagless trait Validation {
-  def minSize(s: String, n: Int): FS[Boolean]
-  def hasNumber(s: String): FS[Boolean]
-}
-
-@tagless trait Interaction {
-  def tell(msg: String): FS[Unit]
-  def ask(prompt: String): FS[String]
-}
-```
-
-
-This is similar to the simplified manual encoding below:
-
-```tut:book
+```tut:silent
 import freestyle.free.FreeS
 import freestyle.free.internal.EffectLike
 
 case class User(id: Long, name: String)
 
-trait UserRepository[F[_]] extends EffectLike[F] {
+trait Users[F[_]] extends EffectLike[F] {
   def get(id: Long): FS[User]
   def save(user: User): FS[User]
   def getAll(filter: String): FS[List[User]]
 }
 
-object UserRepository {
+object Users {
   import _root_.cats.arrow.FunctionK
   import _root_.freestyle.free.InjK
   import _root_.freestyle.free.FreeS
@@ -65,7 +51,7 @@ object UserRepository {
   final case class Save(user: User) extends Op[User]
   final case class GetAll(filter: String) extends Op[List[User]]
 
-  class To[L[_]](implicit ii: InjK[Op, L]) extends UserRepository[L] {
+  class To[L[_]](implicit ii: InjK[Op, L]) extends Users[L] {
 
     private[this] val inj = FreeS.inject[Op, L](ii)
 
@@ -76,13 +62,12 @@ object UserRepository {
     def getAll(filter: String): FS[List[User]] = inj( GetAll(filter) )
   }
 
-  implicit def to[L[_]](implicit I: InjK[Op, L]): UserRepository[L] =
+  implicit def to[L[_]](implicit I: InjK[Op, L]): Users[L] =
     new To[L]
 
-  def apply[L[_]](implicit c: UserRepository[L]): UserRepository[L] = c
+  def apply[L[_]](implicit c: Users[L]): Users[L] = c
 
   trait Handler[M[_]] extends FSHandler[Op, M] {
-
     protected[this] def get(id: Long): M[User]
     protected[this] def save(user: User): M[User]
     protected[this] def getAll(filter: String): M[List[User]]
@@ -97,41 +82,102 @@ object UserRepository {
 }
 ```
 
-Let's examine the two fragments above to understand what Freestyle is doing for you.
+Let us examine how the `@free`-annotated trait relates to the code generated from it. 
 
-## Automatic method implementations
+### Generalise Trait
 
-From the abstract smart constructors, Freestyle generates an Algebraic data type available through a companion object.
+The `@free` macro makes two changes to the trait `Users`.
+
+1. It adds a type parameter `F[_]`, of kind `* -> *`, which is a general type in which operations are constructed. This makes `Users[F[_]]` resemble a [_Generalised Abstract Data Type (GADT)_](https://pchiusano.github.io/2014-05-20/scala-gadts.html), an interface to construct the algebra's operations into a type `F[_]`.
+
+2. It makes `Users` to extend `EffectLike[F[_]]`. This trait defines the type `FS[_]`, used in the smart constructors, as `FS[_] = FreeS.Par[F]`, which in turn is an alias for `Free[FreeApplicative[F, ?], ?]`.
+
+The `@free` annotation works as a syntactic sugar for writing a GADT in Scala. Without the `EffectLike` trait, the algebra GADT would be written as follows:
+```Scala
+trait Users[F[_]] {
+  def get(id: Long): FreeS.Par[F, User]
+  def save(user: User): FreeS.Par[F, User]
+  def getAll(filter: String): FreeS.Par[F, List[User]]
+}
+```
+
+### Algebraic Data Type
+
+From the abstract smart constructors, `@free` generates an algebraic data type (ADT) of operations inside the companion object.
 This Algebraic data type contains the shape needed to implement the abstract methods.
 
-Freestyle automatically implements those abstract methods using the `Inject` strategy for composing unrelated ADTs through a Coproduct as described
-in [Data types a la Carte](http://www.cs.ru.nl/~W.Swierstra/Publications/DataTypesALaCarte.pdf) by Wouter Swierstra.
+```Scala
+  sealed trait Op[A] extends Product with Serializable
 
-## Dependency Injection
+  final case class Get(id: Long) extends Op[User]
+  final case class Save(user: User) extends Op[User]
+  final case class GetAll(filter: String) extends Op[List[User]]
+```
+Some important features of this ADT are the following ones:
+* The root of the ADT is a sealed trait `Op[A]`. Note that this name `Op` is the same in _every_ `@free`-generated algebra.
+* For each smart constructor `def foo(x: X, y: Y, ...): FS[Z]`, the `@free` generates a case class `Foo`, whose fields are the parameters of the constructor. For those with a background in object-oriented design, this is similar to the [Command Pattern](http://wiki.c2.com/?CommandPattern).
+* The parameter `A` in the root trait `Op[A]` describes the type of the expected result of that operation.
+
+### Injection
+
+If the modified trait `Users[F[_]]` declares an interface for the algebra, the companion object `Users` provides an implementation for that interface.
+
+The `@free` annotation adds into the companion object a class `To[L[_]]`, which implements the `Users` GADT for the target type `L[_]` by using an `InjK[Op, L]` object. An `InjK[F[_], G[_]]` is a special type of tranformation, much like the `FunctionK` in `cats`, that allows to transform a `F[A]` into a `G[A]`. In the case of the `To` class, we need an `InjK[Op, L]`, that allows transforming an object `Req[A]` in the `Op` ADT above, to a value `L[A]` in the target type `L`. The class `To[L[_]]` implements each operation of the algebra by just applying that `InjK` object to the instance of the `Op` ADT.
+
+The `InjK` is based the `Inject` strategy from the [Data types à-la-Carte](http://www.cs.ru.nl/~W.Swierstra/Publications/DataTypesALaCarte.pdf) article, which describes how to compose unrelated ADTs using the Coproduct (or `EitherK` in `cats`).
+
+### Dependency Injection
 
 As you may have noticed when defining algebras with `@free`, there is no need to provide implicit evidence for the necessary `Inject` typeclasses that otherwise need to be manually provided to further evaluate your free monads when they are interleaved with other `Free` programs.
 
-Beside providing the appropriate `Inject` evidences,  Freestyle creates an implicit method that will enable implicit summoning of the smart
-constructors class implementation and an `apply` method that allows summoning instances of your smart constructors where needed.
-This effectively enables implicits based Dependency Injection where you may choose to override implementations
-using the implicits scoping rules to place different implementations where appropriate.
+Beside providing the appropriate `Inject` evidences,  Freestyle creates an implicit method that will enable implicit summoning of the smart constructors class implementation and an `apply` method that allows summoning instances of your smart constructors where needed.
+This effectively enables implicits based Dependency Injection where you may choose to override implementations using the implicits scoping rules to place different implementations where appropriate.
 
 ```tut:book
-val userRepository = UserRepository[UserRepository.Op]
+val users = Users[Users.Op]
+
+def myService[F[_]](implicit users: Users[F]) = ???
+
+def myService2[F[_]: Users] = ???
 ```
 
-```tut:book
-def myService[F[_]](implicit userRepository: UserRepository[F]) = ???
+### Composed Operations
+
+The trait `EffectLike[F[_]]` mentioned above, apart from the type alias `FS[_]`, also defines two type aliases `FS.Seq[_]` and `FS.Par[]`.
+
+```Scala
+trait EffectLike[F[_]] {
+  final type FS[A] = FreeS.Par[F, A]
+  final object FS {
+    final type Seq[A] = FreeS[F, A]
+    final type Par[A] = FreeS.Par[F, A]
+  }
+}
 ```
 
+These type aliases can be used to define some `FS` operations that are derived from other operations. , by combining other operations:
+
+* `FS.Par[A]` is an alias for `FreeApplicative[F, A]`. You can declare a derived operation of type `FS.Par` by applying the methods of the `Functor` and `Applicative` type classes.
+* `FS.Seq[A]` is an alias for `Free[FreeApplicative[F, ?], A]`, that can be combined using the methods of the `Monad` type class.
+
 ```tut:book
-def myService2[F[_]: UserRepository] = ???
+import cats.syntax.apply._
+import cats.syntax.monad._
+@free trait X {
+  def a: FS[Int]
+  def b(i: Int): FS.Par[Int] = a.map( x => x + i)
+  def c: FS.Par[Int] = (a,b(42)).mapN(_ + _)
+  def d: FS.Seq[Int] = c.freeS.flatMap(x => b(x).freeS)
+}
 ```
+
+We use the type aliae `FS.Seq` and `FS.Par` to indicate complex operations, which combine the algebra's basic requests with the operations from the `Monad` (or `Applicative`) type class. The names follow the intuition that `Applicative` operations combine data-independent computations that can be run in parallel, and `Monad` operations combine data-dependent computations that need to be run in sequence.
+
+Note that, although  `FS[_]` and `FS.Par[_]` are equivalent, `@free` only allows using the former for abstract methods. 
 
 ## Convenient type aliases
 
-All companions generated with `@free` define a `sealed trait Op[A]` as the root node of the requests ADT.
-You may use this to manually build `Coproduct` types which will serve in the parametrization of your application and code as in the example below:
+As described above, `@free` always uses the name `Op` for the sealed trait at the root of the requests ADT. This allows you to access it uniformly, for instance to build a `Coproduct` type that helps you to parametrize you application code. Here is an example for this:
 
 ```tut:book
 import cats.data.EitherK
@@ -149,15 +195,28 @@ type C1[A] = EitherK[Service1.Op, Service2.Op, A]
 type Module[A] = EitherK[Service3.Op, C1, A]
 ```
 
-This is obviously far from ideal, as building `EitherK` types by hand often results in bizarre compile errors
-when the types don't align properly from being placed in the wrong order.
+This is obviously far from ideal, as building `EitherK` types by hand often results in bizarre compile errors when the types don't align properly from being placed in the wrong order.
 
 ### Combining `@tagless` and `@free` algebras
 
-Freestyle comes with built-in support to compose `@free` and `@tagless` algebras.
+Freestyle allows us to compose `@free` and `@tagless` algebras. Let us consider the following `@tagless` algebras:
+
+```tut:book
+import freestyle.tagless._
+
+@tagless trait Validation {
+  def minSize(s: String, n: Int): FS[Boolean]
+  def hasNumber(s: String): FS[Boolean]
+}
+
+@tagless trait Interaction {
+  def tell(msg: String): FS[Unit]
+  def ask(prompt: String): FS[String]
+}
+```
 
 For every `@tagless` algebra, there is also a free-based representation that is stack-safe by nature, and that can be used
-to lift `@tagless` algebras to the context of application where `@free` and `@tagless` algebras coexist.
+to lift `@tagless` algebras to a context mixing `@free` and `@tagless` algebras.
 
 Let's redefine `program` to support `LoggingM` which is a `@free` defined algebra of logging operations:
 

--- a/docs/src/main/tut/docs/core/algebras/README.md
+++ b/docs/src/main/tut/docs/core/algebras/README.md
@@ -47,19 +47,16 @@ object Users {
   import _root_.freestyle.free.FreeS
 
   sealed trait Op[A] extends Product with Serializable
-  final case class Get(id: Long) extends Op[User]
-  final case class Save(user: User) extends Op[User]
-  final case class GetAll(filter: String) extends Op[List[User]]
+  final case class GetOp(id: Long) extends Op[User]
+  final case class SaveOp(user: User) extends Op[User]
+  final case class GetAllOp(filter: String) extends Op[List[User]]
 
   class To[L[_]](implicit ii: InjK[Op, L]) extends Users[L] {
-
     private[this] val inj = FreeS.inject[Op, L](ii)
 
-    def get(id: Long): FS[User] = inj( Get(id) )
-
-    def save(user: User): FS[User] = inj( Save(user) )
-
-    def getAll(filter: String): FS[List[User]] = inj( GetAll(filter) )
+    def get(id: Long): FS[User] = inj( GetOp(id) )
+    def save(user: User): FS[User] = inj( SaveOp(user) )
+    def getAll(filter: String): FS[List[User]] = inj( GetAllOp(filter) )
   }
 
   implicit def to[L[_]](implicit I: InjK[Op, L]): Users[L] =
@@ -73,9 +70,9 @@ object Users {
     protected[this] def getAll(filter: String): M[List[User]]
 
     override def apply[A](fa: Op[A]): M[A] = fa match {
-      case l @ Get(_) => get(l.id)
-      case l @ Save(_) => save(l.user)
-      case l @ GetAll(_) => getAll(l.filter)
+      case l @ GetOp(_) => get(l.id)
+      case l @ SaveOp(_) => save(l.user)
+      case l @ GetAllOp(_) => getAll(l.filter)
     }
   }
 
@@ -109,9 +106,9 @@ This Algebraic data type contains the shape needed to implement the abstract met
 ```Scala
   sealed trait Op[A] extends Product with Serializable
 
-  final case class Get(id: Long) extends Op[User]
-  final case class Save(user: User) extends Op[User]
-  final case class GetAll(filter: String) extends Op[List[User]]
+  final case class GetOp(id: Long) extends Op[User]
+  final case class SaveOp(user: User) extends Op[User]
+  final case class GetAllOp(filter: String) extends Op[List[User]]
 ```
 Some important features of this ADT are the following ones:
 * The root of the ADT is a sealed trait `Op[A]`. Note that this name `Op` is the same in _every_ `@free`-generated algebra.

--- a/modules/core/shared/src/test/scala/freestyle/free/free.scala
+++ b/modules/core/shared/src/test/scala/freestyle/free/free.scala
@@ -22,6 +22,7 @@ import cats.kernel.instances.int._
 import cats.instances.option._
 import cats.instances.list._
 import cats.syntax.apply._
+import cats.syntax.flatMap._
 import freestyle.free.implicits._
 import org.scalatest.{Matchers, WordSpec}
 
@@ -209,7 +210,6 @@ class freeTests extends WordSpec with Matchers {
     }
 
     "using the Applicative instance to combine operations into a FS.Par" in {
-      import cats.syntax.apply._
       @free trait X {
         def a: FS[Int]
         def b: FS.Par[Int] = (a, a).mapN(_+_)
@@ -221,7 +221,6 @@ class freeTests extends WordSpec with Matchers {
     }
 
     "using the Monad instance to combine operations into a FS.Seq" in {
-      import cats.syntax.monad._
       @free trait X {
         def a: FS[Int]
         def b(x: Int): FS[Int]
@@ -238,7 +237,6 @@ class freeTests extends WordSpec with Matchers {
     }
 
     "mixing all of the above" in {
-      import cats.syntax.apply._
       @free trait X {
         def a: FS[Int]
         def b(i: Int): FS.Par[Int] = a.map(x => x+i)


### PR DESCRIPTION
Work in progreess. Do not merge. 

This PR resolves 462. We extend the documentation of the `@free` annotation. We explain what `FS`, `FS.Seq` and `FS.Par` are.

We add in the freeetests an example using monadic operations.
