### PR TITLE
FS-478 Simplify Tagless

### DIFF
--- a/modules/core/shared/src/main/scala/freestyle/free/internal/free.scala
+++ b/modules/core/shared/src/main/scala/freestyle/free/internal/free.scala
@@ -66,7 +66,7 @@ object freeImpl {
 
 }
 
-private[internal] case class Algebra(
+case class Algebra(
     mods: Seq[Mod],
     name: Type.Name,
     tparams: Seq[Type.Param],

--- a/modules/core/shared/src/main/scala/freestyle/free/internal/free.scala
+++ b/modules/core/shared/src/main/scala/freestyle/free/internal/free.scala
@@ -66,7 +66,7 @@ object freeImpl {
 
 }
 
-case class Algebra(
+private[freestyle] case class Algebra(
     mods: Seq[Mod],
     name: Type.Name,
     tparams: Seq[Type.Param],

--- a/modules/core/shared/src/test/scala/freestyle/tagless/TaglessTests.scala
+++ b/modules/core/shared/src/test/scala/freestyle/tagless/TaglessTests.scala
@@ -34,6 +34,107 @@ import modules._
 
 class TaglessTests extends WordSpec with Matchers {
 
+  "the @tagless macro annotation should be accepted if it is applied to" when {
+
+    "a trait with at least one request" in {
+      "@tagless trait X { def bar(x:Int): FS[Int] }" should compile
+    }
+
+    "a trait with an F[_] bound type param" in {
+      "@tagless @debug trait FBound[F[_]] { def bar(x:Int): FS[Int] }" should compile
+    }
+
+    "an abstract class with at least one request" in {
+      "@tagless abstract class X { def bar(x:Int): FS[Int] }" should compile
+    }
+
+    "a trait with an abstact method of type FS" in {
+      "@tagless trait X { def f(a: Char) : FS[Int] }" should compile
+    }
+
+    "a trait with type parameters" ignore {
+      "@tagless trait X[A] { def ix(a: A) : FS[A] }" should compile
+    }
+
+    "a trait with some concrete non-FS members" ignore {
+      """@tagless trait X {
+        def x: FS[Int]
+        def y: Int = 5
+        val z: Int = 6
+      }""" should compile
+    }
+
+    "a trait with a request with multiple params" in {
+      "@tagless trait X { def f(a: Int, b: Int): FS[Int] }" should compile
+    }
+
+    "a trait with a currified request, with multiple params lists" ignore {
+      "@tagless trait X { def f(a: Int)(b: Int): FS[Int] }" should compile
+    }
+
+    "a trait with some implicit parameters, with many params lists" ignore {
+      "@tagless trait X { def f(a: Int)(implicit b: Int): FS[Int] }" should compile
+    }
+
+    "a trait with a request with no args" ignore {
+      "@tagless @debug trait X { def f: FS[Int] }" should compile
+    }
+
+    "a trait with type parameters in the method" in {
+      "@tagless trait X { def ix[A](a: A) : FS[A] }" should compile
+    }
+
+    "a trait with high bounded type parameters in the method" in {
+      "@tagless trait X { def ix[A <: Int](a: A) : FS[A] }" should compile
+    }
+
+    "a trait with lower bounded type parameters in the method" in {
+      "@tagless trait X { def ix[A >: Int](a: A) : FS[A] }" should compile
+    }
+
+    "a trait with different type parameters in the method" in {
+      "@tagless trait X { def ix[A <: Int, B, C >: Int](a: A, b: B, c: C) : FS[A] }" should compile
+    }
+
+    "a trait with high bounded type parameters and implicits in the method" in {
+      """
+        trait X[A]
+        @tagless trait Y { def ix[A <: Int : X](a: A) : FS[A] }
+      """ should compile
+    }
+
+  }
+
+  "the @tagless macro annotation should be rejected, and the compilation fail, if it is applied to" when {
+
+    "an empty trait" in (
+      "@tagless trait X" shouldNot compile
+    )
+
+    "an empty abstract class" in (
+      "@tagless abstract class X" shouldNot compile
+    )
+
+    "a non-abstract class" in {
+      "@tagless class X" shouldNot compile
+    }
+
+    "a trait with companion object" in {
+      "@tagless trait X {def f: FS[Int]} ; object X" shouldNot compile
+    }
+
+    "an abstract class with a companion object" in {
+      "@tagless trait X {def f: FS[Int]} ; object X" shouldNot compile
+    }
+
+    "a trait with any non-abstact methods of type FS" in {
+      "@tagless trait X { def f(a: Char) : FS[Int] = 0 } " shouldNot compile
+    }
+
+  }
+
+
+
   "Tagless final algebras" should {
 
     "Allow a trait with an F[_] bound type param" in {

--- a/modules/core/shared/src/test/scala/freestyle/tagless/TaglessTests.scala
+++ b/modules/core/shared/src/test/scala/freestyle/tagless/TaglessTests.scala
@@ -40,8 +40,8 @@ class TaglessTests extends WordSpec with Matchers {
       "@tagless trait X { def bar(x:Int): FS[Int] }" should compile
     }
 
-    "a trait with an F[_] bound type param" in {
-      "@tagless @debug trait FBound[F[_]] { def bar(x:Int): FS[Int] }" should compile
+    "a trait with an F-Bound type param" in {
+      "@tagless trait FBound[F[_]] { def bar(x:Int): FS[Int] }" should compile
     }
 
     "an abstract class with at least one request" in {
@@ -80,8 +80,8 @@ class TaglessTests extends WordSpec with Matchers {
       "@tagless @debug trait X { def f: FS[Int] }" should compile
     }
 
-    "a trait with type parameters in the method" in {
-      "@tagless trait X { def ix[A](a: A) : FS[A] }" should compile
+    "a trait with a method with type parameters" in {
+      "@tagless trait WiX { def ix[A](a: A) : FS[A] }" should compile
     }
 
     "a trait with high bounded type parameters in the method" in {

--- a/modules/core/shared/src/test/scala/freestyle/tagless/TaglessTests.scala
+++ b/modules/core/shared/src/test/scala/freestyle/tagless/TaglessTests.scala
@@ -40,8 +40,13 @@ class TaglessTests extends WordSpec with Matchers {
       "@tagless trait X { def bar(x:Int): FS[Int] }" should compile
     }
 
-    "a trait with an F-Bound type param" in {
-      "@tagless trait FBound[F[_]] { def bar(x:Int): FS[Int] }" should compile
+    "a trait with a kind-1 type param" when {
+      "typing the request with reserved FS" in {
+        "@tagless trait FBound[F[_]] { def ann(x:Int): FS[Int] }" should compile
+      }
+      "typing the request with the user-provided F-Bound type param" in {
+        "@tagless trait FBound[F[_]] { def bob(y:Int): F[Int] }" should compile
+      }
     }
 
     "an abstract class with at least one request" in {

--- a/modules/examples/todolist/src/main/scala/todo/runtime/handlers/H2TagRepositoryHandler.scala
+++ b/modules/examples/todolist/src/main/scala/todo/runtime/handlers/H2TagRepositoryHandler.scala
@@ -17,7 +17,8 @@
 package todo
 package runtime.handlers
 
-import doobie.imports._
+import doobie._
+import doobie.implicits._
 import todo.model.Tag
 import todo.persistence.TagRepository
 

--- a/modules/integrations/cache-redis/src/main/scala/rediscala/free/RedisMap.scala
+++ b/modules/integrations/cache-redis/src/main/scala/rediscala/free/RedisMap.scala
@@ -37,34 +37,34 @@ class MapWrapper[M[_], Key, Value](
     ByteStringSerializer.String.contramap(formatVal)
 
   override def get(key: Key): Ops[M, Option[Value]] =
-    RediscalaCont.get[Key, Option[Value]](key).transform(toM).map(_.flatten)
+    RediscalaCont.get[Key, Option[Value]](key).mapK(toM).map(_.flatten)
 
   override def put(key: Key, value: Value): Ops[M, Unit] =
-    RediscalaCont.set(key, value).transform(toM).void
+    RediscalaCont.set(key, value).mapK(toM).void
 
   override def putAll(keyValues: Map[Key, Value]): Ops[M, Unit] =
-    RediscalaCont.mset(keyValues).transform(toM).void
+    RediscalaCont.mset(keyValues).mapK(toM).void
 
   override def putIfAbsent(key: Key, newVal: Value): Ops[M, Unit] =
-    RediscalaCont.setnx(key, newVal).transform(toM).void
+    RediscalaCont.setnx(key, newVal).mapK(toM).void
 
   override def delete(key: Key): Ops[M, Unit] =
-    RediscalaCont.del(List(key)).transform(toM).void
+    RediscalaCont.del(List(key)).mapK(toM).void
 
   override def hasKey(key: Key): Ops[M, Boolean] =
-    RediscalaCont.exists(key).transform(toM)
+    RediscalaCont.exists(key).mapK(toM)
 
   override def keys: Ops[M, List[Key]] =
-    RediscalaCont.keys.transform(toM).map(_.toList.flatMap(parseKey.apply))
+    RediscalaCont.keys.mapK(toM).map(_.toList.flatMap(parseKey.apply))
 
   override def clear(): Ops[M, Unit] =
-    RediscalaCont.flushDB.transform(toM).void
+    RediscalaCont.flushDB.mapK(toM).void
 
   override def replace(key: Key, newVal: Value): Ops[M, Unit] =
-    RediscalaCont.setxx(key, newVal).transform(toM).void
+    RediscalaCont.setxx(key, newVal).mapK(toM).void
 
   override def isEmpty: Ops[M, Boolean] =
-    RediscalaCont.scan.transform(toM).map(_.data.isEmpty)
+    RediscalaCont.scan.mapK(toM).map(_.data.isEmpty)
 
 }
 


### PR DESCRIPTION
Resolves #478. Succeeds #490.
 
We simplify the generation of the `Handler`, and of the `StackSafe.Handler` trait definitions. Instead, we make the `Handler` to be a sub-trait of both of them. This removes some code generation

We also change how we generate and use `FunctorK` type-class from the [mainecoon](https://github.com/kailuowang/mainecoon) library. 
* We add to every `@tagless`-annotated trait a `mapK` function, which takes a `FunctionK`. 
* We change the `FunctorK`instance to use the trait's `mapK` function. 
* We change the `implicit def derive` method to use the trait's `mapK` function. 

We move some logic for manipulating Scalameta case classes into the `ScalametaUtil` object. 

We extend the test suite on the `@tagless` macro, copying some tests for the `@free` macro.
  