### PR TITLE
FS-517 Isues with StackSafe Expansion

### DIFF
--- a/docs/src/main/tut/docs/core/algebras/README.md
+++ b/docs/src/main/tut/docs/core/algebras/README.md
@@ -201,12 +201,12 @@ Freestyle allows us to compose `@free` and `@tagless` algebras. Let us consider 
 ```tut:book
 import freestyle.tagless._
 
-@tagless trait Validation {
+@tagless @stacksafe trait Validation {
   def minSize(s: String, n: Int): FS[Boolean]
   def hasNumber(s: String): FS[Boolean]
 }
 
-@tagless trait Interaction {
+@tagless @stacksafe trait Interaction {
   def tell(msg: String): FS[Unit]
   def ask(prompt: String): FS[String]
 }

--- a/docs/src/main/tut/docs/core/handlers/README.md
+++ b/docs/src/main/tut/docs/core/handlers/README.md
@@ -154,12 +154,12 @@ Tagless final algebras are declared using the `@tagless` macro annotation.
 
 ```tut:book
 
-@tagless trait Validation {
+@tagless @stacksafe trait Validation {
   def minSize(s: String, n: Int): FS[Boolean]
   def hasNumber(s: String): FS[Boolean]
 }
 
-@tagless trait Interaction {
+@tagless @stacksafe trait Interaction {
   def tell(msg: String): FS[Unit]
   def ask(prompt: String): FS[String]
 }

--- a/docs/src/main/tut/docs/core/modules/README.md
+++ b/docs/src/main/tut/docs/core/modules/README.md
@@ -21,10 +21,10 @@ import freestyle.tagless._
 ```tut:book
 
 object algebras {
-    @tagless trait Database {
+    @tagless @stacksafe trait Database {
       def get(id: Int): FS[Int]
     }
-    @tagless trait Cache {
+    @tagless @stacksafe trait Cache {
       def get(id: Int): FS[Option[Int]]
     }
     @free trait Presenter {

--- a/modules/async/async/shared/src/main/scala/tagless/async.scala
+++ b/modules/async/async/shared/src/main/scala/tagless/async.scala
@@ -23,7 +23,7 @@ import freestyle.async._
 object async {
 
   /** Async computation algebra. **/
-  @tagless trait AsyncM {
+  @tagless @stacksafe trait AsyncM {
     def async[A](fa: Proc[A]): FS[A]
   }
 

--- a/modules/config/src/main/scala/tagless/config.scala
+++ b/modules/config/src/main/scala/tagless/config.scala
@@ -23,7 +23,7 @@ import freestyle.config._
 
 object config {
 
-  @tagless sealed trait ConfigM {
+  @tagless @stacksafe sealed trait ConfigM {
     def load: FS[Config]
     def empty: FS[Config]
     def parseString(s: String): FS[Config]

--- a/modules/config/src/test/scala/tagless/ConfigTests.scala
+++ b/modules/config/src/test/scala/tagless/ConfigTests.scala
@@ -126,7 +126,7 @@ class ConfigTests extends WordSpec with Matchers {
 }
 
 object algebras {
-  @tagless
+  @tagless @stacksafe
   trait NonConfig {
     def x: FS[Int]
   }

--- a/modules/core/shared/src/main/scala/freestyle/free/internal/ScalametaUtil.scala
+++ b/modules/core/shared/src/main/scala/freestyle/free/internal/ScalametaUtil.scala
@@ -59,6 +59,20 @@ object ScalametaUtil {
       stats: Seq[Stat]) =
     Object(mods, name, Template(early, parents, self, if (stats.isEmpty) Some(stats) else None))
 
+  implicit class ModsOps(val mods: Seq[Mod]) extends AnyVal {
+
+    def hasMod(mod: Mod): Boolean = mods.exists {
+      case `mod` => true
+      case _ => false
+    }
+
+    def removeMod(mod: Mod): Seq[Mod] = mods.filter {
+      case `mod` => false
+      case _ => true
+    }
+
+  }
+
   implicit class TypeNameOps(val typeName: Type.Name) extends AnyVal {
 
     // take Y, replace Y name with tyn

--- a/modules/core/shared/src/main/scala/freestyle/free/internal/syntax.scala
+++ b/modules/core/shared/src/main/scala/freestyle/free/internal/syntax.scala
@@ -38,10 +38,15 @@ object syntax {
   }
 
   final class ModOps(mods: Seq[Mod]) {
-
     def filtered: Seq[Mod] = mods.filter {
       case mod"@debug" => false
+      case mod"@stacksafe" => false
       case _           => true
+    }
+
+    def isStackSafe: Boolean = mods.exists {
+      case mod"@stacksafe" => true
+      case _ => false
     }
   }
 

--- a/modules/core/shared/src/main/scala/freestyle/tagless/internal/tagless.scala
+++ b/modules/core/shared/src/main/scala/freestyle/tagless/internal/tagless.scala
@@ -34,10 +34,12 @@ object taglessImpl {
 
   def tagless(defn: Any): Stat = defn match {
     case cls: Trait =>
-      freeAlg(Algebra(cls.mods.filtered, cls.name, cls.tparams, cls.ctor, cls.templ), isTrait = true)
+      val isStackSafe = cls.mods.isStackSafe
+      freeAlg(Algebra(cls.mods.filtered, cls.name, cls.tparams, cls.ctor, cls.templ, isStackSafe), isTrait = true)
         .`debug?`(cls.mods)
     case cls: Class if isAbstract(cls) =>
-      freeAlg(Algebra(cls.mods.filtered, cls.name, cls.tparams, cls.ctor, cls.templ), isTrait = false)
+      val isStackSafe = cls.mods.isStackSafe
+      freeAlg(Algebra(cls.mods.filtered, cls.name, cls.tparams, cls.ctor, cls.templ, isStackSafe), isTrait = false)
         .`debug?`(cls.mods)
 
     case c: Class /* ! isAbstract */   => abort(s"$invalid in ${c.name}. $abstractOnly")
@@ -60,7 +62,8 @@ case class Algebra(
     name: Type.Name,
     tparams: Seq[Type.Param],
     ctor: Ctor.Primary,
-    templ: Template
+    templ: Template,
+    isStackSafe: Boolean
 ) {
   import Util._
 
@@ -106,7 +109,7 @@ case class Algebra(
       parents = pat.templ.parents,
       self = self.param,
       stats = templ.stats.map( _ :+ mapKDef(self))
-    ))
+    ), isStackSafe )
   }
 
   def mapKDef(sf: Term.Name): Defn.Def = {
@@ -129,13 +132,21 @@ case class Algebra(
     val runTParams: Seq[Type.Param] = tyParamK(mm) +: cleanedTParams
     val runTArgs: Seq[Type]         = mm +: cleanedTParams.map(toType)
 
-    val handlerT: Trait = q"""
-      trait Handler[..$allTParams] extends ${name.ctor}[..$allTNames] with StackSafe.Handler[..$allTNames] {
-        ..${requestDecls.map(_.addMod(Mod.Override()))}
-      }
-    """
+    val handlerT: Trait =
+      if (isStackSafe)
+        q"""
+          trait Handler[..$allTParams] extends ${name.ctor}[..$allTNames] with StackSafe.Handler[..$allTNames] {
+            ..${requestDecls.map(_.addMod(Mod.Override()))}
+          }
+        """
+      else
+        q"""
+          trait Handler[..$allTParams] extends ${name.ctor}[..$allTNames] {
+            ..${requestDecls.map(_.addMod(Mod.Override()))}
+          }
+        """
 
-    val stackSafeAlg: FreeAlgebra = {
+    lazy val stackSafeAlg: FreeAlgebra = {
       def withFS( req: Decl.Def): Decl.Def =
         req.copy(decltpe = req.decltpe match {
           case Type.Apply(_, targs) => Type.Apply( Type.Name("FS"), targs)
@@ -145,8 +156,8 @@ case class Algebra(
       val t: Trait = q" trait StackSafe { ..${requestDecls.map(withFS)} } "
       FreeAlgebra(Seq.empty[Mod], Type.Name("StackSafe"), allTParams, t.ctor, t.templ)
     }
-    val stackSafeT: Trait = stackSafeAlg.enrich.toTrait
-    val stackSafeD: Object = stackSafeAlg.mkCompanion
+    lazy val stackSafeT: Trait = stackSafeAlg.enrich.toTrait
+    lazy val stackSafeD: Object = stackSafeAlg.mkCompanion
 
     val deriveDef: Defn.Def = {
       val deriveTTs = tyParamK(mm) +: tyParamK(nn) +: cleanedTParams
@@ -183,7 +194,11 @@ case class Algebra(
     prot.copy(
       name = Term.Name(name.value),
       templ = prot.templ.copy(
-        stats = Some(Seq(applyDef, functorKDef, deriveDef, stackSafeT, stackSafeD, handlerT))
+        stats = Some(
+          if (isStackSafe)
+            Seq(applyDef, functorKDef, deriveDef, stackSafeT, stackSafeD, handlerT)
+          else Seq(applyDef, functorKDef, deriveDef, handlerT)
+        )
       ))
   }
 

--- a/modules/core/shared/src/test/scala/freestyle/free/Utils.scala
+++ b/modules/core/shared/src/test/scala/freestyle/free/Utils.scala
@@ -17,8 +17,8 @@
 package freestyle
 package free
 
-@debug
 @free
+@debug
 trait SCtors1 {
   def x(a: Int): FS[Int]
   def y(a: Int): FS[Int]

--- a/modules/core/shared/src/test/scala/freestyle/tagless/TaglessModuleTests.scala
+++ b/modules/core/shared/src/test/scala/freestyle/tagless/TaglessModuleTests.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.tagless
+
+import org.scalatest.{Matchers, WordSpec}
+
+import freestyle.free._
+
+import cats.{~>, Id, Functor, Applicative, Monad, Monoid, Eq}
+import cats.arrow.FunctionK
+import cats.free.Free
+import cats.instances.either._
+import cats.instances.option._
+import cats.kernel.instances.int._
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import algebras._
+import handlers._
+import modules._
+
+class TaglessModuleTests extends WordSpec with Matchers {
+
+  "Tagless final algebras" should {
+
+    "Allow a trait with an F[_] bound type param" in {
+      @tagless @stacksafe trait X[F[_]] {
+        def bar(x:Int): FS[Int]
+      }
+      0 shouldEqual 0
+    }
+
+    "combine with other tagless algebras" in {
+
+      def program[F[_] : Monad : TG1 : TG2: TG3] = {
+        val a1 = TG1[F]
+        val a2 = TG2[F]
+        val a3 = TG3[F]
+        for {
+          a <- a1.x(1)
+          b <- a1.y(1)
+          c <- a2.x2(1)
+          d <- a2.y2(1)
+          e <- a3.y3(1)
+        } yield a + b + c + d + e
+      }
+      program[Option] shouldBe Option(5)
+    }
+
+    "combine with FreeS monadic comprehensions" in {
+      import freestyle.free._
+      import freestyle.free.implicits._
+
+      def program[F[_] : F1: TG1.StackSafe : TG2.StackSafe]: FreeS[F, Int] = {
+        val tg1 = TG1.StackSafe[F]
+        val tg2 = TG2.StackSafe[F]
+        val fs = F1[F]
+        val x : FreeS[F, Int] = for {
+          a <- fs.a(1)
+          tg2a <- tg2.x2(1)
+          b <- fs.b(1)
+          x <- tg1.x(1)
+          tg2b <- tg2.y2(1)
+          y <- tg1.y(1)
+        } yield a + b + x + y + tg2a + tg2b
+        x
+      }
+      import TG1._
+      program[App.Op].interpret[Option] shouldBe Option(6)
+    }
+
+    "work with derived handlers" in {
+
+      def program[F[_]: TG1: Monad] =
+        for {
+          x <- TG1[F].x(1)
+          y <- TG1[F].y(2)
+        } yield x + y
+
+      type ErrorOr[A] = Either[String, A]
+
+      implicit val fk: Option ~> ErrorOr =
+        λ[Option ~> ErrorOr](_.toRight("error"))
+
+      program[ErrorOr] shouldBe Right(3)
+    }
+
+    "allow for tagless modules" in {
+
+      def program[F[_]: AppTagless: Monad] =
+        for {
+          x <- AppTagless[F].tg1.x(1)
+          y <- AppTagless[F].tg2.x2(2)
+        } yield x + y
+
+      program[Option] shouldBe Some(3)
+    }
+
+  }
+
+}
+
+object modules {
+
+  import algebras._
+
+  @_root_.freestyle.free.module trait App {
+    val f1: F1
+    val tg1: TG1.StackSafe
+    val tg2: TG2.StackSafe
+  }
+
+  @_root_.freestyle.tagless.module trait AppTagless {
+    val tg1: TG1
+    val tg2: TG2
+  }
+
+}
+

--- a/modules/core/shared/src/test/scala/freestyle/tagless/TaglessTests.scala
+++ b/modules/core/shared/src/test/scala/freestyle/tagless/TaglessTests.scala
@@ -39,32 +39,32 @@ class TaglessTests extends WordSpec with Matchers {
   "the @tagless macro annotation should be accepted if it is applied to" when {
 
     "a trait with at least one request" in {
-      "@tagless trait X { def bar(x:Int): FS[Int] }" should compile
+      "@tagless @stacksafe trait X { def bar(x:Int): FS[Int] }" should compile
     }
 
     "a trait with a kind-1 type param" when {
       "typing the request with reserved FS" in {
-        "@tagless trait FBound[F[_]] { def ann(x:Int): FS[Int] }" should compile
+        "@tagless @stacksafe trait FBound[F[_]] { def ann(x:Int): FS[Int] }" should compile
       }
       "typing the request with the user-provided F-Bound type param" in {
-        "@tagless trait FBound[F[_]] { def bob(y:Int): F[Int] }" should compile
+        "@tagless @stacksafe trait FBound[F[_]] { def bob(y:Int): F[Int] }" should compile
       }
     }
 
     "an abstract class with at least one request" in {
-      "@tagless abstract class X { def bar(x:Int): FS[Int] }" should compile
+      "@tagless @stacksafe abstract class X { def bar(x:Int): FS[Int] }" should compile
     }
 
     "a trait with an abstact method of type FS" in {
-      "@tagless trait X { def f(a: Char) : FS[Int] }" should compile
+      "@tagless @stacksafe trait X { def f(a: Char) : FS[Int] }" should compile
     }
 
     "a trait with type parameters" ignore {
-      "@tagless trait X[A] { def ix(a: A) : FS[A] }" should compile
+      "@tagless @stacksafe trait X[A] { def ix(a: A) : FS[A] }" should compile
     }
 
     "a trait with some concrete non-FS members" ignore {
-      """@tagless trait X {
+      """@tagless @stacksafe trait X {
         def x: FS[Int]
         def y: Int = 5
         val z: Int = 6
@@ -72,41 +72,41 @@ class TaglessTests extends WordSpec with Matchers {
     }
 
     "a trait with a method with type parameters" in {
-      "@tagless trait WiX { def ix[A](a: A) : FS[A] }" should compile
+      "@tagless @stacksafe trait WiX { def ix[A](a: A) : FS[A] }" should compile
     }
 
     "a trait with high bounded type parameters in the method" in {
-      "@tagless trait X { def ix[A <: Int](a: A) : FS[A] }" should compile
+      "@tagless @stacksafe trait X { def ix[A <: Int](a: A) : FS[A] }" should compile
     }
 
     "a trait with lower bounded type parameters in the method" in {
-      "@tagless trait X { def ix[A >: Int](a: A) : FS[A] }" should compile
+      "@tagless @stacksafe trait X { def ix[A >: Int](a: A) : FS[A] }" should compile
     }
 
     "a trait with different type parameters in the method" in {
-      "@tagless trait X { def ix[A <: Int, B, C >: Int](a: A, b: B, c: C) : FS[A] }" should compile
+      "@tagless @stacksafe trait X { def ix[A <: Int, B, C >: Int](a: A, b: B, c: C) : FS[A] }" should compile
     }
 
     "a trait with high bounded type parameters and implicits in the method" in {
       """
         trait X[A]
-        @tagless trait Y { def ix[A <: Int : X](a: A) : FS[A] }
+        @tagless @stacksafe trait Y { def ix[A <: Int : X](a: A) : FS[A] }
       """ should compile
     }
 
   }
 
-  "the @tagless macro should preserve the shape of the parameters of the request" when {
+  "the @tagless @stacksafe macro should preserve the shape of the parameters of the request" when {
 
     "there are no parameters" in {
-      @tagless trait X { def f: FS[Int] }
+      @tagless @stacksafe trait X { def f: FS[Int] }
       object Y extends X.Handler[Id] { def f: Int = 42 }
 
       Y.f shouldEqual 42
     }
 
     "there is one list with multiple params" in {
-      @tagless trait X {
+      @tagless @stacksafe trait X {
         def f(a: Int, b: Int): FS[Int]
       }
       object Y extends X.Handler[Id] {
@@ -116,7 +116,7 @@ class TaglessTests extends WordSpec with Matchers {
     }
 
     "there are multiple lists of parameters" ignore {
-      @tagless trait X {
+      @tagless @stacksafe trait X {
         def f(a: Int)(b: Int): FS[Int]
       }
       object Y extends X.Handler[Id] {
@@ -126,7 +126,7 @@ class TaglessTests extends WordSpec with Matchers {
     }
 
     "there are multiple lists of parameters, with the last being implicit" ignore {
-      @tagless trait X {
+      @tagless @stacksafe trait X {
         def f(a: Int)(implicit b: Int): FS[Int]
       }
       object Y extends X.Handler[Id] {
@@ -137,7 +137,7 @@ class TaglessTests extends WordSpec with Matchers {
     }
 
     "there is one type parameter with a type-class bound, and one parameter" ignore {
-      @tagless trait X {
+      @tagless @stacksafe trait X {
         def f[T: Monoid](a: T): FS[T]
         def g[S: Eq](a: S, b: S): FS[Boolean]
       }
@@ -151,7 +151,7 @@ class TaglessTests extends WordSpec with Matchers {
 
   }
 
-  "the @tagless macro annotation should be rejected, and the compilation fail, if it is applied to" when {
+  "the @tagless @stacksafe macro annotation should be rejected, and the compilation fail, if it is applied to" when {
 
     "an empty trait" in (
       "@tagless trait X" shouldNot compile
@@ -181,7 +181,7 @@ class TaglessTests extends WordSpec with Matchers {
 
   "A @tagles trait can define derive methods by combining other basic methods" when {
     "they use a Functor[FS] instance to provide a map operation" in {
-      @tagless trait X {
+      @tagless @stacksafe trait X {
         def a: FS[Int]
         def b(implicit f: Functor[FS]): FS[Int] = a.map(x => x+1)
       }
@@ -192,7 +192,7 @@ class TaglessTests extends WordSpec with Matchers {
     }
 
     "using the Applicative instance of FS to combine operations" in {
-      @tagless trait X {
+      @tagless @stacksafe trait X {
         def a: FS[Int]
         def b(implicit A: Applicative[FS]): FS[Int] = (a, A.pure(1)).mapN(_+_)
       }
@@ -203,7 +203,7 @@ class TaglessTests extends WordSpec with Matchers {
     }
 
     "using the Monad instance of FS to combine operations" in {
-      @tagless trait X {
+      @tagless @stacksafe trait X {
         def a: FS[Int]
         def b(x: Int): FS[Int]
         def c(implicit M: Monad[FS]): FS[Int] = for {
@@ -220,7 +220,7 @@ class TaglessTests extends WordSpec with Matchers {
     }
 
     "mixing all of the above" in {
-      @tagless trait X {
+      @tagless @stacksafe trait X {
         def a: FS[Int]
         def b(i: Int)(implicit F: Functor[FS]): FS[Int] = a.map(x => x+i)
         def c(implicit A: Applicative[FS]): FS[Int] = (a,A.pure(3)).mapN(_+_)
@@ -241,7 +241,7 @@ class TaglessTests extends WordSpec with Matchers {
   "Tagless final algebras" should {
 
     "Allow a trait with an F[_] bound type param" in {
-      "@tagless trait X[F[_]] { def bar(x:Int): FS[Int] }" should compile
+      "@tagless @stacksafe trait X[F[_]] { def bar(x:Int): FS[Int] }" should compile
     }
 
     "combine with other tagless algebras" in {
@@ -316,21 +316,21 @@ class TaglessTests extends WordSpec with Matchers {
 
 object algebras {
 
-  @tagless
+  @tagless @stacksafe
   trait TG1 {
     def x(a: Int): FS[Int]
 
     def y(a: Int): FS[Int]
   }
 
-  @tagless
+  @tagless @stacksafe
   trait TG2 {
     def x2(a: Int): FS[Int]
 
     def y2(a: Int): FS[Int]
   }
 
-  @tagless
+  @tagless @stacksafe
   trait TG3[F[_]] {
     def x3(a: Int): FS[Int]
 

--- a/modules/core/shared/src/test/scala/freestyle/tagless/Utils.scala
+++ b/modules/core/shared/src/test/scala/freestyle/tagless/Utils.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.tagless
+
+import org.scalatest.{Matchers, WordSpec}
+
+import freestyle.free._
+
+import cats.{~>, Functor, Monad}
+import cats.arrow.FunctionK
+import cats.instances.either._
+import cats.instances.option._
+import cats.kernel.instances.int._
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+object algebras {
+
+  @tagless @stacksafe
+  trait TG1 {
+    def x(a: Int): FS[Int]
+
+    def y(a: Int): FS[Int]
+  }
+
+  @tagless @stacksafe
+  trait TG2 {
+    def x2(a: Int): FS[Int]
+
+    def y2(a: Int): FS[Int]
+  }
+
+  @tagless @stacksafe
+  trait TG3[F[_]] {
+    def x3(a: Int): FS[Int]
+
+    def y3(a: Int): FS[Int]
+  }
+
+  @free
+  trait F1 {
+    def a(a: Int): FS[Int]
+
+    def b(a: Int): FS[Int]
+  }
+
+}
+
+object handlers  {
+
+  import algebras._
+
+  implicit val optionHandler1: TG1.Handler[Option] = new TG1.Handler[Option] {
+    def x(a: Int): Option[Int] = Some(a)
+    def y(a: Int): Option[Int] = Some(a)
+  }
+
+  implicit val optionHandler2: TG2.Handler[Option] = new TG2.Handler[Option] {
+    def x2(a: Int): Option[Int] = Some(a)
+    def y2(a: Int): Option[Int] = Some(a)
+  }
+
+  implicit val optionHandler3: TG3.Handler[Option] = new TG3.Handler[Option] {
+    def x3(a: Int): Option[Int] = Some(a)
+    def y3(a: Int): Option[Int] = Some(a)
+  }
+
+  implicit val f1OptionHandler1: F1.Handler[Option] = new F1.Handler[Option] {
+    def a(a: Int): Option[Int] = Some(a)
+    def b(a: Int): Option[Int] = Some(a)
+  }
+
+  implicit def mIdentity[F[_]]: F ~> F = FunctionK.id[F]
+
+}
+
+object utils {
+
+  import algebras._
+
+  val iterations = 50000
+
+  def SOProgram[F[_] : Monad : TG1](i: Int): F[Int] = for {
+    j <- TG1[F].x(i + 1)
+    z <- if (j < iterations) SOProgram[F](j) else Monad[F].pure(j)
+  } yield z
+
+}

--- a/modules/effects/shared/src/main/scala/tagless/effects/either.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/either.scala
@@ -25,7 +25,7 @@ object either {
 
   final class ErrorProvider[E] {
 
-    @tagless sealed trait EitherM {
+    @tagless @stacksafe sealed trait EitherM {
       def either[A](fa: Either[E, A]): FS[A]
       def error[A](e: E): FS[A]
       def catchNonFatal[A](a: Eval[A], f: Throwable => E): FS[A]

--- a/modules/effects/shared/src/main/scala/tagless/effects/error.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/error.scala
@@ -21,7 +21,7 @@ import cats.{Eval, MonadError}
 
 object error {
 
-  @tagless sealed trait ErrorM {
+  @tagless @stacksafe sealed trait ErrorM {
     def either[A](fa: Either[Throwable, A]): FS[A]
     def error[A](e: Throwable): FS[A]
     def catchNonFatal[A](a: Eval[A]): FS[A]

--- a/modules/effects/shared/src/main/scala/tagless/effects/option.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/option.scala
@@ -22,7 +22,7 @@ import cats.mtl.FunctorEmpty
 
 object option {
 
-  @tagless sealed trait OptionM {
+  @tagless @stacksafe sealed trait OptionM {
     def option[A](fa: Option[A]): FS[A]
     def none[A]: FS[A]
   }

--- a/modules/effects/shared/src/main/scala/tagless/effects/reader.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/reader.scala
@@ -23,7 +23,7 @@ object reader {
 
   final class EnvironmentProvider[R] {
 
-    @tagless abstract class ReaderM {
+    @tagless @stacksafe abstract class ReaderM {
       def ask: FS[R]
       def reader[B](f: R => B): FS[B]
     }

--- a/modules/effects/shared/src/main/scala/tagless/effects/state.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/state.scala
@@ -23,7 +23,7 @@ object state {
 
   final class StateSeedProvider[S] {
 
-    @tagless sealed abstract class StateM {
+    @tagless @stacksafe sealed abstract class StateM {
       def get: FS[S]
       def set(s: S): FS[Unit]
       def modify(f: S => S): FS[Unit]

--- a/modules/effects/shared/src/main/scala/tagless/effects/traverse.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/traverse.scala
@@ -25,7 +25,7 @@ object traverse {
 
     /** Acts as a generator providing traversable semantics to programs
      */
-    @tagless sealed abstract class TraverseM {
+    @tagless @stacksafe sealed abstract class TraverseM {
       def empty[A]: FS[A]
       def fromTraversable[A](ta: G[A]): FS[A]
     }

--- a/modules/effects/shared/src/main/scala/tagless/effects/validation.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/validation.scala
@@ -25,7 +25,7 @@ object validation {
     type Errors = List[E]
 
     /** An algebra for introducing validation semantics in a program. **/
-    @tagless sealed trait ValidationM {
+    @tagless @stacksafe sealed trait ValidationM {
       def valid[A](x: A): FS[A]
 
       def invalid(err: E): FS[Unit]

--- a/modules/effects/shared/src/main/scala/tagless/effects/writer.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/writer.scala
@@ -23,7 +23,7 @@ object writer {
 
   final class AccumulatorProvider[W] {
 
-    @tagless sealed abstract class WriterM {
+    @tagless @stacksafe sealed abstract class WriterM {
       def writer[A](aw: (W, A)): FS[A]
       def tell(w: W): FS[Unit]
     }

--- a/modules/effects/shared/src/test/scala/tagless/effects/EffectsTests.scala
+++ b/modules/effects/shared/src/test/scala/tagless/effects/EffectsTests.scala
@@ -541,22 +541,22 @@ object collision {
     val readerM: rd.ReaderM
   }
 
-  @tagless
+  @tagless @stacksafe
   trait B {
     def x: FS[Int]
   }
 
-  @tagless
+  @tagless @stacksafe
   trait C {
     def x: FS[Int]
   }
 
-  @tagless
+  @tagless @stacksafe
   trait D {
     def x: FS[Int]
   }
 
-  @tagless
+  @tagless @stacksafe
   trait E {
     def x: FS[Int]
   }

--- a/modules/logging/jvm/src/main/scala/free/implicits.scala
+++ b/modules/logging/jvm/src/main/scala/free/implicits.scala
@@ -16,5 +16,7 @@
 
 package freestyle.free.loggingJVM
 
-@deprecated("Use freestyle.free.loggingJVM.journal.implicits or freestyle.free.loggingJVM.log4s.implicits instead", "0.6.2")
+@deprecated(
+  "Use freestyle.free.loggingJVM.journal.implicits or freestyle.free.loggingJVM.log4s.implicits instead",
+  "0.6.2")
 object implicits extends freestyle.tagless.loggingJVM.journal.Implicits

--- a/modules/logging/jvm/src/main/scala/tagless/implicits.scala
+++ b/modules/logging/jvm/src/main/scala/tagless/implicits.scala
@@ -16,5 +16,7 @@
 
 package freestyle.tagless.loggingJVM
 
-@deprecated("Use freestyle.tagless.loggingJVM.journal.implicits or freestyle.tagless.loggingJVM.log4s.implicits instead", "0.6.2")
+@deprecated(
+  "Use freestyle.tagless.loggingJVM.journal.implicits or freestyle.tagless.loggingJVM.log4s.implicits instead",
+  "0.6.2")
 object implicits extends freestyle.tagless.loggingJVM.journal.Implicits

--- a/modules/logging/shared/src/main/scala/tagless/logging.scala
+++ b/modules/logging/shared/src/main/scala/tagless/logging.scala
@@ -18,7 +18,7 @@ package freestyle.tagless
 
 object logging {
 
-  @tagless
+  @tagless @stacksafe
   trait LoggingM {
 
     def debug(msg: String, sourceAndLineInfo: Boolean = false)(

--- a/modules/logging/shared/src/test/scala/tagless/algebras.scala
+++ b/modules/logging/shared/src/test/scala/tagless/algebras.scala
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 
 object algebras {
 
-  @tagless
+  @tagless @stacksafe
   trait NonLogging {
     def x: FS[Int]
   }


### PR DESCRIPTION
Resolves #517. 

There are some issues in `@tagless` when using stacksafe, which are due to the fact that the tagless is more flexible than the `@free` macro.

To avoid these issues, we have separated a `@stacksafe` annotation for the `@tagless` annotated traits. Without it, it does not generate the Stacksafe trait and object.

We keep the annotation in all places where `@tagless` was used before. 

Pending issues:
* [ ] Tests to check that the non-stacksafe macro is more flexible, by using `FS` inside method parameters or return type. 
* [ ] Update documentation to indicate `@stacksafe` as an optional feature. 

Note that this change breaks compatibility: any trait annotated with `@tagless` using the previous algebra will lose the `StackSafe` trait-object pair in the companion object. 