### PR TITLE
Updates freestyle Build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val core = module("core")
   .crossDepSettings(
     commonDeps ++ Seq(
       %("cats-free"),
-      %("iota-core", "0.3.4"),
+      %("iota-core"),
       %("simulacrum"),
       %("shapeless") % "test",
       %("cats-laws") % "test",

--- a/docs/src/main/tut/docs/http/hammock/README.md
+++ b/docs/src/main/tut/docs/http/hammock/README.md
@@ -33,7 +33,7 @@ import cats.effect.{Sync, IO}
 import _root_.hammock._
 import _root_.hammock.Uri._
 import _root_.hammock.hi._
-import _root_.hammock.jvm.free.Interpreter
+import _root_.hammock.jvm.Interpreter
 
 ```
 
@@ -71,7 +71,7 @@ Also, you can lift any arbitrary `HttpRequestIO[F]` program to
 
 ```tut
 implicit val interp = Interpreter[IO]
-val response = Hammock.getWithOpts(Uri.unsafeParse("https://jsonplaceholder.typicode.com/posts/1"), Opts.default)
+val response = Hammock.getWithOpts(Uri.unsafeParse("https://jsonplaceholder.typicode.com/posts/1"), Opts.empty)
   
 HammockM[HammockM.Op].run(response).interpret[IO].unsafeRunSync
 ```

--- a/modules/integrations/http/http-client/shared/src/main/scala/free/http/free.scala
+++ b/modules/integrations/http/http-client/shared/src/main/scala/free/http/free.scala
@@ -18,8 +18,6 @@ package freestyle.free
 package http
 
 import _root_.hammock._
-import _root_.hammock.free.algebra._
-import _root_.hammock.free._
 import cats.{MonadError, ~>}
 import cats.effect.Sync
 import cats.free.Free
@@ -32,11 +30,11 @@ object client {
     def options(uri: Uri, headers: Map[String, String]): FS[HttpResponse]
     def get(uri: Uri, headers: Map[String, String]): FS[HttpResponse]
     def head(uri: Uri, headers: Map[String, String]): FS[HttpResponse]
-    def post(uri: Uri, headers: Map[String, String], body: Option[String]): FS[HttpResponse]
-    def put(uri: Uri, headers: Map[String, String], body: Option[String]): FS[HttpResponse]
+    def post(uri: Uri, headers: Map[String, String], body: Option[Entity]): FS[HttpResponse]
+    def put(uri: Uri, headers: Map[String, String], body: Option[Entity]): FS[HttpResponse]
     def delete(uri: Uri, headers: Map[String, String]): FS[HttpResponse]
     def trace(uri: Uri, headers: Map[String, String]): FS[HttpResponse]
-    def run[A](req: HttpRequestIO[A]): FS[A]
+    def run[A](req: Free[HttpF, A]): FS[A]
   }
 
   trait Implicits {
@@ -45,16 +43,16 @@ object client {
         def options(uri: Uri, headers: Map[String, String]): M[HttpResponse] = Ops.options(uri, headers) foldMap I.trans
         def get(uri: Uri, headers: Map[String, String]): M[HttpResponse] = Ops.get(uri, headers) foldMap I.trans
         def head(uri: Uri, headers: Map[String, String]): M[HttpResponse] = Ops.head(uri, headers) foldMap I.trans
-        def post(uri: Uri, headers: Map[String, String], body: Option[String]): M[HttpResponse] = Ops.post(uri, headers, body) foldMap I.trans
-        def put(uri: Uri, headers: Map[String, String], body: Option[String]): M[HttpResponse] = Ops.put(uri, headers, body) foldMap I.trans
+        def post(uri: Uri, headers: Map[String, String], body: Option[Entity]): M[HttpResponse] = Ops.post(uri, headers, body) foldMap I.trans
+        def put(uri: Uri, headers: Map[String, String], body: Option[Entity]): M[HttpResponse] = Ops.put(uri, headers, body) foldMap I.trans
         def delete(uri: Uri, headers: Map[String, String]): M[HttpResponse] = Ops.delete(uri, headers) foldMap I.trans
         def trace(uri: Uri, headers: Map[String, String]): M[HttpResponse] = Ops.trace(uri, headers) foldMap I.trans
-        def run[A](req: HttpRequestIO[A]): M[A] = req foldMap I.trans
+        def run[A](req: Free[HttpF, A]): M[A] = req foldMap I.trans
       }
 
-    implicit def freeSLiftHammock[F[_]: HammockM]: FreeSLift[F, HttpRequestIO] =
-      new FreeSLift[F, HttpRequestIO] {
-        def liftFSPar[A](hio: HttpRequestIO[A]): FreeS.Par[F, A] = HammockM[F].run(hio)
+    implicit def freeSLiftHammock[F[_]: HammockM]: FreeSLift[F, Free[HttpF, ?]] =
+      new FreeSLift[F, Free[HttpF, ?]] {
+        def liftFSPar[A](hio: Free[HttpF, A]): FreeS.Par[F, A] = HammockM[F].run(hio)
       }
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += Resolver.sonatypeRepo("releases")
 
-addSbtPlugin("io.frees"        % "sbt-freestyle"   % "0.3.14")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.0")
+addSbtPlugin("io.frees"        % "sbt-freestyle"   % "0.3.15")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.2-SNAPSHOT"
+version in ThisBuild := "0.5.2"


### PR DESCRIPTION
This PR aligns all the dependencies upgraded to cats `1.0.1`, including `cats-effect`, `monix`, `fs2`, `doobie`, `http4s`, etc. It also required upgrading `hammock` to the latest version (`0.8.1`).

Releases a new patch version: **0.5.2**.