### PR TITLE
Guava Async refactor

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.1-SNAPSHOT"
+version in ThisBuild := "0.6.1"


### PR DESCRIPTION
This PR replaces `~>` by `ListenableFuture` passed by name (`:=>`).

It releases a new patch release with this improvement.