### PR TITLE
use openjdk instead of oraclejdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
   - env: SCALAENV=all
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 before_cache:
 - du -h -d 1 $HOME/.ivy2/


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/10290#issuecomment-432331802

> oraclejdk8 is not preinstalled on Xenial anymore, and cannot be retrieved from Oracle itself anymore. We'd suggest using either openjdk, or the currently supported Oracle JDK.