### PR TITLE
[Docs] Add new Microservices item with nested_options

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -120,6 +120,9 @@ options:
       - title: Core concepts
         url: docs/rpc/core-concepts
 
+      - title: Implementations
+        url: docs/rpc/implementations
+
       - title: IDL Generation
         url: docs/rpc/idl-generation
 

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -120,19 +120,19 @@ options:
       - title: Core concepts
         url: docs/rpc/core-concepts
 
+      - title: Streaming
+        url: docs/rpc/streaming
+ 
+      - title: Annotations
+        url: docs/rpc/annotations
+ 
       - title: IDL Generation
         url: docs/rpc/idl-generation
 
-      - title: Annotations
-        url: docs/rpc/annotations
-
-      - title: Patterns
+     - title: Patterns
         url: docs/rpc/patterns
 
-      - title: Streaming
-        url: docs/rpc/streaming
-
-      - title: SSL/TLS
+     - title: SSL/TLS
         url: docs/rpc/ssl-tls
 
       - title: Metrics Reporting

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -120,9 +120,6 @@ options:
       - title: Core concepts
         url: docs/rpc/core-concepts
 
-      - title: Implementations
-        url: docs/rpc/implementations
-
       - title: IDL Generation
         url: docs/rpc/idl-generation
 

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -109,13 +109,42 @@ options:
       - title: Hammock
         url: docs/integrations/hammock
 
-  - title: Libraries
+  - title: Microservices
     url: docs/rpc
 
     nested_options:
 
-      - title: Microservices
-        url: docs/rpc
+      - title: Quickstart
+        url: docs/rpc/quickstart
+
+      - title: Core concepts
+        url: docs/rpc/core-concepts
+
+      - title: IDL Generation
+        url: docs/rpc/idl-generation
+
+      - title: Annotations
+        url: docs/rpc/annotations
+
+      - title: Patterns
+        url: docs/rpc/patterns
+
+      - title: Streaming
+        url: docs/rpc/streaming
+
+      - title: SSL/TLS
+        url: docs/rpc/ssl-tls
+
+      - title: Metrics Reporting
+        url: docs/rpc/metrics-reporting
+
+      - title: References
+        url: docs/rpc/references
+
+  - title: Libraries
+    url: docs/libraries
+
+    nested_options:
 
       - title: Effects
         url: docs/effects

--- a/docs/src/main/tut/docs/libraries/README.md
+++ b/docs/src/main/tut/docs/libraries/README.md
@@ -1,0 +1,11 @@
+---
+layout: docs
+title: Libraries
+permalink: /docs/libraries/
+---
+
+# Libraries
+
+* [Effects](/docs/effects)
+* [Cassandra](/docs/cassandra)
+* [Kafka](/docs/kafka)


### PR DESCRIPTION
This PR is related to https://github.com/frees-io/freestyle-rpc/issues/176.

In this PR, I am adding a new main section in the left menu called `Microservices` with their nested options. All these new content will be available in the https://github.com/frees-io/freestyle-rpc repository.

Apart from this, I created a new simple layout in the path `/docs/libraries/` to link the libraries available.

