### PR TITLE
Adds log4s logging to free and tagless

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,8 @@ lazy val config = jvmModule("config")
 lazy val logging = module("logging")
   .dependsOn(core)
   .jvmSettings(
-    libraryDependencies += %%("journal-core")
+    libraryDependencies += %%("journal-core"),
+    libraryDependencies += %%("log4s")
   )
   .jsSettings(
     libraryDependencies += %%%("slogging")

--- a/build.sbt
+++ b/build.sbt
@@ -139,8 +139,10 @@ lazy val config = jvmModule("config")
 lazy val logging = module("logging")
   .dependsOn(core)
   .jvmSettings(
-    libraryDependencies += %%("journal-core"),
-    libraryDependencies += %%("log4s")
+    libraryDependencies ++= Seq(
+      %%("journal-core"),
+      %%("log4s")
+    )
   )
   .jsSettings(
     libraryDependencies += %%%("slogging")

--- a/docs/src/main/tut/docs/patterns/logging/README.md
+++ b/docs/src/main/tut/docs/patterns/logging/README.md
@@ -51,6 +51,8 @@ You could use either both, depending on your requirements, and the usage would b
 To use `log4s`:
 
 ```tut:book
+import freestyle.free._
+import freestyle.free.implicits._
 import freestyle.free.logging._
 import freestyle.free.loggingJVM.log4s.implicits._
 
@@ -62,6 +64,8 @@ import freestyle.free.loggingJVM.log4s.implicits._
 To use `journal`:
 
 ```tut:book
+import freestyle.free._
+import freestyle.free.implicits._
 import freestyle.free.logging._
 import freestyle.free.loggingJVM.journal.implicits._
 

--- a/docs/src/main/tut/docs/patterns/logging/README.md
+++ b/docs/src/main/tut/docs/patterns/logging/README.md
@@ -41,6 +41,34 @@ Each one of the operations corresponds to variations of `debug`, `error`, `info`
 The _frees-logging_ module contains built-in interpreters for both Scala.jvm and Scala.js which you may use out of the box.
 The JVM handler interpreter is based on the [Verizon's Journal Library](https://github.com/Verizon/journal) and the JS handler in [slogging](https://github.com/jokade/slogging).
 
+### Wrappers available
+
+Freestyle logging supports two wrappers for logging the messages, `SLF4J` and `log4s`. These wrappers are available in `free` and `tagless`.
+
+You can use one of them depends on your requirements but whatever you choose, the usage will be the same.
+
+To use `log4s`:
+
+```tut:book
+import freestyle.free.logging._
+import freestyle.free.loggingJVM.log4s.implicits._
+
+@module trait App {
+  val log: LoggingM
+}
+```
+
+To use `SLF4J`:
+
+```tut:book
+import freestyle.free.logging._
+import freestyle.free.loggingJVM.journal.implicits._
+
+@module trait App {
+  val log: LoggingM
+}
+```
+
 ### Example
 
 In the following example, we will show how easy it is to add the logging algebra and use it in a pure program.

--- a/docs/src/main/tut/docs/patterns/logging/README.md
+++ b/docs/src/main/tut/docs/patterns/logging/README.md
@@ -36,7 +36,7 @@ The set of abstract operations of the `Logging` algebra are specified as follows
 }
 ```
 
-Each one of the operations corresponds to variations of `debug`, `error`, `info`, and `warn` which cover most use cases when performing logging in an application.
+Each one of the operations correspond to variations of `debug`, `error`, `info`, and `warn` which cover most use cases when performing logging in an application.
 
 The _frees-logging_ module contains built-in interpreters for both Scala.jvm and Scala.js which you may use out of the box.
 The JVM handler interpreter is based on the [Verizon's Journal Library](https://github.com/Verizon/journal) and [Log4s wrapper](https://github.com/Log4s/log4s).
@@ -46,7 +46,7 @@ In addition, the JS handler interpreter is based on [slogging](https://github.co
 
 Freestyle logging supports two wrappers for logging messages, `journal` and `log4s`. These wrappers are only available for `free` and `tagless` in JVM.
 
-You could use either both, depending on your requirements, and the usage would be quite similar.
+You could use either, or both, depending on your requirements, and the usage would be quite similar.
 
 To use `log4s`:
 
@@ -89,7 +89,7 @@ import cats.implicits._
 import scala.util.Try
 ```
 
-We will define a simple algebra with a stub handler that returns a list of customer Id's for illustration purposes:
+We will define a simple algebra with a stub handler that returns a list of customer Ids for illustration purposes:
 
 ```tut:book
 @free trait CustomerService {

--- a/docs/src/main/tut/docs/patterns/logging/README.md
+++ b/docs/src/main/tut/docs/patterns/logging/README.md
@@ -39,13 +39,14 @@ The set of abstract operations of the `Logging` algebra are specified as follows
 Each one of the operations corresponds to variations of `debug`, `error`, `info`, and `warn` which cover most use cases when performing logging in an application.
 
 The _frees-logging_ module contains built-in interpreters for both Scala.jvm and Scala.js which you may use out of the box.
-The JVM handler interpreter is based on the [Verizon's Journal Library](https://github.com/Verizon/journal) and the JS handler in [slogging](https://github.com/jokade/slogging).
+The JVM handler interpreter is based on the [Verizon's Journal Library](https://github.com/Verizon/journal) and [Log4s wrapper](https://github.com/Log4s/log4s).
+In addition, the JS handler interpreter is based on [slogging](https://github.com/jokade/slogging).
 
 ### Wrappers available
 
-Freestyle logging supports two wrappers for logging the messages, `SLF4J` and `log4s`. These wrappers are available in `free` and `tagless`.
+Freestyle logging supports two wrappers for logging messages, `journal` and `log4s`. These wrappers are only available for `free` and `tagless` in JVM.
 
-You can use one of them depends on your requirements but whatever you choose, the usage will be the same.
+You could use either both, depending on your requirements, and the usage would be quite similar.
 
 To use `log4s`:
 
@@ -58,7 +59,7 @@ import freestyle.free.loggingJVM.log4s.implicits._
 }
 ```
 
-To use `SLF4J`:
+To use `journal`:
 
 ```tut:book
 import freestyle.free.logging._

--- a/modules/logging/jvm/src/main/scala/free/implicits.scala
+++ b/modules/logging/jvm/src/main/scala/free/implicits.scala
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-package freestyle.free
-package loggingJVM
+package freestyle.free.loggingJVM
 
 @deprecated("Use freestyle.free.loggingJVM.journal.implicits or freestyle.free.loggingJVM.log4s.implicits instead", "0.6.2")
 object implicits extends freestyle.tagless.loggingJVM.journal.Implicits

--- a/modules/logging/jvm/src/main/scala/free/implicits.scala
+++ b/modules/logging/jvm/src/main/scala/free/implicits.scala
@@ -17,4 +17,5 @@
 package freestyle.free
 package loggingJVM
 
+@deprecated("Use freestyle.free.loggingJVM.journal.implicits or freestyle.free.loggingJVM.log4s.implicits instead", "0.6.2")
 object implicits extends freestyle.tagless.loggingJVM.journal.Implicits

--- a/modules/logging/jvm/src/main/scala/free/implicits.scala
+++ b/modules/logging/jvm/src/main/scala/free/implicits.scala
@@ -15,9 +15,6 @@
  */
 
 package freestyle.free
+package loggingJVM
 
-object loggingJVM {
-
-  object implicits extends freestyle.tagless.loggingJVM.Implicits
-
-}
+object implicits extends freestyle.tagless.loggingJVM.journal.Implicits

--- a/modules/logging/jvm/src/main/scala/free/journal.scala
+++ b/modules/logging/jvm/src/main/scala/free/journal.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.free
+package loggingJVM
+
+object journal {
+
+  object implicits extends freestyle.tagless.loggingJVM.journal.Implicits
+
+}

--- a/modules/logging/jvm/src/main/scala/free/journal.scala
+++ b/modules/logging/jvm/src/main/scala/free/journal.scala
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-package freestyle.free
-package loggingJVM
-package journal
+package freestyle.free.loggingJVM.journal
 
 object implicits extends freestyle.tagless.loggingJVM.journal.Implicits

--- a/modules/logging/jvm/src/main/scala/free/journal.scala
+++ b/modules/logging/jvm/src/main/scala/free/journal.scala
@@ -16,9 +16,6 @@
 
 package freestyle.free
 package loggingJVM
+package journal
 
-object journal {
-
-  object implicits extends freestyle.tagless.loggingJVM.journal.Implicits
-
-}
+object implicits extends freestyle.tagless.loggingJVM.journal.Implicits

--- a/modules/logging/jvm/src/main/scala/free/log4s.scala
+++ b/modules/logging/jvm/src/main/scala/free/log4s.scala
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-package freestyle.free
-package loggingJVM
-package log4s
+package freestyle.free.loggingJVM.log4s
 
 object implicits extends freestyle.tagless.loggingJVM.log4s.Implicits

--- a/modules/logging/jvm/src/main/scala/free/log4s.scala
+++ b/modules/logging/jvm/src/main/scala/free/log4s.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.free
+package loggingJVM
+
+object log4s {
+
+  object implicits extends freestyle.tagless.loggingJVM.log4s.Implicits
+
+}

--- a/modules/logging/jvm/src/main/scala/free/log4s.scala
+++ b/modules/logging/jvm/src/main/scala/free/log4s.scala
@@ -16,9 +16,6 @@
 
 package freestyle.free
 package loggingJVM
+package log4s
 
-object log4s {
-
-  object implicits extends freestyle.tagless.loggingJVM.log4s.Implicits
-
-}
+object implicits extends freestyle.tagless.loggingJVM.log4s.Implicits

--- a/modules/logging/jvm/src/main/scala/tagless/implicits.scala
+++ b/modules/logging/jvm/src/main/scala/tagless/implicits.scala
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-package freestyle.tagless
-package loggingJVM
+package freestyle.tagless.loggingJVM
 
 @deprecated("Use freestyle.tagless.loggingJVM.journal.implicits or freestyle.tagless.loggingJVM.log4s.implicits instead", "0.6.2")
 object implicits extends freestyle.tagless.loggingJVM.journal.Implicits

--- a/modules/logging/jvm/src/main/scala/tagless/implicits.scala
+++ b/modules/logging/jvm/src/main/scala/tagless/implicits.scala
@@ -17,4 +17,5 @@
 package freestyle.tagless
 package loggingJVM
 
+@deprecated("Use freestyle.tagless.loggingJVM.journal.implicits or freestyle.tagless.loggingJVM.log4s.implicits instead", "0.6.2")
 object implicits extends freestyle.tagless.loggingJVM.journal.Implicits

--- a/modules/logging/jvm/src/main/scala/tagless/implicits.scala
+++ b/modules/logging/jvm/src/main/scala/tagless/implicits.scala
@@ -17,6 +17,4 @@
 package freestyle.tagless
 package loggingJVM
 
-import freestyle.tagless.loggingJVM.journal.Implicits
-
-object implicits extends Implicits
+object implicits extends freestyle.tagless.loggingJVM.journal.Implicits

--- a/modules/logging/jvm/src/main/scala/tagless/implicits.scala
+++ b/modules/logging/jvm/src/main/scala/tagless/implicits.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.tagless
+package loggingJVM
+
+import freestyle.tagless.loggingJVM.journal.Implicits
+
+object implicits extends Implicits

--- a/modules/logging/jvm/src/main/scala/tagless/journal.scala
+++ b/modules/logging/jvm/src/main/scala/tagless/journal.scala
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-package freestyle.tagless
-package loggingJVM
+package freestyle.tagless.loggingJVM
 
 import cats.Applicative
 import freestyle.logging._

--- a/modules/logging/jvm/src/main/scala/tagless/journal.scala
+++ b/modules/logging/jvm/src/main/scala/tagless/journal.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.tagless
+package loggingJVM
+
+import cats.Applicative
+import freestyle.logging._
+import freestyle.tagless.logging._
+import _root_.journal._
+
+object journal {
+
+  sealed abstract class TaglessLoggingMHandler[M[_]] extends LoggingM.Handler[M] {
+
+    import sourcecode.{File, Line}
+
+    protected def withLogger[A](f: Logger => A): M[A]
+
+    def debug(msg: String, srcInfo: Boolean)(implicit line: Line, file: File): M[Unit] =
+      withLogger(_.debug(formatMessage(msg, srcInfo, line, file)))
+
+    def debugWithCause(msg: String, cause: Throwable, srcInfo: Boolean)(
+        implicit
+        line: Line,
+        file: File): M[Unit] =
+      withLogger(_.debug(formatMessage(msg, srcInfo, line, file), cause))
+
+    def error(msg: String, srcInfo: Boolean)(implicit line: Line, file: File): M[Unit] =
+      withLogger(_.error(formatMessage(msg, srcInfo, line, file)))
+
+    def errorWithCause(msg: String, cause: Throwable, srcInfo: Boolean)(
+        implicit
+        line: Line,
+        file: File): M[Unit] =
+      withLogger(_.error(formatMessage(msg, srcInfo, line, file), cause))
+
+    def info(msg: String, srcInfo: Boolean)(implicit line: Line, file: File): M[Unit] =
+      withLogger(_.info(formatMessage(msg, srcInfo, line, file)))
+
+    def infoWithCause(msg: String, cause: Throwable, srcInfo: Boolean)(
+        implicit
+        line: Line,
+        file: File): M[Unit] =
+      withLogger(_.info(formatMessage(msg, srcInfo, line, file), cause))
+
+    def warn(msg: String, srcInfo: Boolean)(implicit line: Line, file: File): M[Unit] =
+      withLogger(_.warn(formatMessage(msg, srcInfo, line, file)))
+
+    def warnWithCause(msg: String, cause: Throwable, srcInfo: Boolean)(
+        implicit
+        line: Line,
+        file: File): M[Unit] =
+      withLogger(_.warn(formatMessage(msg, srcInfo, line, file), cause))
+
+  }
+
+  trait Implicits {
+    implicit def taglessLoggingApplicative[M[_]: Applicative](
+        implicit log: Logger = Logger("")): LoggingM.Handler[M] = new TaglessLoggingMHandler[M] {
+
+      protected def withLogger[A](f: Logger => A): M[A] = Applicative[M].pure(f(log))
+
+    }
+  }
+
+  object implicits extends Implicits
+}

--- a/modules/logging/jvm/src/main/scala/tagless/log4s.scala
+++ b/modules/logging/jvm/src/main/scala/tagless/log4s.scala
@@ -15,13 +15,14 @@
  */
 
 package freestyle.tagless
+package loggingJVM
 
 import cats.Applicative
 import freestyle.logging._
 import freestyle.tagless.logging._
-import journal._
+import org.log4s._
 
-object loggingJVM {
+object log4s {
 
   sealed abstract class TaglessLoggingMHandler[M[_]] extends LoggingM.Handler[M] {
 
@@ -36,7 +37,7 @@ object loggingJVM {
         implicit
         line: Line,
         file: File): M[Unit] =
-      withLogger(_.debug(formatMessage(msg, srcInfo, line, file), cause))
+      withLogger(_.debug(cause)(formatMessage(msg, srcInfo, line, file)))
 
     def error(msg: String, srcInfo: Boolean)(implicit line: Line, file: File): M[Unit] =
       withLogger(_.error(formatMessage(msg, srcInfo, line, file)))
@@ -45,7 +46,7 @@ object loggingJVM {
         implicit
         line: Line,
         file: File): M[Unit] =
-      withLogger(_.error(formatMessage(msg, srcInfo, line, file), cause))
+      withLogger(_.error(cause)(formatMessage(msg, srcInfo, line, file)))
 
     def info(msg: String, srcInfo: Boolean)(implicit line: Line, file: File): M[Unit] =
       withLogger(_.info(formatMessage(msg, srcInfo, line, file)))
@@ -54,7 +55,7 @@ object loggingJVM {
         implicit
         line: Line,
         file: File): M[Unit] =
-      withLogger(_.info(formatMessage(msg, srcInfo, line, file), cause))
+      withLogger(_.info(cause)(formatMessage(msg, srcInfo, line, file)))
 
     def warn(msg: String, srcInfo: Boolean)(implicit line: Line, file: File): M[Unit] =
       withLogger(_.warn(formatMessage(msg, srcInfo, line, file)))
@@ -63,13 +64,13 @@ object loggingJVM {
         implicit
         line: Line,
         file: File): M[Unit] =
-      withLogger(_.warn(formatMessage(msg, srcInfo, line, file), cause))
+      withLogger(_.warn(cause)(formatMessage(msg, srcInfo, line, file)))
 
   }
 
   trait Implicits {
     implicit def taglessLoggingApplicative[M[_]: Applicative](
-        implicit log: Logger = Logger("")): LoggingM.Handler[M] = new TaglessLoggingMHandler[M] {
+        implicit log: Logger = getLogger("")): LoggingM.Handler[M] = new TaglessLoggingMHandler[M] {
 
       protected def withLogger[A](f: Logger => A): M[A] = Applicative[M].pure(f(log))
 

--- a/modules/logging/jvm/src/main/scala/tagless/log4s.scala
+++ b/modules/logging/jvm/src/main/scala/tagless/log4s.scala
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-package freestyle.tagless
-package loggingJVM
+package freestyle.tagless.loggingJVM
 
 import cats.Applicative
 import freestyle.logging._

--- a/modules/logging/jvm/src/test/scala/free/LoggingTestsJournal.scala
+++ b/modules/logging/jvm/src/test/scala/free/LoggingTestsJournal.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.free
+
+import cats.instances.future._
+import cats.{Id, Monad}
+import freestyle.free.implicits._
+import freestyle.free.loggingJVM.implicits._
+import org.scalatest.{AsyncWordSpec, Matchers}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NoStackTrace
+
+class LoggingTestsJournal extends AsyncWordSpec with Matchers {
+
+  implicit override def executionContext = ExecutionContext.Implicits.global
+
+  import algebras._
+
+  "Logging Freestyle free integration journal" should {
+
+    case object Cause extends Exception("kaboom") with NoStackTrace
+
+    "allow a log message to be interleaved inside a program monadic flow" in {
+      val program = for {
+        a <- app.nonLogging.x
+        _ <- app.loggingM.debug("Debug Message", sourceAndLineInfo = true)
+        _ <- app.loggingM.debugWithCause("Debug Message", Cause)
+        _ <- app.loggingM.error("Error Message")
+        _ <- app.loggingM.errorWithCause("Error Message", Cause)
+        _ <- app.loggingM.info("Info Message")
+        _ <- app.loggingM.infoWithCause("Info Message", Cause)
+        _ <- app.loggingM.warn("Warning Message")
+        _ <- app.loggingM.warnWithCause("Warning Message", Cause)
+        b <- FreeS.pure(1)
+      } yield a + b
+      program.interpret[Future] map { _ shouldBe 2 }
+    }
+
+    "not depend on MonadError, thus allowing use of Monads without MonadError, like Id, for test algebras" in {
+      val program = for {
+        a <- app.nonLogging.x
+        _ <- app.loggingM.info("Info Message")
+        _ <- app.loggingM.infoWithCause("Info Message", Cause)
+        b <- FreeS.pure(1)
+      } yield a + b
+      program.interpret[TestAlgebra].run("configHere") shouldBe 2
+    }
+
+    "allow injecting a Logger instance" in {
+      val program = for {
+        a <- FreeS.pure(1)
+        _ <- app.loggingM.info("Info Message")
+        _ <- app.loggingM.error("Error Message")
+        b <- FreeS.pure(1)
+      } yield a + b
+
+      implicit val logger = journal.Logger("Potatoes")
+
+      program
+        .interpret[TestAlgebra]
+        .run("configHere") shouldEqual 2
+    }
+  }
+}

--- a/modules/logging/jvm/src/test/scala/free/LoggingTestsLog4s.scala
+++ b/modules/logging/jvm/src/test/scala/free/LoggingTestsLog4s.scala
@@ -25,13 +25,13 @@ import org.scalatest.{AsyncWordSpec, Matchers}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NoStackTrace
 
-class LoggingTests extends AsyncWordSpec with Matchers {
+class LoggingTestsLog4s extends AsyncWordSpec with Matchers {
 
   implicit override def executionContext = ExecutionContext.Implicits.global
 
   import algebras._
 
-  "Logging Freestyle free integration" should {
+  "Logging Freestyle free integration log4s" should {
 
     case object Cause extends Exception("kaboom") with NoStackTrace
 

--- a/modules/logging/jvm/src/test/scala/tagless/LoggingTestsJournal.scala
+++ b/modules/logging/jvm/src/test/scala/tagless/LoggingTestsJournal.scala
@@ -37,7 +37,7 @@ class LoggingTestsJournal extends AsyncWordSpec with Matchers {
   "Logging Freestyle tagless integration journal" should {
 
     import cats.instances.future._
-    import freestyle.tagless.loggingJVM.loggingJVMJournal.implicits._
+    import freestyle.tagless.loggingJVM.journal.implicits._
 
     "allow a log message to be interleaved inside a program monadic flow" in {
 

--- a/modules/logging/jvm/src/test/scala/tagless/LoggingTestsJournal.scala
+++ b/modules/logging/jvm/src/test/scala/tagless/LoggingTestsJournal.scala
@@ -28,16 +28,16 @@ import org.scalatest.{AsyncWordSpec, Matchers}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NoStackTrace
 
-class LoggingTests extends AsyncWordSpec with Matchers {
+class LoggingTestsJournal extends AsyncWordSpec with Matchers {
 
   implicit override def executionContext = ExecutionContext.Implicits.global
 
   case object Cause extends Exception("kaboom") with NoStackTrace
 
-  "Logging Freestyle tagless integration" should {
+  "Logging Freestyle tagless integration journal" should {
 
     import cats.instances.future._
-    import freestyle.tagless.loggingJVM.implicits._
+    import freestyle.tagless.loggingJVM.loggingJVMJournal.implicits._
 
     "allow a log message to be interleaved inside a program monadic flow" in {
 

--- a/modules/logging/jvm/src/test/scala/tagless/LoggingTestsLog4s.scala
+++ b/modules/logging/jvm/src/test/scala/tagless/LoggingTestsLog4s.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.tagless
+
+import cats._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import freestyle.tagless._
+import freestyle.tagless.algebras._
+import freestyle.tagless.logging.LoggingM
+import journal.Logger
+import org.scalatest.{AsyncWordSpec, Matchers}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NoStackTrace
+
+class LoggingTestsLog4s extends AsyncWordSpec with Matchers {
+
+  implicit override def executionContext = ExecutionContext.Implicits.global
+
+  case object Cause extends Exception("kaboom") with NoStackTrace
+
+  "Logging Freestyle tagless integration log4s" should {
+
+    import cats.instances.future._
+    import freestyle.tagless.loggingJVM.loggingJVMLog4s.implicits._
+
+    "allow a log message to be interleaved inside a program monadic flow" in {
+
+      def program[F[_]: Monad](implicit app: App[F]) =
+        for {
+          a <- app.nonLogging.x
+          _ <- app.loggingM.debug("Debug Message", sourceAndLineInfo = true)
+          _ <- app.loggingM.debugWithCause("Debug Message", Cause)
+          _ <- app.loggingM.error("Error Message")
+          _ <- app.loggingM.errorWithCause("Error Message", Cause)
+          _ <- app.loggingM.info("Info Message")
+          _ <- app.loggingM.infoWithCause("Info Message", Cause)
+          _ <- app.loggingM.warn("Warning Message")
+          _ <- app.loggingM.warnWithCause("Warning Message", Cause)
+          b <- Monad[F].pure(1)
+        } yield a + b
+
+      program[Future] map { _ shouldBe 2 }
+
+    }
+
+    "allow injecting a Logger instance" in {
+      def program[F[_]: Monad](implicit app: App[F]) =
+        for {
+          a <- Monad[F].pure(1)
+          _ <- app.loggingM.info("Info Message")
+          _ <- app.loggingM.error("Error Message")
+          b <- Monad[F].pure(1)
+        } yield a + b
+
+      implicit val logger: Logger = journal.Logger("Potatoes")
+
+      program[Future] map { _ shouldBe 2 }
+    }
+  }
+}

--- a/modules/logging/jvm/src/test/scala/tagless/LoggingTestsLog4s.scala
+++ b/modules/logging/jvm/src/test/scala/tagless/LoggingTestsLog4s.scala
@@ -37,7 +37,7 @@ class LoggingTestsLog4s extends AsyncWordSpec with Matchers {
   "Logging Freestyle tagless integration log4s" should {
 
     import cats.instances.future._
-    import freestyle.tagless.loggingJVM.loggingJVMLog4s.implicits._
+    import freestyle.tagless.loggingJVM.log4s.implicits._
 
     "allow a log message to be interleaved inside a program monadic flow" in {
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.2-SNAPSHOT"
+version in ThisBuild := "0.6.2"


### PR DESCRIPTION
This PR adds a new way to log the messages through `log4s`.

I added this logger to `free` and `tagless`. 

This change doesn't have a breaking change because the default implicit `freestyle.free.loggingJVM.implicits` point to `journal` directly.

This PR is in WIP because I want a first code review and if it adapts to your thoughts, I will update the documentation with these changes.