### PR TITLE
FS-532 stacksafe as tagless argument

### DIFF
--- a/docs/src/main/tut/docs/core/algebras/README.md
+++ b/docs/src/main/tut/docs/core/algebras/README.md
@@ -201,12 +201,12 @@ Freestyle allows us to compose `@free` and `@tagless` algebras. Let us consider 
 ```tut:book
 import freestyle.tagless._
 
-@tagless @stacksafe trait Validation {
+@tagless(true) trait Validation {
   def minSize(s: String, n: Int): FS[Boolean]
   def hasNumber(s: String): FS[Boolean]
 }
 
-@tagless @stacksafe trait Interaction {
+@tagless(true) trait Interaction {
   def tell(msg: String): FS[Unit]
   def ask(prompt: String): FS[String]
 }

--- a/docs/src/main/tut/docs/core/handlers/README.md
+++ b/docs/src/main/tut/docs/core/handlers/README.md
@@ -154,12 +154,12 @@ Tagless final algebras are declared using the `@tagless` macro annotation.
 
 ```tut:book
 
-@tagless @stacksafe trait Validation {
+@tagless(true) trait Validation {
   def minSize(s: String, n: Int): FS[Boolean]
   def hasNumber(s: String): FS[Boolean]
 }
 
-@tagless @stacksafe trait Interaction {
+@tagless(true) trait Interaction {
   def tell(msg: String): FS[Unit]
   def ask(prompt: String): FS[String]
 }

--- a/docs/src/main/tut/docs/core/modules/README.md
+++ b/docs/src/main/tut/docs/core/modules/README.md
@@ -21,10 +21,10 @@ import freestyle.tagless._
 ```tut:book
 
 object algebras {
-    @tagless @stacksafe trait Database {
+    @tagless(true) trait Database {
       def get(id: Int): FS[Int]
     }
-    @tagless @stacksafe trait Cache {
+    @tagless(true) trait Cache {
       def get(id: Int): FS[Option[Int]]
     }
     @free trait Presenter {

--- a/modules/async/async/shared/src/main/scala/tagless/async.scala
+++ b/modules/async/async/shared/src/main/scala/tagless/async.scala
@@ -23,7 +23,7 @@ import freestyle.async._
 object async {
 
   /** Async computation algebra. **/
-  @tagless @stacksafe trait AsyncM {
+  @tagless(true) trait AsyncM {
     def async[A](fa: Proc[A]): FS[A]
   }
 

--- a/modules/config/src/main/scala/tagless/config.scala
+++ b/modules/config/src/main/scala/tagless/config.scala
@@ -23,7 +23,7 @@ import freestyle.config._
 
 object config {
 
-  @tagless @stacksafe sealed trait ConfigM {
+  @tagless(true) sealed trait ConfigM {
     def load: FS[Config]
     def empty: FS[Config]
     def parseString(s: String): FS[Config]

--- a/modules/config/src/test/scala/tagless/ConfigTests.scala
+++ b/modules/config/src/test/scala/tagless/ConfigTests.scala
@@ -126,7 +126,7 @@ class ConfigTests extends WordSpec with Matchers {
 }
 
 object algebras {
-  @tagless @stacksafe
+  @tagless(true)
   trait NonConfig {
     def x: FS[Int]
   }

--- a/modules/core/shared/src/main/scala/freestyle/free/internal/ScalametaUtil.scala
+++ b/modules/core/shared/src/main/scala/freestyle/free/internal/ScalametaUtil.scala
@@ -198,6 +198,18 @@ object ScalametaUtil {
     def addParent( ctorCall: Ctor.Call): Template =
       templ.copy( parents = templ.parents ++ Seq(ctorCall) )
 
+    def addStats( newStats: Seq[Stat]): Template =
+      if (newStats.isEmpty) templ else templ.copy(
+        stats = Some( templ.stats.getOrElse(Seq()) ++ newStats)
+      )
+  }
+
+  implicit class ObjectOps(val obj: Object) extends AnyVal {
+
+    def appendStats(newStats: Seq[Stat]): Object =
+      if (newStats.isEmpty) obj
+      else obj.copy( templ = obj.templ.addStats(newStats))
+
   }
 
 }

--- a/modules/core/shared/src/main/scala/freestyle/free/internal/ScalametaUtil.scala
+++ b/modules/core/shared/src/main/scala/freestyle/free/internal/ScalametaUtil.scala
@@ -61,7 +61,6 @@ object ScalametaUtil {
 
     def filtered: Seq[Mod] = mods.filter {
       case mod"@debug" => false
-      case mod"@stacksafe" => false
       case _           => true
     }
 

--- a/modules/core/shared/src/main/scala/freestyle/free/internal/ScalametaUtil.scala
+++ b/modules/core/shared/src/main/scala/freestyle/free/internal/ScalametaUtil.scala
@@ -65,11 +65,6 @@ object ScalametaUtil {
       case _           => true
     }
 
-    def isStackSafe: Boolean = mods.exists {
-      case mod"@stacksafe" => true
-      case _ => false
-    }
-
     def isDebug: Boolean = mods exists {
       case mod"@debug" => true
       case _           => false

--- a/modules/core/shared/src/main/scala/freestyle/free/internal/module.scala
+++ b/modules/core/shared/src/main/scala/freestyle/free/internal/module.scala
@@ -47,18 +47,11 @@ private[internal] case class FreeSModule( clait: Clait ) {
   import errors._
   import clait._
 
-  val effects: Seq[ModEffect] =
-    templ.stats.getOrElse(Nil).collect {
-      case vdec @ Decl.Val(_, Seq(Pat.Var.Term(_)), Type.Apply(tname @ _, Seq(Type.Name(_)))) =>
-        ModEffect(vdec)
-      case vdec @ Decl.Val(_, Seq(Pat.Var.Term(_)), _) => ModEffect(vdec)
-    }
+  val effects: Seq[ModEffect] = templ.stats.getOrElse(Nil).collect { case ModEffect(eff) => eff }
 
   def enrichStat(st: Stat): Stat = st match {
-    case vdec @ Decl.Val(_, Seq(Pat.Var.Term(tname)), Type.Apply(_, Seq(_))) =>
-      vdec
-    case vdec @ Decl.Val(_, Seq(Pat.Var.Term(tname)), ty) =>
-      vdec.copy(decltpe = Type.Apply(ty, Seq(headTParam.toName)))
+    case ModEffect(eff) =>
+      eff.effVal.copy(decltpe = Type.Apply(eff.tyFunc, Seq(headTName)))
     case x => x
   }
 
@@ -82,30 +75,41 @@ private[internal] case class FreeSModule( clait: Clait ) {
     val toTParams: Seq[Type.Param] = gg.paramK +: tailTParams
     val toTArgs: Seq[Type]         = gg +: tailTNames
 
+    val toDefParams:   Seq[Term.Param] = effects.map(_.buildDefParam(gg))
+
     val toClass: Class = {
+      val toClassParams: Seq[Term.Param] = toDefParams.map(_.addMod(Mod.ValParam()))
       val sup: Term.ApplyType = Term.ApplyType(name.ctor, toTArgs)
-      val args: Seq[Term.Param] = effects.map(_.buildConstParam(gg))
-      q"class To[..$toTParams](implicit ..$args) extends $sup { }"
+      q"class To[..$toTParams](implicit ..$toClassParams) extends $sup { }"
     }
 
     val toDef: Defn.Def =
       if (effects.isEmpty)
         q"implicit def to[..$toTParams]: To[..$toTArgs] = new To[..$toTArgs]"
-      else {
-        val args: Seq[Term.Param] = effects.map(_.buildDefParam(gg))
-        q"implicit def to[..$toTParams](..$args): To[..$toTArgs] = new To[..$toTArgs]()"
-      }
+      else
+        q"implicit def to[..$toTParams](..$toDefParams): To[..$toTArgs] = new To[..$toTArgs]()"
 
     (toClass, toDef)
   }
 
-  def makeObject: Object = {
-    val (toClass, toDef) = lifterStats
+  def opStats: (Defn.Type, Defn.Type) = {
+    def makeOpTypesBody: Type =
+      if (effects.isEmpty)
+        iotaTNilKT
+      else
+        effects.map(_.opType).reduce(iotaConcatApply)
     val opType: Defn.Type = {
       val aa: Type.Name = Type.fresh("AA$")
       q"type Op[${aa.param}] = _root_.iota.CopK[OpTypes, $aa]"
     }
     val opTypes = q"type OpTypes = T".copy(body = makeOpTypesBody)
+
+    (opTypes, opType)
+  }
+
+  def makeObject: Object = {
+    val (toClass, toDef) = lifterStats
+    val (opTypes, opType) = opStats
 
     val prot = q"object X {}"
     prot.copy(
@@ -115,35 +119,23 @@ private[internal] case class FreeSModule( clait: Clait ) {
       ))
   }
 
-  def makeOpTypesBody: Type =
-    if (effects.isEmpty)
-      iotaTNilKT
-    else
-      effects.map(_.opType).reduce(iotaConcatApply)
 
 }
 
-private[internal] case class ModEffect(effVal: Decl.Val) {
+private[internal] class ModEffect(val effVal: Decl.Val) {
+
+  val name = effVal.pats.head.name
+
+  val tyFunc: Type = effVal.decltpe match {
+    case Type.Apply(tfun, _) => tfun
+    case ty                  => ty
+  }
 
   // buildParam(x, t) = q"def foo(implicit $x: $t[$gg])"
   def buildDefParam(gg: Type.Name): Term.Param =
     q"def foo(implicit x: Int)".paramss.head.head.copy(
-      name = effVal.pats.head.name,
-      decltpe = Some(effVal.decltpe match {
-        case Type.Apply(t @ _, _) => Type.Apply(t, Seq(gg))
-        case _                    => Type.Apply(effVal.decltpe, Seq(gg))
-      })
-    )
-
-  // buildParam(x, t) = q"class Foo(implicit val $x: $t[$gg])"
-  def buildConstParam(gg: Type.Name): Term.Param =
-    q"def foo(implicit x: Int)".paramss.head.head.copy(
-      mods = Seq(Mod.Implicit(), Mod.ValParam()),
-      name = effVal.pats.head.name,
-      decltpe = Some(effVal.decltpe match {
-        case Type.Apply(t @ _, _) => Type.Apply(t, Seq(gg))
-        case _                    => Type.Apply(effVal.decltpe, Seq(gg))
-      })
+      name = name,
+      decltpe = Some( Type.Apply(tyFunc, Seq(gg)))
     )
 
   // x => q"x.OpTypes"
@@ -155,6 +147,15 @@ private[internal] case class ModEffect(effVal: Decl.Val) {
     case Type.Select(q, Type.Name(n)) => Term.Select(q, Term.Name(n))
     case Type.Apply(t, Seq(_))        => typeToObject(t)
     case _                            => abort(s"found: $ty unmatched. What is the case here")
+  }
+
+}
+
+object ModEffect {
+
+  def unapply(stat: Stat): Option[ModEffect] = stat match {
+    case vdec @ Decl.Val(_, Seq(Pat.Var.Term(_)), _ ) => Some(new ModEffect(vdec) )
+    case _ => None
   }
 
 }

--- a/modules/core/shared/src/main/scala/freestyle/tagless/annotations.scala
+++ b/modules/core/shared/src/main/scala/freestyle/tagless/annotations.scala
@@ -19,13 +19,20 @@ package tagless
 
 import freestyle.tagless.internal._
 
+import scala.meta._
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
 
 @compileTimeOnly("enable macro paradise to expand @tagless macro annotations")
-class tagless extends StaticAnnotation {
+class tagless(val stacksafe: Boolean) extends StaticAnnotation {
   import scala.meta._
 
-  inline def apply(defn: Any): Any = meta { taglessImpl.tagless(defn) }
+  inline def apply(defn: Any): Any = meta {
+    val stacksafe: Boolean = this match {
+      case q"new $_(${Lit.Boolean(ss)})" => ss
+      case _ => false
+    }
+    taglessImpl.tagless(defn, stacksafe)
+  }
 }
 
 @compileTimeOnly("enable macro paradise to expand @module macro annotations")

--- a/modules/core/shared/src/main/scala/freestyle/tagless/annotations.scala
+++ b/modules/core/shared/src/main/scala/freestyle/tagless/annotations.scala
@@ -29,6 +29,7 @@ class tagless(val stacksafe: Boolean) extends StaticAnnotation {
   inline def apply(defn: Any): Any = meta {
     val stacksafe: Boolean = this match {
       case q"new $_(${Lit.Boolean(ss)})" => ss
+      case q"new $_(stacksafe = ${Lit.Boolean(ss)})" => ss
       case _ => false
     }
     taglessImpl.tagless(defn, stacksafe)

--- a/modules/core/shared/src/main/scala/freestyle/tagless/internal/tagless.scala
+++ b/modules/core/shared/src/main/scala/freestyle/tagless/internal/tagless.scala
@@ -31,9 +31,9 @@ object taglessImpl {
   val errors = new ErrorMessages("@tagless")
   import errors._
 
-  def tagless(defn: Any): Stat = {
+  def tagless(defn: Any, stackSafe: Boolean): Stat = {
     val (clait, isTrait) = Clait.parse("@tagless", defn)
-    val alg = Algebra(clait)
+    val alg = Algebra(clait, stackSafe)
     if (alg.requestDecls.isEmpty)
       abort(s"$invalid in ${alg.clait.name}. $nonEmpty")
     else {
@@ -46,12 +46,10 @@ object taglessImpl {
 
 }
 
-case class Algebra( clait: Clait) {
+case class Algebra( clait: Clait, isStackSafe: Boolean) {
   import clait._
   val errors = new ErrorMessages("@tagless")
   import errors._
-
-  val isStackSafe = clait.mods.isStackSafe
 
   val requestDecls: Seq[Decl.Def] = templ.stats.get.collect {
     case dd: Decl.Def =>

--- a/modules/core/shared/src/main/scala/freestyle/tagless/internal/tagless.scala
+++ b/modules/core/shared/src/main/scala/freestyle/tagless/internal/tagless.scala
@@ -31,9 +31,9 @@ object taglessImpl {
   val errors = new ErrorMessages("@tagless")
   import errors._
 
-  def tagless(defn: Any, stackSafe: Boolean): Stat = {
+  def tagless(defn: Any, stacksafe: Boolean): Stat = {
     val (clait, isTrait) = Clait.parse("@tagless", defn)
-    val alg = Algebra(clait, stackSafe)
+    val alg = Algebra(clait, stacksafe)
     if (alg.requestDecls.isEmpty)
       abort(s"$invalid in ${alg.clait.name}. $nonEmpty")
     else {
@@ -107,7 +107,7 @@ case class Algebra( clait: Clait, isStackSafe: Boolean) {
       } else tr
     }
 
-    lazy val stackSafeAlg: FreeAlgebra = {
+    lazy val stacksafeAlg: FreeAlgebra = {
       def withFS( req: Decl.Def): Decl.Def =
         req.copy(decltpe = req.decltpe match {
           case Type.Apply(_, targs) => Type.Apply( Type.Name("FS"), targs)
@@ -117,8 +117,8 @@ case class Algebra( clait: Clait, isStackSafe: Boolean) {
       val t: Trait = q" trait StackSafe { ..${requestDecls.map(withFS)} } "
       FreeAlgebra(Clait(Seq.empty[Mod], Type.Name("StackSafe"), allTParams, t.ctor, t.templ))
     }
-    lazy val stackSafeT: Trait = stackSafeAlg.enrich.toTrait
-    lazy val stackSafeD: Object = stackSafeAlg.mkCompanion
+    lazy val stacksafeT: Trait = stacksafeAlg.enrich.toTrait
+    lazy val stacksafeD: Object = stacksafeAlg.mkCompanion
 
     val deriveDef: Defn.Def = {
       val deriveTTs = mm.paramK +: nn.paramK +: tailTParams
@@ -158,7 +158,7 @@ case class Algebra( clait: Clait, isStackSafe: Boolean) {
     }
 
     val nstats = Seq(clait.applyDef, functorKDef, deriveDef, handlerT) ++
-      ( if (isStackSafe) Seq(stackSafeT, stackSafeD) else Seq() )
+      ( if (isStackSafe) Seq(stacksafeT, stacksafeD) else Seq() )
 
     val prot = q"object X {}"
     prot.copy(

--- a/modules/core/shared/src/test/scala/freestyle/tagless/StacksafeTests.scala
+++ b/modules/core/shared/src/test/scala/freestyle/tagless/StacksafeTests.scala
@@ -38,7 +38,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
 
   def ok: Unit = (0 shouldEqual 0)
 
-  "the @tagless macro annotation, with the extra @stacksafe annotation, should be accepted if it is applied to" when {
+  "the @tagless macro annotation, with the 'stacksafe' annotation parameter, should be accepted if it is applied to" when {
 
     "a trait that has at least one request (like the plain @tagless), and " when {
 

--- a/modules/core/shared/src/test/scala/freestyle/tagless/StacksafeTests.scala
+++ b/modules/core/shared/src/test/scala/freestyle/tagless/StacksafeTests.scala
@@ -36,13 +36,27 @@ import modules._
 
 class TaglessStacksafeTests extends WordSpec with Matchers {
 
+  def ok: Unit = (0 shouldEqual 0)
+
   "the @tagless macro annotation, with the extra @stacksafe annotation, should be accepted if it is applied to" when {
 
-    "a trait with at least one request" in {
-      @tagless(true) trait X {
-        def bar(x:Int): FS[Int]
+    "a trait that has at least one request (like the plain @tagless), and " when {
+
+      "we use the literal argument" in {
+        @tagless(true) trait X {
+          def bar(x:Int): FS[Int]
+        }
+        val ss: Any = X.StackSafe
+        ok
       }
-      0 shouldEqual 0
+
+      "we use the literal argument with the variable assigned" in {
+        @tagless(stacksafe = true) trait X {
+          def bar(x:Int): FS[Int]
+        }
+        val ss: Any = X.StackSafe
+        ok
+      }
     }
 
     "a trait with a kind-1 type param" when {
@@ -50,27 +64,27 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
         @tagless(true) trait FBound[F[_]] {
           def ann(x:Int): FS[Int]
         }
-        0 shouldEqual 0
+        ok
       }
 
       "typing the request with the user-provided F-Bound type param" in {
         @tagless(true) trait FBound[F[_]] {
           def bob(y:Int): F[Int]
         }
-        0 shouldEqual 0
+        ok
       }
     }
 
     "an abstract class with at least one request" in {
       @tagless(true) abstract class X { def bar(x:Int): FS[Int] }
-      0 shouldEqual 0
+      ok
     }
 
     "a trait with an abstact method of type FS" in {
       @tagless(true) trait X {
         def f(a: Char) : FS[Int]
       }
-      0 shouldEqual 0
+      ok
     }
 
     "a trait with some concrete non-FS members" ignore {
@@ -79,35 +93,35 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
         def y: Int = 5
         val z: Int = 6
       }
-      0 shouldEqual 0
+      ok
     }
 
     "a trait with a method with type parameters" in {
       @tagless(true) trait WiX {
         def ix[A](a: A) : FS[A]
       }
-      0 shouldEqual 0
+      ok
     }
 
     "a trait with high bounded type parameters in the method" in {
       @tagless(true) trait X {
         def ix[A <: Int](a: A) : FS[A]
       }
-      0 shouldEqual 0
+      ok
     }
 
     "a trait with lower bounded type parameters in the method" in {
       @tagless(true) trait X {
         def ix[A >: Int](a: A) : FS[A]
       }
-      0 shouldEqual 0
+      ok
     }
 
     "a trait with different type parameters in the method" in {
       @tagless(true) trait X {
         def ix[A <: Int, B, C >: Int](a: A, b: B, c: C) : FS[A]
       }
-      0 shouldEqual 0
+      ok
     }
 
     "a trait with high bounded type parameters and implicits in the method" in {
@@ -115,7 +129,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
       @tagless(true) trait Y {
         def ix[A <: Int : X](a: A) : FS[A]
       }
-      0 shouldEqual 0
+      ok
     }
 
   }

--- a/modules/core/shared/src/test/scala/freestyle/tagless/StacksafeTests.scala
+++ b/modules/core/shared/src/test/scala/freestyle/tagless/StacksafeTests.scala
@@ -39,7 +39,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
   "the @tagless macro annotation, with the extra @stacksafe annotation, should be accepted if it is applied to" when {
 
     "a trait with at least one request" in {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def bar(x:Int): FS[Int]
       }
       0 shouldEqual 0
@@ -47,14 +47,14 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
 
     "a trait with a kind-1 type param" when {
       "typing the request with reserved FS" in {
-        @tagless @stacksafe trait FBound[F[_]] {
+        @tagless(true) trait FBound[F[_]] {
           def ann(x:Int): FS[Int]
         }
         0 shouldEqual 0
       }
 
       "typing the request with the user-provided F-Bound type param" in {
-        @tagless @stacksafe trait FBound[F[_]] {
+        @tagless(true) trait FBound[F[_]] {
           def bob(y:Int): F[Int]
         }
         0 shouldEqual 0
@@ -62,19 +62,19 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
     }
 
     "an abstract class with at least one request" in {
-      @tagless @stacksafe abstract class X { def bar(x:Int): FS[Int] }
+      @tagless(true) abstract class X { def bar(x:Int): FS[Int] }
       0 shouldEqual 0
     }
 
     "a trait with an abstact method of type FS" in {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def f(a: Char) : FS[Int]
       }
       0 shouldEqual 0
     }
 
     "a trait with some concrete non-FS members" ignore {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def x: FS[Int]
         def y: Int = 5
         val z: Int = 6
@@ -83,28 +83,28 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
     }
 
     "a trait with a method with type parameters" in {
-      @tagless @stacksafe trait WiX {
+      @tagless(true) trait WiX {
         def ix[A](a: A) : FS[A]
       }
       0 shouldEqual 0
     }
 
     "a trait with high bounded type parameters in the method" in {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def ix[A <: Int](a: A) : FS[A]
       }
       0 shouldEqual 0
     }
 
     "a trait with lower bounded type parameters in the method" in {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def ix[A >: Int](a: A) : FS[A]
       }
       0 shouldEqual 0
     }
 
     "a trait with different type parameters in the method" in {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def ix[A <: Int, B, C >: Int](a: A, b: B, c: C) : FS[A]
       }
       0 shouldEqual 0
@@ -112,7 +112,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
 
     "a trait with high bounded type parameters and implicits in the method" in {
       trait X[A]
-      @tagless @stacksafe trait Y {
+      @tagless(true) trait Y {
         def ix[A <: Int : X](a: A) : FS[A]
       }
       0 shouldEqual 0
@@ -120,17 +120,17 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
 
   }
 
-  "the @tagless @stacksafe macro should preserve the shape of the parameters of the request" when {
+  "the @tagless(true) macro should preserve the shape of the parameters of the request" when {
 
     "there are no parameters" in {
-      @tagless @stacksafe trait X { def f: FS[Int] }
+      @tagless(true) trait X { def f: FS[Int] }
       object Y extends X.Handler[Id] { def f: Int = 42 }
 
       Y.f shouldEqual 42
     }
 
     "there is one list with multiple params" in {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def f(a: Int, b: Int): FS[Int]
       }
       object Y extends X.Handler[Id] {
@@ -140,7 +140,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
     }
 
     "there are multiple lists of parameters" in {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def f(a: Int)(b: Int): FS[Int]
       }
       object Y extends X.Handler[Id] {
@@ -150,7 +150,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
     }
 
     "there are multiple lists of parameters, with the last being implicit" ignore {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def f(a: Int)(implicit b: Int): FS[Int]
       }
       object Y extends X.Handler[Id] {
@@ -161,7 +161,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
     }
 
     "there is one type parameter with a type-class bound, and one parameter" ignore {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def f[T: Monoid](a: T): FS[T]
         def g[S: Eq](a: S, b: S): FS[Boolean]
       }
@@ -175,7 +175,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
 
   }
 
-  "the @tagless @stacksafe macro annotation should be rejected, and the compilation fail, if it is applied to" when {
+  "the @tagless(true) macro annotation should be rejected, and the compilation fail, if it is applied to" when {
 
     "an empty trait" in (
       "@tagless trait X" shouldNot compile
@@ -206,7 +206,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
 
   "A @tagles trait can define derive methods by combining other basic methods" when {
     "they use a Functor[FS] instance to provide a map operation" in {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def a: FS[Int]
         def b(implicit f: Functor[FS]): FS[Int] = a.map(x => x+1)
       }
@@ -217,7 +217,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
     }
 
     "using the Applicative instance of FS to combine operations" in {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def a: FS[Int]
         def b(implicit A: Applicative[FS]): FS[Int] = (a, A.pure(1)).mapN(_+_)
       }
@@ -228,7 +228,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
     }
 
     "using the Monad instance of FS to combine operations" in {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def a: FS[Int]
         def b(x: Int): FS[Int]
         def c(implicit M: Monad[FS]): FS[Int] = for {
@@ -245,7 +245,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
     }
 
     "mixing all of the above" in {
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def a: FS[Int]
         def b(i: Int)(implicit F: Functor[FS]): FS[Int] = a.map(x => x+i)
         def c(implicit A: Applicative[FS]): FS[Int] = (a,A.pure(3)).mapN(_+_)
@@ -266,7 +266,7 @@ class TaglessStacksafeTests extends WordSpec with Matchers {
   "A StackSafe Tagless algebra should be able to " when {
     "mapK its Handler to another Handler of the StackSafe" in {
       import cats.instances.list._
-      @tagless @stacksafe trait X {
+      @tagless(true) trait X {
         def a: FS[Int]
       }
       object Y extends X.Handler[Option] {

--- a/modules/core/shared/src/test/scala/freestyle/tagless/TaglessModuleTests.scala
+++ b/modules/core/shared/src/test/scala/freestyle/tagless/TaglessModuleTests.scala
@@ -39,7 +39,7 @@ class TaglessModuleTests extends WordSpec with Matchers {
   "Tagless final algebras" should {
 
     "Allow a trait with an F[_] bound type param" in {
-      @tagless @stacksafe trait X[F[_]] {
+      @tagless(true) trait X[F[_]] {
         def bar(x:Int): FS[Int]
       }
       0 shouldEqual 0

--- a/modules/core/shared/src/test/scala/freestyle/tagless/Utils.scala
+++ b/modules/core/shared/src/test/scala/freestyle/tagless/Utils.scala
@@ -31,21 +31,21 @@ import cats.syntax.functor._
 
 object algebras {
 
-  @tagless @stacksafe
+  @tagless(true)
   trait TG1 {
     def x(a: Int): FS[Int]
 
     def y(a: Int): FS[Int]
   }
 
-  @tagless @stacksafe
+  @tagless(true)
   trait TG2 {
     def x2(a: Int): FS[Int]
 
     def y2(a: Int): FS[Int]
   }
 
-  @tagless @stacksafe
+  @tagless(true)
   trait TG3[F[_]] {
     def x3(a: Int): FS[Int]
 

--- a/modules/effects/shared/src/main/scala/tagless/effects/either.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/either.scala
@@ -25,7 +25,7 @@ object either {
 
   final class ErrorProvider[E] {
 
-    @tagless @stacksafe sealed trait EitherM {
+    @tagless(true) sealed trait EitherM {
       def either[A](fa: Either[E, A]): FS[A]
       def error[A](e: E): FS[A]
       def catchNonFatal[A](a: Eval[A], f: Throwable => E): FS[A]

--- a/modules/effects/shared/src/main/scala/tagless/effects/error.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/error.scala
@@ -21,7 +21,7 @@ import cats.{Eval, MonadError}
 
 object error {
 
-  @tagless @stacksafe sealed trait ErrorM {
+  @tagless(true) sealed trait ErrorM {
     def either[A](fa: Either[Throwable, A]): FS[A]
     def error[A](e: Throwable): FS[A]
     def catchNonFatal[A](a: Eval[A]): FS[A]

--- a/modules/effects/shared/src/main/scala/tagless/effects/option.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/option.scala
@@ -22,7 +22,7 @@ import cats.mtl.FunctorEmpty
 
 object option {
 
-  @tagless @stacksafe sealed trait OptionM {
+  @tagless(true) sealed trait OptionM {
     def option[A](fa: Option[A]): FS[A]
     def none[A]: FS[A]
   }

--- a/modules/effects/shared/src/main/scala/tagless/effects/reader.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/reader.scala
@@ -23,7 +23,7 @@ object reader {
 
   final class EnvironmentProvider[R] {
 
-    @tagless @stacksafe abstract class ReaderM {
+    @tagless(true) abstract class ReaderM {
       def ask: FS[R]
       def reader[B](f: R => B): FS[B]
     }

--- a/modules/effects/shared/src/main/scala/tagless/effects/state.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/state.scala
@@ -23,7 +23,7 @@ object state {
 
   final class StateSeedProvider[S] {
 
-    @tagless @stacksafe sealed abstract class StateM {
+    @tagless(true) sealed abstract class StateM {
       def get: FS[S]
       def set(s: S): FS[Unit]
       def modify(f: S => S): FS[Unit]

--- a/modules/effects/shared/src/main/scala/tagless/effects/traverse.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/traverse.scala
@@ -25,7 +25,7 @@ object traverse {
 
     /** Acts as a generator providing traversable semantics to programs
      */
-    @tagless @stacksafe sealed abstract class TraverseM {
+    @tagless(true) sealed abstract class TraverseM {
       def empty[A]: FS[A]
       def fromTraversable[A](ta: G[A]): FS[A]
     }

--- a/modules/effects/shared/src/main/scala/tagless/effects/validation.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/validation.scala
@@ -25,7 +25,7 @@ object validation {
     type Errors = List[E]
 
     /** An algebra for introducing validation semantics in a program. **/
-    @tagless @stacksafe sealed trait ValidationM {
+    @tagless(true) sealed trait ValidationM {
       def valid[A](x: A): FS[A]
 
       def invalid(err: E): FS[Unit]

--- a/modules/effects/shared/src/main/scala/tagless/effects/writer.scala
+++ b/modules/effects/shared/src/main/scala/tagless/effects/writer.scala
@@ -23,7 +23,7 @@ object writer {
 
   final class AccumulatorProvider[W] {
 
-    @tagless @stacksafe sealed abstract class WriterM {
+    @tagless(true) sealed abstract class WriterM {
       def writer[A](aw: (W, A)): FS[A]
       def tell(w: W): FS[Unit]
     }

--- a/modules/effects/shared/src/test/scala/tagless/effects/EffectsTests.scala
+++ b/modules/effects/shared/src/test/scala/tagless/effects/EffectsTests.scala
@@ -541,22 +541,22 @@ object collision {
     val readerM: rd.ReaderM
   }
 
-  @tagless @stacksafe
+  @tagless(true)
   trait B {
     def x: FS[Int]
   }
 
-  @tagless @stacksafe
+  @tagless(true)
   trait C {
     def x: FS[Int]
   }
 
-  @tagless @stacksafe
+  @tagless(true)
   trait D {
     def x: FS[Int]
   }
 
-  @tagless @stacksafe
+  @tagless(true)
   trait E {
     def x: FS[Int]
   }

--- a/modules/logging/shared/src/main/scala/tagless/logging.scala
+++ b/modules/logging/shared/src/main/scala/tagless/logging.scala
@@ -18,7 +18,7 @@ package freestyle.tagless
 
 object logging {
 
-  @tagless @stacksafe
+  @tagless(true)
   trait LoggingM {
 
     def debug(msg: String, sourceAndLineInfo: Boolean = false)(

--- a/modules/logging/shared/src/test/scala/tagless/algebras.scala
+++ b/modules/logging/shared/src/test/scala/tagless/algebras.scala
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 
 object algebras {
 
-  @tagless @stacksafe
+  @tagless(true)
   trait NonLogging {
     def x: FS[Int]
   }


### PR DESCRIPTION
This PR resolves #532. 

We make `stacksafe` into an optional argument of the `@tagless` macro annotation, following the examples [here](http://scalameta.org/paradise/#HowdoIpassanargumenttothemacroannotation?). 

