### PR TITLE
Minor examples fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,10 @@ libraryDependencies += "io.frees" %%% "frees-monix"             % "0.8.0"
 
 ## Freestyle Examples
 
-* [TodoList](./modules/examples/todolist/README.md).
+* [todolist-lib](./modules/examples/todolist-lib/README.md).
+* [todolist-http-http4s](./modules/examples/todolist-http-http4s/README.md).
+* [todolist-http-finch](./modules/examples/todolist-http-finch/README.md).
+* [slick-example](.modules/examples/slick-example/README.md).
 
 ## Commercial Support
 

--- a/modules/examples/todolist-http-finch/README.md
+++ b/modules/examples/todolist-http-finch/README.md
@@ -1,5 +1,7 @@
 # TodoList HTTP service using finch
 
+TodoList http service implementation using [`finch`](https://finagle.github.io/finch/) and [`todolist-lib`](../todolist-lib).
+
 ## Running the Application
 
 ```scala

--- a/modules/examples/todolist-http-finch/README.md
+++ b/modules/examples/todolist-http-finch/README.md
@@ -1,9 +1,9 @@
-# TodoList Example
+# TodoList HTTP service using finch
 
 ## Running the Application
 
 ```scala
-sbt todolist/run
+sbt todolist-http-finch/run
 ```
 
 By default, it'll bootstrap in port `8081`.

--- a/modules/examples/todolist-http-finch/src/main/resources/application.conf
+++ b/modules/examples/todolist-http-finch/src/main/resources/application.conf
@@ -1,4 +1,6 @@
 http {
   host = "127.0.0.1"
+  host = ${?HOST}
   port = 8081
+  port = ${?PORT}
 }

--- a/modules/examples/todolist-http-finch/src/main/scala/todo/TodoListApp.scala
+++ b/modules/examples/todolist-http-finch/src/main/scala/todo/TodoListApp.scala
@@ -15,28 +15,27 @@
  */
 
 package examples.todolist
-package http
 
+import cats._
+import cats.effect.IO
+import cats.implicits._
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.{Http, ListeningServer, Service}
 import com.twitter.server.TwitterServer
 import com.twitter.util.{Await, Future}
-import io.circe.generic.auto._
-import io.finch.circe._
-import cats.effect.IO
-import cats.{~>, Monad}
-import cats.implicits._
 import doobie.util.transactor.Transactor
-import freestyle.tagless.module
-import freestyle.tagless.logging.LoggingM
-import freestyle.tagless.loggingJVM.log4s.implicits._
+import examples.todolist.http.Api
+import examples.todolist.persistence.Persistence
+import examples.todolist.services.Services
 import freestyle.tagless.config.ConfigM
 import freestyle.tagless.config.implicits._
 import freestyle.tagless.effects.error.ErrorM
 import freestyle.tagless.effects.error.implicits._
-import examples.todolist.http.apis.Api
-import examples.todolist.persistence.Persistence
-import examples.todolist.services.Services
+import freestyle.tagless.logging.LoggingM
+import freestyle.tagless.loggingJVM.log4s.implicits._
+import freestyle.tagless.module
+import io.circe.generic.auto._
+import io.finch.circe._
 
 @module
 trait App[F[_]] {

--- a/modules/examples/todolist-http-finch/src/main/scala/todo/http/Api.scala
+++ b/modules/examples/todolist-http-finch/src/main/scala/todo/http/Api.scala
@@ -17,8 +17,6 @@
 package examples.todolist
 package http
 
-import examples.todolist.http._
-
 /**
  * Finch http endpoints
  */

--- a/modules/examples/todolist-http-finch/src/main/scala/todo/http/Api.scala
+++ b/modules/examples/todolist-http-finch/src/main/scala/todo/http/Api.scala
@@ -16,18 +16,33 @@
 
 package examples.todolist
 package http
-package apis
 
-import io.finch.Endpoint
+import examples.todolist.http._
 
-trait CRUDApi[A] {
+/**
+ * Finch http endpoints
+ */
+class Api[F[_]](
+    implicit appApi: AppApi[F],
+    genericApi: GenericApi[F],
+    todoItemApi: TodoItemApi[F],
+    todoListApi: TodoListApi[F],
+    tagApi: TagApi[F]) {
 
-  val reset: Endpoint[Int]
-  val retrieve: Endpoint[A]
-  val list: Endpoint[List[A]]
-  val insert: Endpoint[Option[A]]
-  val update: Endpoint[Option[A]]
-  val destroy: Endpoint[Int]
+  val endpoints =
+    appApi.endpoints :+:
+      genericApi.endpoints :+:
+      todoItemApi.endpoints :+:
+      todoListApi.endpoints :+:
+      tagApi.endpoints
 
-  lazy val endpoints = reset :+: retrieve :+: list :+: insert :+: update :+: destroy
+}
+
+object Api {
+  implicit def instance[F[_]](
+      implicit appApi: AppApi[F],
+      genericApi: GenericApi[F],
+      todoItemApi: TodoItemApi[F],
+      todoListApi: TodoListApi[F],
+      tagApi: TagApi[F]): Api[F] = new Api[F]
 }

--- a/modules/examples/todolist-http-finch/src/main/scala/todo/http/AppApi.scala
+++ b/modules/examples/todolist-http-finch/src/main/scala/todo/http/AppApi.scala
@@ -16,16 +16,15 @@
 
 package examples.todolist
 package http
-package apis
 
-import cats.{~>, Monad}
-import cats.Monad.ops._
+import cats._
+import cats.implicits._
 import com.twitter.util.Future
+import examples.todolist.TodoForm
+import examples.todolist.service.AppService
 import io.circe.generic.auto._
 import io.finch._
 import io.finch.circe._
-import examples.todolist.TodoForm
-import examples.todolist.service.AppService
 
 class AppApi[F[_]: Monad](implicit service: AppService[F], handler: F ~> Future) {
 

--- a/modules/examples/todolist-http-finch/src/main/scala/todo/http/CRUDApi.scala
+++ b/modules/examples/todolist-http-finch/src/main/scala/todo/http/CRUDApi.scala
@@ -16,32 +16,17 @@
 
 package examples.todolist
 package http
-package apis
 
-/**
- * Finch http endpoints
- */
-class Api[F[_]](
-    implicit appApi: AppApi[F],
-    genericApi: GenericApi[F],
-    todoItemApi: TodoItemApi[F],
-    todoListApi: TodoListApi[F],
-    tagApi: TagApi[F]) {
+import io.finch.Endpoint
 
-  val endpoints =
-    appApi.endpoints :+:
-      genericApi.endpoints :+:
-      todoItemApi.endpoints :+:
-      todoListApi.endpoints :+:
-      tagApi.endpoints
+trait CRUDApi[A] {
 
-}
+  val reset: Endpoint[Int]
+  val retrieve: Endpoint[A]
+  val list: Endpoint[List[A]]
+  val insert: Endpoint[Option[A]]
+  val update: Endpoint[Option[A]]
+  val destroy: Endpoint[Int]
 
-object Api {
-  implicit def instance[F[_]](
-      implicit appApi: AppApi[F],
-      genericApi: GenericApi[F],
-      todoItemApi: TodoItemApi[F],
-      todoListApi: TodoListApi[F],
-      tagApi: TagApi[F]): Api[F] = new Api[F]
+  lazy val endpoints = reset :+: retrieve :+: list :+: insert :+: update :+: destroy
 }

--- a/modules/examples/todolist-http-finch/src/main/scala/todo/http/GenericApi.scala
+++ b/modules/examples/todolist-http-finch/src/main/scala/todo/http/GenericApi.scala
@@ -16,14 +16,13 @@
 
 package examples.todolist
 package http
-package apis
 
-import cats.{~>, Monad}
-import cats.Monad.ops._
+import cats._
+import cats.implicits._
 import com.twitter.util.Future
-import io.finch._
-import freestyle.tagless.logging.LoggingM
 import examples.todolist.model.Pong
+import freestyle.tagless.logging.LoggingM
+import io.finch._
 
 class GenericApi[F[_]: Monad](implicit log: LoggingM[F], handler: F ~> Future) {
 

--- a/modules/examples/todolist-http-finch/src/main/scala/todo/http/TodoItemApi.scala
+++ b/modules/examples/todolist-http-finch/src/main/scala/todo/http/TodoItemApi.scala
@@ -16,17 +16,15 @@
 
 package examples.todolist
 package http
-package apis
 
-import cats.~>
-import cats.Monad
-import cats.Monad.ops._
+import cats._
+import cats.implicits._
 import com.twitter.util.Future
-import io.finch._
-import io.finch.circe._
-import io.circe.generic.auto._
 import examples.todolist.TodoItem
 import examples.todolist.service.TodoItemService
+import io.circe.generic.auto._
+import io.finch._
+import io.finch.circe._
 
 class TodoItemApi[F[_]: Monad](implicit service: TodoItemService[F], handler: F ~> Future)
     extends CRUDApi[TodoItem] {

--- a/modules/examples/todolist-http-finch/src/main/scala/todo/runtime/implicits.scala
+++ b/modules/examples/todolist-http-finch/src/main/scala/todo/runtime/implicits.scala
@@ -39,32 +39,6 @@ object implicits extends ProductionImplicits
  */
 trait ProductionImplicits {
 
-  implicit val futureEffectSyncMonadError: cats.MonadError[Future, Throwable] with cats.effect.Sync[
-    Future] =
-    new MonadError[Future, Throwable] with cats.effect.Sync[Future] {
-
-      override def pure[A](x: A): Future[A] = Future.value(x)
-
-      override def flatMap[A, B](fa: Future[A])(f: (A) => Future[B]): Future[B] = fa flatMap f
-
-      override def suspend[A](thunk: => Future[A]): Future[A] = Future.Unit.flatMap { _ =>
-        thunk
-      }
-
-      override def raiseError[A](e: Throwable): Future[Nothing] = Future.exception(e)
-
-      override def tailRecM[A, B](a: A)(f: (A) => Future[Either[A, B]]): Future[B] = {
-        f(a).map {
-          case Left(a1) => tailRecM(a1)(f)
-          case Right(c) => Future.value(c)
-        }.flatten
-      }
-
-      override def handleErrorWith[A](fa: Future[A])(f: (Throwable) => Future[A]): Future[A] =
-        fa.rescue { case t => f(t) }
-
-    }
-
   implicit val xa: HikariTransactor[IO] =
     HikariTransactor[IO](new HikariDataSource(new HikariConfig(new Properties {
       setProperty("driverClassName", "org.h2.Driver")

--- a/modules/examples/todolist-http-finch/src/main/scala/todo/runtime/implicits.scala
+++ b/modules/examples/todolist-http-finch/src/main/scala/todo/runtime/implicits.scala
@@ -17,23 +17,18 @@
 package examples.todolist
 package runtime
 
-import java.util.Properties
-import scala.concurrent.ExecutionContext
 import cats._
-import cats.effect._
+import cats.effect.IO
 import com.twitter.util._
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 import doobie._
-import doobie.implicits._
 import doobie.hikari._
 import doobie.hikari.implicits._
+import doobie.implicits._
 import examples.todolist.persistence._
-import examples.todolist.persistence.runtime.{
-  AppRepositoryHandler,
-  TagRepositoryHandler,
-  TodoItemRepositoryHandler,
-  TodoListRepositoryHandler
-}
+import examples.todolist.persistence.runtime._
+import java.util.Properties
+import scala.concurrent.ExecutionContext
 
 object implicits extends ProductionImplicits
 

--- a/modules/examples/todolist-http-finch/src/main/scala/todo/services/Services.scala
+++ b/modules/examples/todolist-http-finch/src/main/scala/todo/services/Services.scala
@@ -17,10 +17,10 @@
 package examples.todolist
 package services
 
-import examples.todolist.service.{AppService, TagService, TodoItemService, TodoListService}
-import freestyle.tagless.module
+import examples.todolist.service._
 import freestyle.tagless.config.ConfigM
 import freestyle.tagless.logging.LoggingM
+import freestyle.tagless.module
 
 /**
  * Module containing all the algebras declared in this layer.

--- a/modules/examples/todolist-http-http4s/README.md
+++ b/modules/examples/todolist-http-http4s/README.md
@@ -1,5 +1,7 @@
 # TodoList HTTP service using http4s
 
+TodoList http service implementation using [`http4s`](https://http4s.org/) and [`todolist-lib`](../todolist-lib).
+
 ## Running the Application
 
 ```scala

--- a/modules/examples/todolist-lib/README.md
+++ b/modules/examples/todolist-lib/README.md
@@ -1,3 +1,14 @@
-# TodoList Service Example
+# TodoList lib
 
-> TBD
+This example contains the definition of all algebras to manage todolists. It
+provides the model, all persistence algebras and all service algebras.
+
+It also provides an implementation for the persistence algebras using
+[`doobie`](https://tpolecat.github.io/doobie/) with a `h2` database.
+
+## Usages
+
+This *library* has been used to implement two examples:
+
+ - [`todolist-http-finch`](../todolist-http-finch): Application to manage todolists over http using [`finch`](https://finagle.github.io/finch/)
+ - [`todolist-http-http4s`](../todolist-http-http4s): Application to manage todolists over http using [`http4s`](https://http4s.org/)

--- a/modules/examples/todolist-lib/src/main/scala/todo/persistence/runtime/TagRepositoryHandler.scala
+++ b/modules/examples/todolist-lib/src/main/scala/todo/persistence/runtime/TagRepositoryHandler.scala
@@ -56,10 +56,10 @@ class TagRepositoryHandler[F[_]: Monad](implicit T: Transactor[F])
     createQuery.run.transact(T)
 
   def init: F[Int] =
-    createQuery.run
+    dropQuery.run
       .flatMap(
-        creates =>
-          dropQuery.run
-            .map(_ + creates))
+        drops =>
+          createQuery.run
+            .map(_ + drops))
       .transact(T)
 }

--- a/modules/examples/todolist-lib/src/main/scala/todo/persistence/runtime/TodoItemRepositoryHandler.scala
+++ b/modules/examples/todolist-lib/src/main/scala/todo/persistence/runtime/TodoItemRepositoryHandler.scala
@@ -56,10 +56,10 @@ class TodoItemRepositoryHandler[F[_]: Monad](implicit T: Transactor[F])
     createQuery.run.transact(T)
 
   def init: F[Int] =
-    createQuery.run
+    dropQuery.run
       .flatMap(
-        creates =>
-          dropQuery.run
-            .map(_ + creates))
+        drops =>
+          createQuery.run
+            .map(_ + drops))
       .transact(T)
 }

--- a/modules/examples/todolist-lib/src/main/scala/todo/persistence/runtime/TodoListRepositoryHandler.scala
+++ b/modules/examples/todolist-lib/src/main/scala/todo/persistence/runtime/TodoListRepositoryHandler.scala
@@ -56,10 +56,10 @@ class TodoListRepositoryHandler[F[_]: Monad](implicit T: Transactor[F])
     createQuery.run.transact(T)
 
   def init: F[Int] =
-    createQuery.run
+    dropQuery.run
       .flatMap(
-        creates =>
-          dropQuery.run
-            .map(_ + creates))
+        drops =>
+          createQuery.run
+            .map(_ + drops))
       .transact(T)
 }

--- a/modules/examples/todolist-lib/src/main/scala/todo/persistence/runtime/queries/TodoListQueries.scala
+++ b/modules/examples/todolist-lib/src/main/scala/todo/persistence/runtime/queries/TodoListQueries.scala
@@ -56,7 +56,7 @@ object TodoListQueries {
             id INT AUTO_INCREMENT PRIMARY KEY,
             title VARCHAR,
             tag_id INT,
-            FOREIGN KEY (tag_id) REFERENCES TAGS(id)
+            FOREIGN KEY (tag_id) REFERENCES tags(id)
           )
        """.update
 }


### PR DESCRIPTION
This PR make minor fixes in examples so the work properly. It also updates documentation.

- `todolist-lib`:
    - Update README.md
    - Fix foreign key in todo_lists table
    - Fix drop methods in repositories

- `todolist-http-finch`:
     - Update README.md
     - Move TodoListApp to main package
     - Move APIs to `http` package
     - Remove unused implicit
     - Sort imports
     - Support env vars in application.conf

- `todolist-http-http4s`:
    - Update README.md

- In main `README.md`, all examples references have been updated