### PR TITLE
Freestyle Effects for @tagless

### DIFF
--- a/docs/src/main/tut/docs/effects/async/README.md
+++ b/docs/src/main/tut/docs/effects/async/README.md
@@ -54,7 +54,7 @@ The imports for the _frees-async_ AsyncContext:
 
 ```tut:silent
 import freestyle.async._
-import freestyle.async.implicits._
+import freestyle.free.async.implicits._
 ```
 
 Now if we want to create a freestyle program which uses the `findBooks` function and returns all the books sorted by the year they were written, we can use the `AsyncM` effect:

--- a/docs/src/main/tut/docs/effects/async/README.md
+++ b/docs/src/main/tut/docs/effects/async/README.md
@@ -93,7 +93,7 @@ We can run these programs using:
 - Cats' `IO` as target effect type:
 
 ```tut:book
-import freestyle.free.asyncCatsEffect.implicits._
+import freestyle.async.catsEffect.implicits._
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.Duration

--- a/modules/async/async-cats-effect/shared/src/main/scala/AsyncCatsEffect.scala
+++ b/modules/async/async-cats-effect/shared/src/main/scala/AsyncCatsEffect.scala
@@ -15,7 +15,7 @@
  */
 
 package freestyle.async
-package asyncCatsEffect
+package catsEffect
 
 import cats.effect.Effect
 

--- a/modules/async/async-cats-effect/shared/src/main/scala/AsyncCatsEffect.scala
+++ b/modules/async/async-cats-effect/shared/src/main/scala/AsyncCatsEffect.scala
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package freestyle.free.asyncCatsEffect
+package freestyle.async
+package asyncCatsEffect
 
-import freestyle.async._
-import freestyle.free.async._
 import cats.effect.Effect
 
 trait AsyncCatsEffectImplicits {

--- a/modules/async/async-cats-effect/shared/src/test/scala/AsyncCatsEffectTests.scala
+++ b/modules/async/async-cats-effect/shared/src/test/scala/AsyncCatsEffectTests.scala
@@ -15,14 +15,14 @@
  */
 
 package freestyle.async
-package asyncCatsEffect
+package catsEffect
 
 import cats.effect.IO
 import freestyle.free._
 import freestyle.free.implicits._
 import freestyle.free.async._
 import freestyle.free.async.implicits._
-import freestyle.async.asyncCatsEffect.implicits._
+import freestyle.async.catsEffect.implicits._
 import org.scalatest.{AsyncWordSpec, Matchers}
 import scala.concurrent.ExecutionContext
 

--- a/modules/async/async-cats-effect/shared/src/test/scala/AsyncCatsEffectTests.scala
+++ b/modules/async/async-cats-effect/shared/src/test/scala/AsyncCatsEffectTests.scala
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-package freestyle.free.asyncCatsEffect
+package freestyle.async
+package asyncCatsEffect
 
 import cats.effect.IO
 import freestyle.free._
 import freestyle.free.implicits._
 import freestyle.free.async._
 import freestyle.free.async.implicits._
-import freestyle.free.asyncCatsEffect.implicits._
+import freestyle.async.asyncCatsEffect.implicits._
 import org.scalatest.{AsyncWordSpec, Matchers}
 import scala.concurrent.ExecutionContext
 
-class AsyncFs2Tests extends AsyncWordSpec with Matchers {
+class AsyncCatsEffectTests extends AsyncWordSpec with Matchers {
 
-  implicit override def executionContext = ExecutionContext.Implicits.global
+  implicit override def executionContext: ExecutionContext = ExecutionContext.Implicits.global
 
   "Async Cats Effect Freestyle integration" should {
     "support IO as the target runtime" in {

--- a/modules/async/async-guava/src/main/scala/AsyncGuava.scala
+++ b/modules/async/async-guava/src/main/scala/AsyncGuava.scala
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package freestyle.free.asyncGuava
+package freestyle.async
+package asyncGuava
 
 import cats.~>
 import com.google.common.util.concurrent._
-import freestyle.free._
-import freestyle.async.AsyncContext
 import java.util.concurrent.{Executor => JavaExecutor}
 
 import scala.concurrent.ExecutionContext
@@ -27,11 +26,11 @@ import scala.concurrent.ExecutionContext
 trait AsyncGuavaImplicits {
 
   class ListenableFuture2AsyncM[F[_]](implicit AC: AsyncContext[F], E: ExecutionContext)
-      extends FSHandler[ListenableFuture, F] {
-    override def apply[A](listenableFuture: ListenableFuture[A]): F[A] =
+      extends (ListenableFuture ~> F) {
+    override def apply[A](fa: ListenableFuture[A]): F[A] =
       AC.runAsync { cb =>
         Futures.addCallback(
-          listenableFuture,
+          fa,
           new FutureCallback[A] {
             override def onSuccess(result: A): Unit = cb(Right(result))
 

--- a/modules/async/async-guava/src/main/scala/AsyncGuava.scala
+++ b/modules/async/async-guava/src/main/scala/AsyncGuava.scala
@@ -15,7 +15,7 @@
  */
 
 package freestyle.async
-package asyncGuava
+package guava
 
 import cats.~>
 import com.google.common.util.concurrent._

--- a/modules/async/async-guava/src/test/scala/AsyncGuavaTests.scala
+++ b/modules/async/async-guava/src/test/scala/AsyncGuavaTests.scala
@@ -15,7 +15,7 @@
  */
 
 package freestyle.async
-package asyncGuava
+package guava
 
 import java.util.concurrent.{Callable, Executors}
 

--- a/modules/async/async-guava/src/test/scala/AsyncGuavaTests.scala
+++ b/modules/async/async-guava/src/test/scala/AsyncGuavaTests.scala
@@ -14,26 +14,23 @@
  * limitations under the License.
  */
 
-package freestyle.free.asyncGuava
+package freestyle.async
+package asyncGuava
 
 import java.util.concurrent.{Callable, Executors}
 
 import cats.~>
 import com.google.common.util.concurrent.{ListenableFuture, ListeningExecutorService, MoreExecutors}
-import freestyle.async
-import freestyle.async.Proc
 import org.scalatest._
-import freestyle.free.async.implicits._
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-class AsyncGuavaTests extends WordSpec with Matchers {
+class AsyncGuavaTests extends WordSpec with Matchers with Implicits {
 
   import ExecutionContext.Implicits.global
 
-  val aa: async.AsyncContext[Future] = futureAsyncContext
-  val exception: Throwable           = new RuntimeException("Test exception")
+  val exception: Throwable = new RuntimeException("Test exception")
 
   val service: ListeningExecutorService =
     MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(10))

--- a/modules/async/async-guava/src/test/scala/asyncGuava/free/AsyncGuavaTests.scala
+++ b/modules/async/async-guava/src/test/scala/asyncGuava/free/AsyncGuavaTests.scala
@@ -20,8 +20,9 @@ import java.util.concurrent.{Callable, Executors}
 
 import cats.~>
 import com.google.common.util.concurrent.{ListenableFuture, ListeningExecutorService, MoreExecutors}
+import freestyle.async
+import freestyle.async.Proc
 import org.scalatest._
-import freestyle.async.implicits._
 import freestyle.free.async.implicits._
 
 import scala.concurrent.duration.Duration
@@ -31,7 +32,8 @@ class AsyncGuavaTests extends WordSpec with Matchers {
 
   import ExecutionContext.Implicits.global
 
-  val exception: Throwable = new RuntimeException("Test exception")
+  val aa: async.AsyncContext[Future] = futureAsyncContext
+  val exception: Throwable           = new RuntimeException("Test exception")
 
   val service: ListeningExecutorService =
     MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(10))
@@ -47,6 +49,7 @@ class AsyncGuavaTests extends WordSpec with Matchers {
     })
 
   val handler: ListenableFuture ~> Future = implicits.listenableFuture2Async[Future]
+
   val conv: ListenableFuture[Void] => ListenableFuture[Unit] =
     implicits.listenableVoidToListenableUnit
 

--- a/modules/async/async/shared/src/main/scala/async.scala
+++ b/modules/async/async/shared/src/main/scala/async.scala
@@ -60,7 +60,10 @@ object async {
 
     final class FutureOps[A](f: Future[A]) {
 
+      @deprecated("Use unsafeTo instead.", "0.5.4")
       def to[F[_]](implicit AC: AsyncContext[F], E: ExecutionContext): F[A] = future2AsyncM[F, A](f)
+
+      def unsafeTo[F[_]](implicit AC: AsyncContext[F], E: ExecutionContext): F[A] = future2AsyncM[F, A](f)
 
     }
 

--- a/modules/async/async/shared/src/main/scala/async.scala
+++ b/modules/async/async/shared/src/main/scala/async.scala
@@ -19,7 +19,7 @@ package freestyle
 import scala.util._
 import scala.concurrent._
 
-object async {
+package object async {
 
   /** An asynchronous computation that might fail. **/
   type Proc[A] = (Either[Throwable, A] => Unit) => Unit

--- a/modules/async/async/shared/src/main/scala/async.scala
+++ b/modules/async/async/shared/src/main/scala/async.scala
@@ -60,7 +60,7 @@ object async {
 
     final class FutureOps[A](f: Future[A]) {
 
-      @deprecated("Use unsafeTo instead.", "0.5.4")
+      @deprecated("Use unsafeTo instead.", "0.6.0")
       def to[F[_]](implicit AC: AsyncContext[F], E: ExecutionContext): F[A] = future2AsyncM[F, A](f)
 
       def unsafeTo[F[_]](implicit AC: AsyncContext[F], E: ExecutionContext): F[A] = future2AsyncM[F, A](f)

--- a/modules/async/async/shared/src/main/scala/async.scala
+++ b/modules/async/async/shared/src/main/scala/async.scala
@@ -66,5 +66,4 @@ object async {
 
   }
 
-  object implicits extends Implicits
 }

--- a/modules/async/async/shared/src/main/scala/free/async.scala
+++ b/modules/async/async/shared/src/main/scala/free/async.scala
@@ -30,18 +30,11 @@ object async {
 
   class Future2AsyncM[F[_]](implicit AC: AsyncContext[F], E: ExecutionContext)
     extends FSHandler[Future, F] {
-    override def apply[A](future: Future[A]): F[A] =
-      AC.runAsync { cb =>
-        E.execute(new Runnable {
-          def run(): Unit = future.onComplete {
-            case Failure(e) => cb(Left(e))
-            case Success(r) => cb(Right(r))
-          }
-        })
-      }
+    override def apply[A](future: Future[A]): F[A] = future2AsyncM[F, A](future)
+
   }
 
-  trait Implicits {
+  trait FreeImplicits extends Implicits with Syntax {
 
     implicit def freeStyleAsyncMHandler[M[_]](
         implicit MA: AsyncContext[M]
@@ -52,18 +45,5 @@ object async {
       }
   }
 
-  trait Syntax {
-
-    implicit def futureOps[A](f: Future[A]): FutureOps[A] = new FutureOps(f)
-
-    final class FutureOps[A](f: Future[A]) {
-
-      def to[F[_]](implicit AC: AsyncContext[F], E: ExecutionContext): F[A] =
-        new Future2AsyncM[F].apply(f)
-
-    }
-
-  }
-
-  object implicits extends Implicits with Syntax
+  object implicits extends FreeImplicits
 }

--- a/modules/async/async/shared/src/main/scala/free/async.scala
+++ b/modules/async/async/shared/src/main/scala/free/async.scala
@@ -19,7 +19,6 @@ package freestyle.free
 import scala.concurrent._
 import scala.util._
 import freestyle.async._
-import freestyle.async.implicits._
 
 object async {
 

--- a/modules/async/async/shared/src/main/scala/tagless/async.scala
+++ b/modules/async/async/shared/src/main/scala/tagless/async.scala
@@ -19,7 +19,6 @@ package freestyle.tagless
 import scala.concurrent._
 import scala.util._
 import freestyle.async._
-import freestyle.async.implicits._
 
 object async {
 

--- a/modules/async/async/shared/src/main/scala/tagless/async.scala
+++ b/modules/async/async/shared/src/main/scala/tagless/async.scala
@@ -28,7 +28,7 @@ object async {
     def async[A](fa: Proc[A]): FS[A]
   }
 
-  trait Implicits {
+  trait AsyncImplicits extends Implicits with Syntax {
 
     implicit def taglessAsyncMHandler[M[_]](implicit MA: AsyncContext[M]): AsyncM.Handler[M] =
       new AsyncM.Handler[M] {
@@ -36,5 +36,5 @@ object async {
       }
   }
 
-  object implicits extends Implicits
+  object implicits extends AsyncImplicits
 }

--- a/modules/async/async/shared/src/test/scala/free/AsyncTests.scala
+++ b/modules/async/async/shared/src/test/scala/free/AsyncTests.scala
@@ -24,7 +24,6 @@ import freestyle.free._
 import freestyle.free.implicits._
 import freestyle.free.async._
 import freestyle.free.async.implicits._
-import freestyle.async.implicits._
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/modules/async/async/shared/src/test/scala/free/Future2AsyncMTests.scala
+++ b/modules/async/async/shared/src/test/scala/free/Future2AsyncMTests.scala
@@ -16,10 +16,9 @@
 
 package freestyle.free
 
-import freestyle.free.async.implicits._
 import freestyle.async._
-import freestyle.async.implicits._
 import freestyle.free.async.Future2AsyncM
+import freestyle.free.async.implicits._
 import org.scalatest._
 import cats.effect.{Effect, IO}
 

--- a/modules/async/async/shared/src/test/scala/tagless/AsyncTests.scala
+++ b/modules/async/async/shared/src/test/scala/tagless/AsyncTests.scala
@@ -21,7 +21,6 @@ import cats.instances.future._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import freestyle.async.AsyncContext
-import freestyle.async.implicits._
 import freestyle.tagless._
 import freestyle.tagless.async._
 import freestyle.tagless.async.implicits._

--- a/modules/effects/shared/src/main/scala/free/effects/option.scala
+++ b/modules/effects/shared/src/main/scala/free/effects/option.scala
@@ -17,23 +17,13 @@
 package freestyle.free
 package effects
 
-import cats.Applicative
-import cats.mtl.FunctorEmpty
-
 object option {
 
-  @free sealed trait OptionM {
-    def option[A](fa: Option[A]): FS[A]
-    def none[A]: FS[A]
-  }
+  type OptionM[F[_]] = freestyle.tagless.effects.option.OptionM.StackSafe[F]
 
-  trait Implicits {
-    implicit def freeStyleOptionMHandler[M[_]](
-        implicit FE: FunctorEmpty[M], A: Applicative[M]): OptionM.Handler[M] =
-      new OptionM.Handler[M] {
-        def option[A](fa: Option[A]): M[A] = FE.flattenOption(A.pure(fa))
-        def none[A]: M[A]                  = option(Option.empty[A])
-      }
+  val OptionM = freestyle.tagless.effects.option.OptionM.StackSafe
+
+  trait FreeImplicits extends freestyle.tagless.effects.option.Implicits {
 
     class OptionFreeSLift[F[_]: OptionM] extends FreeSLift[F, Option] {
       def liftFSPar[A](fa: Option[A]): FreeS.Par[F, A] = OptionM[F].option(fa)
@@ -42,5 +32,5 @@ object option {
     implicit def freeSLiftOption[F[_]: OptionM]: FreeSLift[F, Option] = new OptionFreeSLift[F]
   }
 
-  object implicits extends Implicits
+  object implicits extends FreeImplicits
 }

--- a/modules/effects/shared/src/main/scala/free/effects/reader.scala
+++ b/modules/effects/shared/src/main/scala/free/effects/reader.scala
@@ -17,28 +17,19 @@
 package freestyle.free
 package effects
 
-import cats.mtl.ApplicativeAsk
-
 object reader {
 
   final class EnvironmentProvider[R] {
 
-    @free abstract class ReaderM {
-      def ask: FS[R]
-      def reader[B](f: R => B): FS[B]
-    }
+    val taglessV: freestyle.tagless.effects.reader.EnvironmentProvider[R] =
+      freestyle.tagless.effects.reader[R]
 
-    trait Implicits {
+    type ReaderM[F[_]] = taglessV.ReaderM.StackSafe[F]
 
-      implicit def freestyleReaderMHandler[M[_]](
-          implicit AL: ApplicativeAsk[M, R]): ReaderM.Handler[M] =
-        new ReaderM.Handler[M] {
-          def ask: M[R]                  = AL.ask
-          def reader[B](f: R => B): M[B] = AL.reader(f)
-        }
-    }
+    val ReaderM = taglessV.ReaderM.StackSafe
 
-    object implicits extends Implicits
+    object implicits extends taglessV.Implicits
+
   }
 
   def apply[R] = new EnvironmentProvider[R]

--- a/modules/effects/shared/src/main/scala/free/effects/validation.scala
+++ b/modules/effects/shared/src/main/scala/free/effects/validation.scala
@@ -17,59 +17,30 @@
 package freestyle.free
 package effects
 
-import cats.data.{NonEmptyList, State, Validated, ValidatedNel}
-import cats.mtl.MonadState
-
 object validation {
+
   final class ValidationProvider[E] {
-    type Errors = List[E]
 
-    /** An algebra for introducing validation semantics in a program. **/
-    @free sealed trait ValidationM {
-      def valid[A](x: A): FS[A]
+    val taglessV: freestyle.tagless.effects.validation.ValidationProvider[E] =
+      freestyle.tagless.effects.validation[E]
 
-      def invalid(err: E): FS[Unit]
+    type ValidationM[F[_]] = taglessV.ValidationM.StackSafe[F]
 
-      def errors: FS[Errors]
+    val ValidationM = taglessV.ValidationM.StackSafe
 
-      def fromEither[A](x: Either[E, A]): FS[Either[E, A]]
+    trait FreeImplicits extends taglessV.Implicits {
 
-      def fromValidatedNel[A](x: ValidatedNel[E, A]): FS[ValidatedNel[E, A]]
+      implicit class FreeValidSyntax[A](private val s: A) {
+        def liftValid[F[_]: ValidationM] = ValidationM[F].valid(s)
+      }
+      implicit class FreeInvalidSyntax[A](private val e: E) {
+        def liftInvalid[F[_]: ValidationM] = ValidationM[F].invalid(e)
+      }
+
     }
 
-    trait Implicits {
-      implicit def freeStyleValidationMStateInterpreter[M[_]](
-          implicit MS: MonadState[M, Errors]
-      ): ValidationM.Handler[M] = new ValidationM.Handler[M] {
-        def valid[A](x: A): M[A] = MS.monad.pure(x)
+    object implicits extends FreeImplicits
 
-        def errors: M[Errors] = MS.get
-
-        def invalid(err: E): M[Unit] = MS.modify((s: Errors) => s :+ err)
-
-        def fromEither[A](x: Either[E, A]): M[Either[E, A]] =
-          x match {
-            case Left(err) => MS.monad.as(invalid(err), x)
-            case Right(_)  => MS.monad.pure(x)
-          }
-
-        def fromValidatedNel[A](x: ValidatedNel[E, A]): M[ValidatedNel[E, A]] =
-          x match {
-            case Validated.Invalid(errs) =>
-              MS.monad.as(MS.modify((s: Errors) => s ++ errs.toList), x)
-            case Validated.Valid(_) => MS.monad.pure(x)
-          }
-      }
-
-      implicit class ValidSyntax[A](private val s: A) {
-        def liftValid[F[_]: ValidationM]: FreeS[F, A] = ValidationM[F].valid(s)
-      }
-      implicit class InvalidSyntax[A](private val e: E) {
-        def liftInvalid[F[_]: ValidationM]: FreeS[F, Unit] = ValidationM[F].invalid(e)
-      }
-    }
-
-    object implicits extends Implicits
   }
 
   def apply[E] = new ValidationProvider[E]

--- a/modules/effects/shared/src/main/scala/free/effects/writer.scala
+++ b/modules/effects/shared/src/main/scala/free/effects/writer.scala
@@ -17,29 +17,18 @@
 package freestyle.free
 package effects
 
-import cats.mtl.FunctorTell
-
 object writer {
 
-  final class AccumulatorProvider[W] {
+  final class AccumulatorProvider[E] {
 
-    @free sealed abstract class WriterM {
-      def writer[A](aw: (W, A)): FS[A]
-      def tell(w: W): FS[Unit]
-    }
+    val taglessV: freestyle.tagless.effects.writer.AccumulatorProvider[E] =
+      freestyle.tagless.effects.writer[E]
 
-    trait Implicits {
+    type WriterM[F[_]] = taglessV.WriterM.StackSafe[F]
 
-      implicit def freestyleWriterMHandler[M[_]](
-          implicit FT: FunctorTell[M, W]): WriterM.Handler[M] =
-        new WriterM.Handler[M] {
-          def writer[A](aw: (W, A)): M[A] = FT.tuple(aw)
-          def tell(w: W): M[Unit]         = FT.tell(w)
-        }
+    val WriterM = taglessV.WriterM.StackSafe
 
-    }
-
-    object implicits extends Implicits
+    object implicits extends taglessV.Implicits
   }
 
   def apply[W] = new AccumulatorProvider[W]

--- a/modules/effects/shared/src/main/scala/tagless/effects/either.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/either.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.tagless
+package effects
+
+import cats.{Eval, MonadError}
+
+import scala.util.control.NonFatal
+
+object either {
+
+  final class ErrorProvider[E] {
+
+    @tagless sealed trait EitherM {
+      def either[A](fa: Either[E, A]): FS[A]
+      def error[A](e: E): FS[A]
+      def catchNonFatal[A](a: Eval[A], f: Throwable => E): FS[A]
+    }
+
+    trait Implicits {
+      implicit def freeStyleEitherMHandler[M[_]](
+          implicit ME: MonadError[M, E]): EitherM.Handler[M] = new EitherM.Handler[M] {
+        def either[A](fa: Either[E, A]): M[A] = fa.fold(ME.raiseError[A], ME.pure[A])
+        def error[A](e: E): M[A]              = ME.raiseError[A](e)
+        def catchNonFatal[A](a: Eval[A], f: Throwable => E): M[A] =
+          try ME.pure(a.value)
+          catch {
+            case NonFatal(e) => ME.raiseError(f(e))
+          }
+      }
+
+      implicit class EitherFSLift[A](fa: Either[E, A])  {
+        def liftF[F[_]: EitherM]: F[A] = EitherM[F].either(fa)
+      }
+    }
+
+    object implicits extends Implicits
+  }
+
+  def apply[E]: ErrorProvider[E] = new ErrorProvider
+}

--- a/modules/effects/shared/src/main/scala/tagless/effects/either.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/either.scala
@@ -34,7 +34,7 @@ object either {
     trait Implicits {
       implicit def freeStyleEitherMHandler[M[_]](
           implicit ME: MonadError[M, E]): EitherM.Handler[M] = new EitherM.Handler[M] {
-        def either[A](fa: Either[E, A]): M[A] = fa.fold(ME.raiseError[A], ME.pure[A])
+        def either[A](fa: Either[E, A]): M[A] = ME.fromEither(fa)
         def error[A](e: E): M[A]              = ME.raiseError[A](e)
         def catchNonFatal[A](a: Eval[A], f: Throwable => E): M[A] =
           try ME.pure(a.value)

--- a/modules/effects/shared/src/main/scala/tagless/effects/error.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/error.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.tagless
+package effects
+
+import cats.{Eval, MonadError}
+
+object error {
+
+  @tagless sealed trait ErrorM {
+    def either[A](fa: Either[Throwable, A]): FS[A]
+    def error[A](e: Throwable): FS[A]
+    def catchNonFatal[A](a: Eval[A]): FS[A]
+  }
+
+  trait Implicits {
+
+    implicit def freeStyleErrorMHandler[M[_]](
+        implicit ME: MonadError[M, Throwable]): ErrorM.Handler[M] = new ErrorM.Handler[M] {
+      def either[A](fa: Either[Throwable, A]): M[A] = fa.fold(ME.raiseError[A], ME.pure[A])
+      def error[A](e: Throwable): M[A]              = ME.raiseError[A](e)
+      def catchNonFatal[A](a: Eval[A]): M[A]        = ME.catchNonFatal[A](a.value)
+    }
+
+    implicit class ErrorFSLift[A](fa: Either[Throwable, A])  {
+      def liftF[F[_]: ErrorM]: F[A] = ErrorM[F].either(fa)
+    }
+
+  }
+
+  object implicits extends Implicits
+}

--- a/modules/effects/shared/src/main/scala/tagless/effects/error.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/error.scala
@@ -31,7 +31,7 @@ object error {
 
     implicit def freeStyleErrorMHandler[M[_]](
         implicit ME: MonadError[M, Throwable]): ErrorM.Handler[M] = new ErrorM.Handler[M] {
-      def either[A](fa: Either[Throwable, A]): M[A] = fa.fold(ME.raiseError[A], ME.pure[A])
+      def either[A](fa: Either[Throwable, A]): M[A] = ME.fromEither(fa)
       def error[A](e: Throwable): M[A]              = ME.raiseError[A](e)
       def catchNonFatal[A](a: Eval[A]): M[A]        = ME.catchNonFatal[A](a.value)
     }

--- a/modules/effects/shared/src/main/scala/tagless/effects/implicits.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/implicits.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package freestyle.free
+package freestyle.tagless
 package effects
 
-object implicits extends option.FreeImplicits with error.FreeImplicits
+object implicits extends option.Implicits with error.Implicits

--- a/modules/effects/shared/src/main/scala/tagless/effects/option.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/option.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.tagless
+package effects
+
+import cats.Applicative
+import cats.mtl.FunctorEmpty
+
+object option {
+
+  @tagless sealed trait OptionM {
+    def option[A](fa: Option[A]): FS[A]
+    def none[A]: FS[A]
+  }
+
+  trait Implicits {
+    implicit def freeStyleOptionMHandler[M[_]](
+        implicit FE: FunctorEmpty[M], A: Applicative[M]): OptionM.Handler[M] =
+      new OptionM.Handler[M] {
+        def option[A](fa: Option[A]): M[A] = FE.flattenOption(A.pure(fa))
+        def none[A]: M[A]                  = option(Option.empty[A])
+      }
+
+    implicit class OptionFSLift[F[_]: OptionM, A](fa: Option[A])  {
+      def liftF: F[A] = OptionM[F].option(fa)
+    }
+
+  }
+
+  object implicits extends Implicits
+}

--- a/modules/effects/shared/src/main/scala/tagless/effects/reader.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/reader.scala
@@ -14,7 +14,33 @@
  * limitations under the License.
  */
 
-package freestyle.free
+package freestyle.tagless
 package effects
 
-object implicits extends option.FreeImplicits with error.FreeImplicits
+import cats.mtl.ApplicativeAsk
+
+object reader {
+
+  final class EnvironmentProvider[R] {
+
+    @tagless abstract class ReaderM {
+      def ask: FS[R]
+      def reader[B](f: R => B): FS[B]
+    }
+
+    trait Implicits {
+
+      implicit def freestyleReaderMHandler[M[_]](
+          implicit AL: ApplicativeAsk[M, R]): ReaderM.Handler[M] =
+        new ReaderM.Handler[M] {
+          def ask: M[R]                  = AL.ask
+          def reader[B](f: R => B): M[B] = AL.reader(f)
+        }
+    }
+
+    object implicits extends Implicits
+  }
+
+  def apply[R] = new EnvironmentProvider[R]
+
+}

--- a/modules/effects/shared/src/main/scala/tagless/effects/state.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/state.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.tagless
+package effects
+
+import cats.mtl.MonadState
+
+object state {
+
+  final class StateSeedProvider[S] {
+
+    @tagless sealed abstract class StateM {
+      def get: FS[S]
+      def set(s: S): FS[Unit]
+      def modify(f: S => S): FS[Unit]
+      def inspect[A](f: S => A): FS[A]
+    }
+
+    trait Implicits {
+
+      implicit def freestyleStateMHandler[M[_]](implicit MS: MonadState[M, S]): StateM.Handler[M] =
+        new StateM.Handler[M] {
+          def get: M[S]                   = MS.get
+          def set(s: S): M[Unit]          = MS.set(s)
+          def modify(f: S => S): M[Unit]  = MS.modify(f)
+          def inspect[A](f: S => A): M[A] = MS.inspect(f)
+        }
+
+      implicit class StateFSLift[A](fa: Function1[S, A])  {
+        def liftF[F[_]: StateM]: F[A] = StateM[F].inspect(fa)
+      }
+
+    }
+
+    object implicits extends Implicits
+  }
+
+  def apply[S] = new StateSeedProvider[S]
+
+}

--- a/modules/effects/shared/src/main/scala/tagless/effects/traverse.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/traverse.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.tagless
+package effects
+
+import cats.{Alternative, Foldable, Monad}
+
+object traverse {
+
+  final class TraverseProvider[G[_]] {
+
+    /** Acts as a generator providing traversable semantics to programs
+     */
+    @tagless sealed abstract class TraverseM {
+      def empty[A]: FS[A]
+      def fromTraversable[A](ta: G[A]): FS[A]
+    }
+
+    /** Interpretable as long as a `Foldable` instance for G[_] and a `Monad` and
+     * an `Alternative` instnace for M[_] exists in scope.
+     */
+    trait Implicits {
+      implicit def freestyleTraverseMHandler[F[_], M[_]](
+          implicit M: Monad[M],
+          MA: Alternative[M],
+          FT: Foldable[G]): TraverseM.Handler[M] =
+        new TraverseM.Handler[M] {
+          def empty[A]: M[A]                     = MA.empty[A]
+          def fromTraversable[A](ta: G[A]): M[A] = FT.foldMap(ta)(MA.pure)(MA.algebra[A])
+        }
+
+      implicit class TraverseFSLift[F[_]: TraverseM, A](fa: G[A])  {
+        def liftF: F[A] = TraverseM[F].fromTraversable(fa)
+      }
+    }
+
+    object implicits extends Implicits
+  }
+
+  def apply[T[_]] = new TraverseProvider[T]
+
+  def list = apply[List]
+
+}

--- a/modules/effects/shared/src/main/scala/tagless/effects/validation.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/validation.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.tagless
+package effects
+
+import cats.data.{Validated, ValidatedNel}
+import cats.mtl.MonadState
+
+object validation {
+  final class ValidationProvider[E] {
+    type Errors = List[E]
+
+    /** An algebra for introducing validation semantics in a program. **/
+    @tagless sealed trait ValidationM {
+      def valid[A](x: A): FS[A]
+
+      def invalid(err: E): FS[Unit]
+
+      def errors: FS[Errors]
+
+      def fromEither[A](x: Either[E, A]): FS[Either[E, A]]
+
+      def fromValidatedNel[A](x: ValidatedNel[E, A]): FS[ValidatedNel[E, A]]
+    }
+
+    trait Implicits {
+      implicit def freeStyleValidationMStateInterpreter[M[_]](
+          implicit MS: MonadState[M, Errors]
+      ): ValidationM.Handler[M] = new ValidationM.Handler[M] {
+        def valid[A](x: A): M[A] = MS.monad.pure(x)
+
+        def errors: M[Errors] = MS.get
+
+        def invalid(err: E): M[Unit] = MS.modify((s: Errors) => s :+ err)
+
+        def fromEither[A](x: Either[E, A]): M[Either[E, A]] =
+          x match {
+            case Left(err) => MS.monad.as(invalid(err), x)
+            case Right(_)  => MS.monad.pure(x)
+          }
+
+        def fromValidatedNel[A](x: ValidatedNel[E, A]): M[ValidatedNel[E, A]] =
+          x match {
+            case Validated.Invalid(errs) =>
+              MS.monad.as(MS.modify((s: Errors) => s ++ errs.toList), x)
+            case Validated.Valid(_) => MS.monad.pure(x)
+          }
+      }
+
+      implicit class ValidSyntax[A](private val s: A) {
+        def liftValid[F[_]: ValidationM]: F[A] = ValidationM[F].valid(s)
+      }
+      implicit class InvalidSyntax[A](private val e: E) {
+        def liftInvalid[F[_]: ValidationM]: F[Unit] = ValidationM[F].invalid(e)
+      }
+    }
+
+    object implicits extends Implicits
+  }
+
+  def apply[E] = new ValidationProvider[E]
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.4-SNAPSHOT"
+version in ThisBuild := "0.5.4"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.4"
+version in ThisBuild := "0.6.0"


### PR DESCRIPTION
This PR brings support for freestyle-effects for @tagless final encoding.

From now on, `asyncCatsEffect` and `asyncGuava` have been moved to `freestyle.async` (both async integrations are not really tied to `free`.

Releases a new minor version due to the breaking changes in this PR: **0.6.0**.