### PR TITLE
FS-528 Override MapK for tagless-stacksafe Handler.

### DIFF
--- a/modules/core/shared/src/main/scala/freestyle/free/internal/ScalametaUtil.scala
+++ b/modules/core/shared/src/main/scala/freestyle/free/internal/ScalametaUtil.scala
@@ -132,6 +132,11 @@ object ScalametaUtil {
       })
   }
 
+  implicit class DefnDefOps(val defnDef: Defn.Def) extends AnyVal {
+    def addMod(mod: Mod): Defn.Def = defnDef.copy(mods = defnDef.mods :+ mod)
+  }
+
+
   implicit class TermParamListOps(val termParams: Seq[Term.Param]) extends AnyVal {
     def hasImplicit: Boolean = termParams.exists(_.isImplicit)
 

--- a/modules/core/shared/src/test/scala/freestyle/tagless/TaglessTests.scala
+++ b/modules/core/shared/src/test/scala/freestyle/tagless/TaglessTests.scala
@@ -338,10 +338,6 @@ class TaglessTests extends WordSpec with Matchers {
     import algebras._
     import handlers._
 
-    "Allow a trait with an F[_] bound type param" in {
-      "@tagless trait X[F[_]] { def bar(x:Int): FS[Int] }" should compile
-    }
-
     "combine with other tagless algebras" in {
 
       def program[F[_] : Monad : TG1 : TG2: TG3] = {


### PR DESCRIPTION
Override the `mapK` method for the Handler of a tagless-stacksafe algebra.

@loostro 