### PR TITLE
Release 0.8.1

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.1-SNAPSHOT"
+version in ThisBuild := "0.8.1"


### PR DESCRIPTION
This patch version only will publish the `todolist-lib` library example, which is being used in one of the  `freestyle-rpc` examples (currently using snapshots).