### PR TITLE
AsyncContext implicit now requires Async instead of Effect

### DIFF
--- a/modules/async/async-cats-effect/shared/src/main/scala/AsyncCatsEffect.scala
+++ b/modules/async/async-cats-effect/shared/src/main/scala/AsyncCatsEffect.scala
@@ -17,10 +17,10 @@
 package freestyle.async
 package catsEffect
 
-import cats.effect.Effect
+import cats.effect.Async
 
 trait AsyncCatsEffectImplicits {
-  implicit def catsEffectAsyncContext[F[_]](implicit F: Effect[F]): AsyncContext[F] =
+  implicit def catsEffectAsyncContext[F[_]](implicit F: Async[F]): AsyncContext[F] =
     new AsyncContext[F] {
       def runAsync[A](fa: Proc[A]): F[A] = F.async(fa)
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.3-SNAPSHOT"
+version in ThisBuild := "0.6.3"


### PR DESCRIPTION
Lessen the constraint from `Effect` to `Async` for the `AsyncContext` implicit