### PR TITLE
Remove Tagless doc. link from menu

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -19,9 +19,6 @@ options:
      - title: Parallelism
        url: docs/core/parallelism/
 
-     - title: Tagless Final
-       url: docs/core/tagless/
-
   - title: Effects
     url: docs/effects/
 


### PR DESCRIPTION
* Remove the link to Tagless from the docs sidebar menu, as the information related to it, it is now integrated in other sections, per this PR: https://github.com/frees-io/freestyle/pull/488