### PR TITLE
Fix syntax highlighting

### DIFF
--- a/docs/src/main/tut/docs/patterns/config/README.md
+++ b/docs/src/main/tut/docs/patterns/config/README.md
@@ -131,8 +131,7 @@ If we decide to use the Typesafe Config object instead of the Case Classy librar
 
 So, given the example described above, the required code will be pretty similar except we'll load the Config object and use the methods that it provides:
 
-```
-tut:book
+```tut:book
 def filteredStates[F[_]](implicit app : App[F]): FreeS[F, List[String]] =
   for {
     currentStates <- app.issuesService.states


### PR DESCRIPTION
Due to extra newline, the `tut:book` syntax highlighting directive is shown as part of code example:

![screenshot](https://user-images.githubusercontent.com/1419884/35520283-e5125a9e-0516-11e8-9605-e8e0b27a4da6.png)
